### PR TITLE
fix: result order of airlock create

### DIFF
--- a/src/__tests__/entities/DopplerFactory.test.ts
+++ b/src/__tests__/entities/DopplerFactory.test.ts
@@ -247,7 +247,7 @@ describe('DopplerFactory', () => {
       
       vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
         request: { address: mockAddresses.airlock, functionName: 'create', args: [{}, {}] },
-        result: [mockPoolAddress, mockTokenAddress],
+        result: [mockTokenAddress, mockPoolAddress],
       } as any)
       vi.mocked(walletClient.writeContract).mockResolvedValueOnce(mockTxHash as `0x${string}`)
       vi.mocked(publicClient.waitForTransactionReceipt).mockResolvedValueOnce(
@@ -275,7 +275,7 @@ describe('DopplerFactory', () => {
       
       vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
         request: { address: mockAddresses.airlock, functionName: 'create', args: [{}, {}] },
-        result: [mockPoolAddress, mockTokenAddress],
+        result: [mockTokenAddress, mockPoolAddress],
       } as any)
       vi.mocked(walletClient.writeContract).mockResolvedValueOnce(mockTxHash as `0x${string}`)
       vi.mocked(publicClient.waitForTransactionReceipt).mockResolvedValueOnce(
@@ -369,7 +369,7 @@ describe('DopplerFactory', () => {
       
       vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
         request: { address: mockAddresses.airlock, functionName: 'create', args: [{}, {}] },
-        result: [mockPoolAddress, mockTokenAddress],
+        result: [mockTokenAddress, mockPoolAddress],
       } as any)
       vi.mocked(walletClient.writeContract).mockResolvedValueOnce(mockTxHash as `0x${string}`)
       vi.mocked(publicClient.waitForTransactionReceipt).mockResolvedValueOnce(
@@ -408,7 +408,7 @@ describe('DopplerFactory', () => {
 
       vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
         request: { address: mockAddresses.airlock, functionName: 'create', args: [{}, {}] },
-        result: [mockPoolAddress, mockTokenAddress],
+        result: [mockTokenAddress, mockPoolAddress],
       } as any)
       vi.mocked(walletClient.writeContract).mockResolvedValueOnce(mockTxHash as `0x${string}`)
       vi.mocked(publicClient.waitForTransactionReceipt).mockResolvedValueOnce(
@@ -436,7 +436,7 @@ describe('DopplerFactory', () => {
       vi.mocked(publicClient.estimateContractGas).mockImplementationOnce(async () => 12_250_000n)
       vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
         request: {},
-        result: [mockPoolAddress, mockTokenAddress],
+        result: [mockTokenAddress, mockPoolAddress],
       } as any)
 
       const { createParams, hookAddress, tokenAddress, poolId, gasEstimate } = await factory.simulateCreateDynamicAuction(
@@ -457,7 +457,7 @@ describe('DopplerFactory', () => {
       vi.mocked(publicClient.estimateContractGas).mockImplementationOnce(async () => 10_000_000n)
       vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
         request: { address: mockAddresses.airlock, functionName: 'create', args: [{}, {}] },
-        result: [mockPoolAddress, mockTokenAddress],
+        result: [mockTokenAddress, mockPoolAddress],
       } as any)
       vi.mocked(walletClient.writeContract).mockResolvedValueOnce(mockTxHash as `0x${string}`)
       vi.mocked(publicClient.waitForTransactionReceipt).mockResolvedValueOnce(createMockTransactionReceipt([]))

--- a/src/__tests__/integration/sdk-workflows.test.ts
+++ b/src/__tests__/integration/sdk-workflows.test.ts
@@ -204,7 +204,7 @@ describe('SDK Workflows Integration Tests', () => {
           functionName: 'create',
           args: [{}, {}],
         },
-        result: [mockHookAddress, mockTokenAddress],
+        result: [mockTokenAddress, mockHookAddress],
       } as any)
 
       vi.mocked(walletClient.writeContract).mockResolvedValueOnce(mockTxHash as `0x${string}`)

--- a/src/entities/DopplerFactory.ts
+++ b/src/entities/DopplerFactory.ts
@@ -707,9 +707,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     let actualTokenAddress: Address = tokenAddress
     
     if (simResult && Array.isArray(simResult) && simResult.length >= 2) {
-      // Tests expect [poolOrHook, asset]
-      actualHookAddress = simResult[0] as Address
-      actualTokenAddress = simResult[1] as Address
+      // Tests expect [asset, poolOrHook]
+      actualTokenAddress = simResult[0] as Address
+      actualHookAddress = simResult[1] as Address
     } else {
       // Fallback: Parse the Create event from logs
       const createEvent = (receipt.logs as readonly unknown[]).find((log: unknown) => {
@@ -790,8 +790,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       throw new Error('Failed to simulate dynamic auction create')
     }
 
-    const hookAddress = simResult[0] as Address
-    const tokenAddress = simResult[1] as Address
+    const tokenAddress = simResult[0] as Address
+    const hookAddress = simResult[1] as Address
 
     const poolId = this.computePoolId({
       currency0: tokenAddress < params.sale.numeraire ? tokenAddress : params.sale.numeraire,


### PR DESCRIPTION
the contract always returns asset 1st, pool 2nd https://github.com/whetstoneresearch/doppler/blob/f3dc150975a1b5ad5b77418d12636b43fbf62ceb/src/Airlock.sol#L144