### PR TITLE
Update CI to use address checksum

### DIFF
--- a/.github/workflows/pr-address-diff.yml
+++ b/.github/workflows/pr-address-diff.yml
@@ -21,6 +21,16 @@ jobs:
           owner: whetstoneresearch
           repositories: doppler-sdk-alpha
       
+      - name: Post initial comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: address-diff
+          message: |
+            ## ⏳ Checking Address Changes...
+            
+            Comparing utilized addresses between base and PR branch. This will update when complete.
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -58,6 +68,9 @@ jobs:
       - name: Generate diff
         id: diff
         run: |
+          # Get human-readable timestamp
+          timestamp=$(date -u '+%B %d, %Y at %H:%M:%S UTC')
+          
           if npx --yes json-diff snapshots/addresses.base.json snapshots/addresses.pr.json > diff_output.txt 2>&1; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "No address changes detected"
@@ -65,13 +78,17 @@ jobs:
             # Create comment for no utilized address changes
             {
               echo 'COMMENT_BODY<<EOF'
-              echo '## ✅ Generated Addresses Updated'
+              echo '## ✅ No Address Changes'
               echo ''
-              echo '`deployments.generated.ts` was regenerated with new deployment data.'
+              echo 'This PR does not modify any addresses currently used by the SDK.'
               echo ''
-              echo '**No changes to utilized addresses** — The addresses actually used by the SDK (in `ADDRESSES` constant) remain the same.'
+              echo 'While `deployments.generated.ts` or `addresses.ts` may have been updated, the runtime addresses referenced by `ADDRESSES` remain unchanged. This typically means:'
+              echo '- New contracts were deployed but are not yet integrated into the SDK'
+              echo '- Code formatting or comments were updated'
+              echo '- Unused addresses in the generated file changed'
               echo ''
-              echo '> This means new contracts may have been deployed, but the SDK is not yet using them.'
+              echo "---"
+              echo "*Last checked: ${timestamp}*"
               echo EOF
             } >> $GITHUB_ENV
           else
@@ -90,6 +107,9 @@ jobs:
               echo '```diff'
               cat diff_output.txt
               echo '```'
+              echo ''
+              echo "---"
+              echo "*Last checked: ${timestamp}*"
               echo EOF
             } >> $GITHUB_ENV
           fi

--- a/.github/workflows/pr-address-diff.yml
+++ b/.github/workflows/pr-address-diff.yml
@@ -32,7 +32,7 @@ jobs:
           message: |
             ## 🔄⏳ Checking Address Changes...
             
-            Currently comparing utilized addresses between base and PR branch. This comment will update automatically when the check completes.
+            Currently comparing `${{ github.event.pull_request.head.ref }}` with `${{ github.event.pull_request.base.ref }}`. This comment will update automatically when the check completes.
             
             ---
             *Started: ${{ steps.timestamp.outputs.started }}*
@@ -74,6 +74,9 @@ jobs:
       
       - name: Generate diff
         id: diff
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           # Get human-readable timestamp
           timestamp=$(date -u '+%B %d, %Y at %H:%M:%S UTC')
@@ -86,6 +89,8 @@ jobs:
             {
               echo 'COMMENT_BODY<<EOF'
               echo '## ✅ No Address Changes'
+              echo ''
+              echo "Compared \`${HEAD_REF}\` with \`${BASE_REF}\`"
               echo ''
               echo 'This PR does not modify any addresses currently used by the SDK.'
               echo ''
@@ -106,6 +111,8 @@ jobs:
             {
               echo 'COMMENT_BODY<<EOF'
               echo '## 🔄 Address Changes Detected'
+              echo ''
+              echo "Compared \`${HEAD_REF}\` with \`${BASE_REF}\`"
               echo ''
               echo 'The following addresses used by the SDK have changed:'
               echo ''

--- a/.github/workflows/pr-address-diff.yml
+++ b/.github/workflows/pr-address-diff.yml
@@ -1,0 +1,105 @@
+name: PR Address Diff
+on:
+  pull_request:
+    paths:
+      - 'src/addresses.ts'
+      - 'src/deployments.generated.ts'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  address-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: whetstoneresearch
+          repositories: doppler-sdk-alpha
+      
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      
+      - name: Create snapshots directory
+        run: mkdir -p snapshots
+      
+      - name: Snapshot PR addresses
+        run: pnpx tsx ./scripts/snapshot-addresses.ts > snapshots/addresses.pr.json
+      
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+      
+      - name: Snapshot base addresses
+        run: |
+          cd base
+          pnpm install --frozen-lockfile
+          pnpx tsx ./scripts/snapshot-addresses.ts > ../snapshots/addresses.base.json
+      
+      - name: Generate diff
+        id: diff
+        run: |
+          if npx --yes json-diff snapshots/addresses.base.json snapshots/addresses.pr.json > diff_output.txt 2>&1; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No address changes detected"
+            
+            # Create comment for no utilized address changes
+            {
+              echo 'COMMENT_BODY<<EOF'
+              echo '## ✅ Generated Addresses Updated'
+              echo ''
+              echo '`deployments.generated.ts` was regenerated with new deployment data.'
+              echo ''
+              echo '**No changes to utilized addresses** — The addresses actually used by the SDK (in `ADDRESSES` constant) remain the same.'
+              echo ''
+              echo '> This means new contracts may have been deployed, but the SDK is not yet using them.'
+              echo EOF
+            } >> $GITHUB_ENV
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Address changes detected"
+            
+            # Create comment body for actual changes
+            {
+              echo 'COMMENT_BODY<<EOF'
+              echo '## 🔄 Address Changes Detected'
+              echo ''
+              echo 'The following addresses used by the SDK have changed:'
+              echo ''
+              echo '> **Note:** This diff shows **only** the addresses actually used by the SDK (from `ADDRESSES` constant).'
+              echo ''
+              echo '```diff'
+              cat diff_output.txt
+              echo '```'
+              echo EOF
+            } >> $GITHUB_ENV
+          fi
+      
+      - name: Post or update comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: address-diff
+          message: ${{ env.COMMENT_BODY }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+

--- a/.github/workflows/pr-address-diff.yml
+++ b/.github/workflows/pr-address-diff.yml
@@ -22,13 +22,20 @@ jobs:
           repositories: doppler-sdk-alpha
       
       - name: Post initial comment
+        id: timestamp
+        run: echo "started=$(date -u '+%B %d, %Y at %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+      
+      - name: Post in-progress comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: address-diff
           message: |
-            ## ⏳ Checking Address Changes...
+            ## 🔄⏳ Checking Address Changes...
             
-            Comparing utilized addresses between base and PR branch. This will update when complete.
+            Currently comparing utilized addresses between base and PR branch. This comment will update automatically when the check completes.
+            
+            ---
+            *Started: ${{ steps.timestamp.outputs.started }}*
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-address-diff.yml
+++ b/.github/workflows/pr-address-diff.yml
@@ -27,8 +27,6 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/update-addresses.yml
+++ b/.github/workflows/update-addresses.yml
@@ -1,5 +1,9 @@
 name: Update Addresses
-on: [workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -60,11 +64,30 @@ jobs:
         working-directory: doppler-sdk-alpha
       - name: Create human-readable diff
         run: |
-          echo '### Address diff' > PR_BODY.md
+          echo '## Automated Address Update' > PR_BODY.md
           echo '' >> PR_BODY.md
-          echo '```diff' >> PR_BODY.md
-          npx --yes json-diff snapshots/addresses.pre.json snapshots/addresses.post.json >> PR_BODY.md || true
-          echo '```' >> PR_BODY.md
+          echo 'This PR updates `deployments.generated.ts` from the latest `Deployments.json` in the doppler repo.' >> PR_BODY.md
+          echo '' >> PR_BODY.md
+          
+          # Check if there are actual differences in utilized addresses
+          if npx --yes json-diff snapshots/addresses.pre.json snapshots/addresses.post.json > diff_output.txt 2>&1; then
+            echo '### Address Changes' >> PR_BODY.md
+            echo '' >> PR_BODY.md
+            echo 'No changes to utilized addresses. The generated file may have formatting or metadata updates.' >> PR_BODY.md
+          else
+            echo '### Address Changes' >> PR_BODY.md
+            echo '' >> PR_BODY.md
+            echo 'The following addresses are utilized by the SDK and have changed:' >> PR_BODY.md
+            echo '' >> PR_BODY.md
+            echo '> **Note:** `deployments.generated.ts` contains all deployed contracts, but the SDK only uses a subset.' >> PR_BODY.md
+            echo '> This diff shows **only** the addresses actually referenced in the codebase.' >> PR_BODY.md
+            echo '' >> PR_BODY.md
+            echo '```diff' >> PR_BODY.md
+            cat diff_output.txt >> PR_BODY.md
+            echo '```' >> PR_BODY.md
+          fi
+          
+          rm -f diff_output.txt
         working-directory: doppler-sdk-alpha
       - name: Prepare dated snapshot
         id: stamp

--- a/.github/workflows/update-addresses.yml
+++ b/.github/workflows/update-addresses.yml
@@ -39,8 +39,6 @@ jobs:
           repositories: doppler-sdk-alpha
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/update-addresses.yml
+++ b/.github/workflows/update-addresses.yml
@@ -78,8 +78,19 @@ jobs:
         with:
           name: addresses-snapshot-${{ steps.stamp.outputs.stamp }}
           path: doppler-sdk-alpha/snapshots/addresses-${{ steps.stamp.outputs.stamp }}.json
-          retention-days: 365
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet src/deployments.generated.ts; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected in generated addresses"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected in generated addresses"
+          fi
+        working-directory: doppler-sdk-alpha
       - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           path: doppler-sdk-alpha
@@ -89,7 +100,6 @@ jobs:
           body-path: doppler-sdk-alpha/PR_BODY.md
           commit-message: "chore: update generated addresses"
           branch: chore/update-addresses
-          branch-suffix: timestamp
           delete-branch: true
           add-paths: |
             src/deployments.generated.ts

--- a/.github/workflows/update-addresses.yml
+++ b/.github/workflows/update-addresses.yml
@@ -50,57 +50,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: doppler-sdk-alpha
-      - name: Create snapshots directory
-        run: mkdir -p snapshots
-        working-directory: doppler-sdk-alpha
-      - name: Snapshot pre-generation used addresses
-        run: pnpx tsx ./scripts/snapshot-addresses.ts > snapshots/addresses.pre.json
-        working-directory: doppler-sdk-alpha
       - name: Generate deployments.generated.ts from Deployments.json
         run: pnpm run generate:addresses -- --source ../doppler/Deployments.json --out src/deployments.generated.ts
         working-directory: doppler-sdk-alpha
-      - name: Snapshot post-generation used addresses
-        run: pnpx tsx ./scripts/snapshot-addresses.ts > snapshots/addresses.post.json
-        working-directory: doppler-sdk-alpha
-      - name: Create human-readable diff
-        run: |
-          echo '## Automated Address Update' > PR_BODY.md
-          echo '' >> PR_BODY.md
-          echo 'This PR updates `deployments.generated.ts` from the latest `Deployments.json` in the doppler repo.' >> PR_BODY.md
-          echo '' >> PR_BODY.md
-          
-          # Check if there are actual differences in utilized addresses
-          if npx --yes json-diff snapshots/addresses.pre.json snapshots/addresses.post.json > diff_output.txt 2>&1; then
-            echo '### Address Changes' >> PR_BODY.md
-            echo '' >> PR_BODY.md
-            echo 'No changes to utilized addresses. The generated file may have formatting or metadata updates.' >> PR_BODY.md
-          else
-            echo '### Address Changes' >> PR_BODY.md
-            echo '' >> PR_BODY.md
-            echo 'The following addresses are utilized by the SDK and have changed:' >> PR_BODY.md
-            echo '' >> PR_BODY.md
-            echo '> **Note:** `deployments.generated.ts` contains all deployed contracts, but the SDK only uses a subset.' >> PR_BODY.md
-            echo '> This diff shows **only** the addresses actually referenced in the codebase.' >> PR_BODY.md
-            echo '' >> PR_BODY.md
-            echo '```diff' >> PR_BODY.md
-            cat diff_output.txt >> PR_BODY.md
-            echo '```' >> PR_BODY.md
-          fi
-          
-          rm -f diff_output.txt
-        working-directory: doppler-sdk-alpha
-      - name: Prepare dated snapshot
-        id: stamp
-        run: |
-          stamp=$(date -u +%Y-%m-%dT%H%M%SZ)
-          echo "stamp=$stamp" >> $GITHUB_OUTPUT
-          cp snapshots/addresses.post.json "snapshots/addresses-${stamp}.json"
-        working-directory: doppler-sdk-alpha
-      - name: Upload dated snapshot artifact (365 days)
-        uses: actions/upload-artifact@v4
-        with:
-          name: addresses-snapshot-${{ steps.stamp.outputs.stamp }}
-          path: doppler-sdk-alpha/snapshots/addresses-${{ steps.stamp.outputs.stamp }}.json
       - name: Check for changes
         id: changes
         run: |
@@ -120,7 +72,12 @@ jobs:
           base: main
           token: ${{ steps.generate-token.outputs.token }}
           title: "chore: update generated addresses"
-          body-path: doppler-sdk-alpha/PR_BODY.md
+          body: |
+            ## Automated Address Update
+            
+            This PR updates `deployments.generated.ts` from the latest `Deployments.json` in the doppler repo.
+            
+            See the automated comment below for detailed address changes.
           commit-message: "chore: update generated addresses"
           branch: chore/update-addresses
           delete-branch: true

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -182,7 +182,7 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].TokenFactory as Address,
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].UniswapV3Initializer as Address,
     v3Quoter: '0x385A5cf5F83e99f7BB2852b6A19C3538b9FA7658' as Address,
-    v4Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].UniswapV4Initializer as Address,
+    v4Initializer: '0x2F2BAcd46d3F5c9EE052Ab392b73711dB89129DB' as Address,
     doppler: '0x06FEFD02F0b6d9f57F52cfacFc113665Dfa20F0f' as Address,
     dopplerLens: '0x333e3c607b141b18ff6de9f258db6e77fe7491e0' as Address,
     dopplerDeployer: '0x06FEFD02F0b6d9f57F52cfacFc113665Dfa20F0f' as Address,

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -1,4 +1,5 @@
 import { Address } from 'viem'
+import { GENERATED_DOPPLER_DEPLOYMENTS } from './deployments.generated'
 
 // Chain IDs
 export const CHAIN_IDS = {
@@ -95,54 +96,52 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     uniswapV4Quoter: '0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203' as Address,
   },
   [CHAIN_IDS.BASE]: {
-    airlock: '0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12' as Address,
+    airlock: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].Airlock as Address,
     tokenFactory: '0xFAafdE6a5b658684cC5eb0C5c2c755B00A246F45' as Address,
-    v3Initializer: '0xaA47D2977d622DBdFD33eeF6a8276727c52EB4e5' as Address,
+    v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].UniswapV3Initializer as Address,
     v3Quoter: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a' as Address,
-    lockableV3Initializer: '0xe0dc4012ac9c868f09c6e4b20d66ed46d6f258d0' as Address,
+    lockableV3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].LockableUniswapV3Initializer as Address,
     v4Initializer: '0x82ac010c67f70bacf7655cd8948a4ad92a173cac' as Address,
-    v4MulticurveInitializer: '0x65dE470Da664A5be139A5D812bE5FDa0d76CC951' as Address, // From Doppler multicurve deployments (Base mainnet)
-    v4ScheduledMulticurveInitializer: '0xa36715Da46DdF4A769F3290f49aF58Bf8132Ed8e' as Address, // From Doppler scheduled multicurve deployments (Base mainnet)
+    v4MulticurveInitializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].UniswapV4MulticurveInitializer as Address, // From Doppler multicurve deployments (Base mainnet)
     doppler: '0x2f2bacd46d3f5c9ee052ab392b73711db89129db' as Address,
-    dopplerLens: '0x43d0d97ec9241a8f05a264f94b82a1d2e600f2b3' as Address,
+    dopplerLens: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].DopplerLensQuoter as Address,
     dopplerDeployer: '0x8350cAd81149A9944c2fb4276955FaAA7D61e836' as Address,
     poolManager: '0x498581ff718922c3f8e6a244956af099b2652b2b' as Address,
     stateView: '0xa3c0c9b65bad0b08107aa264b0f3db444b867a71' as Address,
-    v2Migrator: '0x5F3bA43D44375286296Cb85F1EA2EBfa25dde731' as Address,
-    v3Migrator: '0x5F3bA43D44375286296Cb85F1EA2EBfa25dde731' as Address,
+    v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].UniswapV2Migrator as Address,
+    v3Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].UniswapV2Migrator as Address,
     v4Migrator: '0xa24e35a5d71d02a59b41e7c93567626302da1958' as Address,
-    noOpMigrator: '0x6ddfed58d238ca3195e49d8ac3d4cea6386e5c33' as Address,
+    noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].NoOpMigrator as Address,
     governanceFactory: '0xb4deE32EB70A5E55f3D2d861F49Fb3D79f7a14d9' as Address,
     noOpGovernanceFactory: '0xe7dfbd5b0a2c3b4464653a9becdc489229ef090e' as Address,
-    streamableFeesLocker: '0x0a00775d71a42cd33d62780003035e7f5b47bd3a' as Address,
+    streamableFeesLocker: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].StreamableFeesLocker as Address,
     universalRouter: '0x6ff5693b99212da76ad316178a184ab56d299b43' as Address,
     univ2Router02: '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24' as Address,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address,
-    bundler: '0x136191B46478cAB023cbC01a36160C4Aad81677a' as Address,
+    bundler: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].Bundler as Address,
     weth: '0x4200000000000000000000000000000000000006' as Address,
     uniswapV4Quoter: '0x0d5e0f971ed27fbff6c2837bf31316121532048d' as Address,
   },
   [CHAIN_IDS.BASE_SEPOLIA]: {
-    airlock: '0x3411306ce66c9469bff1535ba955503c4bde1c6e' as Address,
+    airlock: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].Airlock as Address,
     tokenFactory: '0xc69ba223c617f7d936b3cf2012aa644815dbe9ff' as Address,
     doppler404Factory: '0xdd8cea2890f1b3498436f19ec8da8fecc2cb7af7' as Address,
-    v3Initializer: '0x4c3062b9ccfdbcb10353f57c1b59a29d4c5cfa47' as Address,
+    v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].UniswapV3Initializer as Address,
     v3Quoter: '0xC5290058841028F1614F3A6F0F5816cAd0df5E27' as Address,
-    lockableV3Initializer: '0x16ada5be50c3c2d94af5feae6b539c40a78ad53c' as Address,
+    lockableV3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].LockableUniswapV3Initializer as Address,
     v4Initializer: '0x8e891d249f1ecbffa6143c03eb1b12843aef09d3' as Address,
     v4MulticurveInitializer: '0x359b5952a254baaa0105381825daedb8986bb55c' as Address, // From doppler multicurve deployments (Base Sepolia)
-    v4ScheduledMulticurveInitializer: '0x5C10D3e14Aae2Ef95619B25E907E013260E832E4' as Address, // From Doppler scheduled multicurve deployments (Base Sepolia)
     doppler: '0x60a039e4add40ca95e0475c11e8a4182d06c9aa0' as Address,
-    dopplerLens: '0x4a8d81db741248a36d9eb3bc6ef648bf798b47a7' as Address,
+    dopplerLens: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].DopplerLensQuoter as Address,
     dopplerDeployer: '0x60a039e4add40ca95e0475c11e8a4182d06c9aa0' as Address,
     poolManager: '0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408' as Address,
     stateView: '0x571291b572ed32ce6751a2cb2486ebee8defb9b4' as Address,
-    v2Migrator: '0x04a898f3722c38f9def707bd17dc78920efa977c' as Address,
+    v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].UniswapV2Migrator as Address,
     v3Migrator: '0xb2ec6559704467306d04322a5dc082b2af4562dd' as Address,
     v4Migrator: '0xb2ec6559704467306d04322a5dc082b2af4562dd' as Address,
     v4MigratorHook: '0x508812fcdd4972a59b66eb2cad3772279c052000' as Address,
-    noOpMigrator: '0xf11066abbd329ac4bba39455340539322c222eb0' as Address,
-    governanceFactory: '0x9dbfaadc8c0cb2c34ba698dd9426555336992e20' as Address,
+    noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].NoOpMigrator as Address,
+    governanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].GovernanceFactory as Address,
     noOpGovernanceFactory: '0x916b8987e4ad325c10d58ed8dc2036a6ff5eb228' as Address,
     streamableFeesLocker: '0x4da7d7a8034510c0ffd38a9252237ae8dba3cb61' as Address,
     universalRouter: '0x492E6456D9528771018DeB9E87ef7750EF184104' as Address,
@@ -154,50 +153,50 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
   },
   [CHAIN_IDS.INK]: {
     airlock: '0x014E1c0bd34f3B10546E554CB33B3293fECDD056' as Address,
-    tokenFactory: '0xFAafdE6a5b658684cC5eb0C5c2c755B00A246F45' as Address,
-    v3Initializer: '0xaA47D2977d622DBdFD33eeF6a8276727c52EB4e5' as Address,
+    tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].TokenFactory as Address,
+    v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].UniswapV3Initializer as Address,
     v3Quoter: '0x96b572D2d880cf2Fa2563651BD23ADE6f5516652' as Address,
     v4Initializer: '0xC99b485499f78995C6F1640dbB1413c57f8BA684' as Address,
-    doppler: '0xa82c66b6ddEb92089015C3565E05B5c9750b2d4B' as Address,
+    doppler: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].DopplerDeployer as Address,
     dopplerLens: '0x3972c00f7ed4885e145823eb7c655375d275a1c5' as Address,
-    dopplerDeployer: '0xa82c66b6ddEb92089015C3565E05B5c9750b2d4B' as Address,
+    dopplerDeployer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].DopplerDeployer as Address,
     poolManager: '0x360e68faccca8ca495c1b759fd9eee466db9fb32' as Address,
     stateView: '0x76fd297e2d437cd7f76d50f01afe6160f86e9990' as Address,
-    v2Migrator: '0x5F3bA43D44375286296Cb85F1EA2EBfa25dde731' as Address,
-    v3Migrator: '0x5F3bA43D44375286296Cb85F1EA2EBfa25dde731' as Address,
-    v4Migrator: '0x5F3bA43D44375286296Cb85F1EA2EBfa25dde731' as Address, // Same as v2/v3 migrator
-    governanceFactory: '0xb4deE32EB70A5E55f3D2d861F49Fb3D79f7a14d9' as Address,
+    v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].UniswapV2Migrator as Address,
+    v3Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].UniswapV2Migrator as Address,
+    v4Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].UniswapV2Migrator as Address, // Same as v2/v3 migrator
+    governanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].GovernanceFactory as Address,
     noOpGovernanceFactory: ZERO_ADDRESS, // Not yet deployed
     streamableFeesLocker: ZERO_ADDRESS, // Not yet deployed
     universalRouter: '0x112908dac86e20e7241b0927479ea3bf935d1fa0' as Address,
     univ2Router02: '0xB3FB126ACDd5AdCA2f50Ac644a7a2303745f18b4' as Address,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address,
-    bundler: '0x136191B46478cAB023cbC01a36160C4Aad81677a' as Address,
+    bundler: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].Bundler as Address,
     weth: ZERO_ADDRESS, // TODO: Get INK WETH address
     uniswapV4Quoter: '0x3972c00f7ed4885e145823eb7c655375d275a1c5' as Address,
   },
   [CHAIN_IDS.UNICHAIN]: {
-    airlock: '0x77EbfBAE15AD200758E9E2E61597c0B07d731254' as Address,
-    tokenFactory: '0x43d0D97EC9241A8F05A264f94B82A1d2E600f2B3' as Address,
-    v3Initializer: '0x9F4e56be80f08ba1A2445645EFa6d231E27b43ec' as Address,
+    airlock: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].Airlock as Address,
+    tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].TokenFactory as Address,
+    v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].UniswapV3Initializer as Address,
     v3Quoter: '0x385A5cf5F83e99f7BB2852b6A19C3538b9FA7658' as Address,
-    v4Initializer: '0x2F2BAcd46d3F5c9EE052Ab392b73711dB89129DB' as Address,
+    v4Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].UniswapV4Initializer as Address,
     doppler: '0x06FEFD02F0b6d9f57F52cfacFc113665Dfa20F0f' as Address,
     dopplerLens: '0x333e3c607b141b18ff6de9f258db6e77fe7491e0' as Address,
     dopplerDeployer: '0x06FEFD02F0b6d9f57F52cfacFc113665Dfa20F0f' as Address,
     poolManager: '0x1f98400000000000000000000000000000000004' as Address,
     stateView: '0x86e8631a016f9068c3f085faf484ee3f5fdee8f2' as Address,
-    v2Migrator: '0xf6023127f6E937091D5B605680056A6D27524bad' as Address,
-    v3Migrator: '0xf6023127f6E937091D5B605680056A6D27524bad' as Address,
-    v4Migrator: '0xf6023127f6E937091D5B605680056A6D27524bad' as Address, // Same as v2/v3 migrator
-    noOpMigrator: '0x917da361072ce968acd810bbfc9b64079426ebf0' as Address,
-    governanceFactory: '0x99C94B9Df930E1E21a4E4a2c105dBff21bF5c5aE' as Address,
+    v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].UniswapV2Migrator as Address,
+    v3Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].UniswapV2Migrator as Address,
+    v4Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].UniswapV2Migrator as Address, // Same as v2/v3 migrator
+    noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].NoOpMigrator as Address,
+    governanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].GovernanceFactory as Address,
     noOpGovernanceFactory: ZERO_ADDRESS, // Not yet deployed
     streamableFeesLocker: ZERO_ADDRESS, // Not yet deployed
     universalRouter: '0xef740bf23acae26f6492b10de645d6b98dc8eaf3' as Address,
     univ2Router02: '0x284f11109359a7e1306c3e447ef14d38400063ff' as Address,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address,
-    bundler: '0x91231cDdD8d6C86Df602070a3081478e074b97b7' as Address,
+    bundler: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN].Bundler as Address,
     weth: ZERO_ADDRESS, // TODO: Get Unichain WETH address
     uniswapV4Quoter: '0x333e3c607b141b18ff6de9f258db6e77fe7491e0' as Address,
   },
@@ -215,7 +214,7 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     v2Migrator: '0x44C448E38A2C3D206c9132E7f645510dFbBC946b' as Address,
     v3Migrator: '0x44C448E38A2C3D206c9132E7f645510dFbBC946b' as Address,
     v4Migrator: '0x44C448E38A2C3D206c9132E7f645510dFbBC946b' as Address, // Same as v2/v3 migrator
-    noOpMigrator: '0x193f48a45b6025dded10bc4baeef65c833696387' as Address,
+    noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN_SEPOLIA].NoOpMigrator as Address,
     governanceFactory: '0x1E4332EEfAE9e4967C2D186f7b2d439D778e81cC' as Address,
     noOpGovernanceFactory: ZERO_ADDRESS, // Not yet deployed
     streamableFeesLocker: ZERO_ADDRESS, // Not yet deployed

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -103,6 +103,7 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     lockableV3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].LockableUniswapV3Initializer as Address,
     v4Initializer: '0x82ac010c67f70bacf7655cd8948a4ad92a173cac' as Address,
     v4MulticurveInitializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].UniswapV4MulticurveInitializer as Address, // From Doppler multicurve deployments (Base mainnet)
+    v4ScheduledMulticurveInitializer: '0xa36715Da46DdF4A769F3290f49aF58Bf8132Ed8e' as Address, // From Doppler scheduled multicurve deployments (Base mainnet)
     doppler: '0x2f2bacd46d3f5c9ee052ab392b73711db89129db' as Address,
     dopplerLens: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].DopplerLensQuoter as Address,
     dopplerDeployer: '0x8350cAd81149A9944c2fb4276955FaAA7D61e836' as Address,
@@ -131,6 +132,7 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     lockableV3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].LockableUniswapV3Initializer as Address,
     v4Initializer: '0x8e891d249f1ecbffa6143c03eb1b12843aef09d3' as Address,
     v4MulticurveInitializer: '0x359b5952a254baaa0105381825daedb8986bb55c' as Address, // From doppler multicurve deployments (Base Sepolia)
+    v4ScheduledMulticurveInitializer: '0x5C10D3e14Aae2Ef95619B25E907E013260E832E4' as Address, // From Doppler scheduled multicurve deployments (Base Sepolia)
     doppler: '0x60a039e4add40ca95e0475c11e8a4182d06c9aa0' as Address,
     dopplerLens: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].DopplerLensQuoter as Address,
     dopplerDeployer: '0x60a039e4add40ca95e0475c11e8a4182d06c9aa0' as Address,


### PR DESCRIPTION
- updates address generation to use `getAddresses` from `viem`
- switches CI to run on every push to main
  - PRs will get reused, so only 1 will ever be open at a time
- adds a more verbose description to generated PRs