### PR TITLE
feat: use seconds for auction duration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -225,7 +225,7 @@ await sdk.factory.createDynamicAuction({
     numeraire: wethAddress,
   },
   auction: {
-    duration: 7,
+    duration: 7 * DAY_SECONDS,
     epochLength: 3600,
     startTick: -92103,
     endTick: -69080,

--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ console.log('Token address:', result.tokenAddress)
 Dynamic auctions use Uniswap V4 hooks to implement gradual Dutch auctions where the price moves over time.
 
 ```typescript
-import { DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk'
+import { DynamicAuctionBuilder, DAY_SECONDS } from '@whetstone-research/doppler-sdk'
 
 const params = new DynamicAuctionBuilder()
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/metadata.json' })
   .saleConfig({ initialSupply: parseEther('1000000'), numTokensToSell: parseEther('900000'), numeraire: '0x...' })
   .poolConfig({ fee: 3000, tickSpacing: 60 })
   .auctionByTicks({
-    durationDays: 7,
+    duration: 7 * DAY_SECONDS,
     epochLength: 3600,
     startTick: -92103,
     endTick: -69080,
@@ -812,6 +812,7 @@ import {
   mineTokenAddress,
   getAddresses,
   DopplerBytecode,
+  DAY_SECONDS,
 } from '@whetstone-research/doppler-sdk'
 import { parseEther, keccak256, encodePacked, encodeAbiParameters } from 'viem'
 import { base } from 'viem/chains'
@@ -825,7 +826,7 @@ const builder = new DynamicAuctionBuilder()
   })
   .poolConfig({ fee: 3000, tickSpacing: 60 })
   .auctionByTicks({
-    durationDays: 7,
+    duration: 7 * DAY_SECONDS,
     epochLength: 3600,
     startTick: -92103,
     endTick: -69080,

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -114,10 +114,10 @@ Methods (chainable):
   - Defaults: `numeraire = ZERO_ADDRESS` (token is paired against ETH)
 - poolConfig({ fee, tickSpacing })
 - Price configuration methods (use one or the other, not both)
-  - auctionByTicks({ startTick, endTick, minProceeds, maxProceeds, durationDays?, epochLength?, gamma?, numPdSlugs? })
-    - Defaults: `durationDays = DEFAULT_AUCTION_DURATION (7)`, `epochLength = DEFAULT_EPOCH_LENGTH (43200)`, `numPdSlugs` optional
+  - auctionByTicks({ startTick, endTick, minProceeds, maxProceeds, duration?, epochLength?, gamma?, numPdSlugs? })
+    - Defaults: `duration = DEFAULT_AUCTION_DURATION (604800)`, `epochLength = DEFAULT_EPOCH_LENGTH (43200)`, `numPdSlugs` optional
     - If `gamma` omitted, computed from ticks, duration, epoch length, and `tickSpacing`
-  - auctionByPriceRange({ priceRange, minProceeds, maxProceeds, durationDays?, epochLength?, gamma?, tickSpacing?, numPdSlugs? })
+  - auctionByPriceRange({ priceRange, minProceeds, maxProceeds, duration?, epochLength?, gamma?, tickSpacing?, numPdSlugs? })
     - Uses `pool.tickSpacing` unless `tickSpacing` is provided here
 - withVesting({ duration?, cliffDuration?, recipients?, amounts? } | undefined)
   - Omit to disable vesting. Default duration if provided but undefined is `0` for dynamic auctions.
@@ -147,7 +147,7 @@ Validation highlights:
 - token name/symbol non‑empty
 - `startTick < endTick`
 - `initialSupply > 0`, `numTokensToSell > 0`, and `numTokensToSell <= initialSupply`
-- `durationDays > 0`, `epochLength > 0`, and `durationDays * 86400` divisible by `epochLength`
+- `duration > 0`, `epochLength > 0`, and `duration` divisible by `epochLength`
 - `tickSpacing > 0`; if `gamma` provided, it must be a multiple of `tickSpacing`
 - For V4 migration config (if chosen), beneficiary percentages must sum to 10000
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -181,7 +181,7 @@ const { hookAddress, tokenAddress } = await factory.create({
 
 #### After (Builder pattern)
 ```typescript
-import { DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk'
+import { DynamicAuctionBuilder, DAY_SECONDS } from '@whetstone-research/doppler-sdk'
 
 const params = new DynamicAuctionBuilder()
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/token' })
@@ -191,7 +191,7 @@ const params = new DynamicAuctionBuilder()
     priceRange: { startPrice: 0.0001, endPrice: 0.01 },
     minProceeds: parseEther('50'),
     maxProceeds: parseEther('500'),
-    durationDays: 7,
+    duration: 7 * DAY_SECONDS,
     epochLength: 3600,
   })
   .withMigration({

--- a/examples/dynamic-auction-v4.ts
+++ b/examples/dynamic-auction-v4.ts
@@ -10,7 +10,7 @@
 // UNCOMMENT IF RUNNING LOCALLY
 // import { DopplerSDK, DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk';
 
-import { DopplerSDK } from '../src';
+import { DAY_SECONDS, DopplerSDK } from '../src';
 
 import {
   createPublicClient,
@@ -64,7 +64,7 @@ async function main() {
     })
     .poolConfig({ fee: 3000, tickSpacing: 60 })
     .auctionByTicks({
-      durationDays: 7,
+      duration: 7 * DAY_SECONDS,
       epochLength: 3600,
       startTick: -92103,
       endTick: -69080,

--- a/src/__tests__/entities/DopplerFactory.mining.test.ts
+++ b/src/__tests__/entities/DopplerFactory.mining.test.ts
@@ -5,6 +5,7 @@ import { mockAddresses } from '../mocks/addresses'
 import type { CreateDynamicAuctionParams } from '../../types'
 import { parseEther, type Address, decodeAbiParameters } from 'viem'
 import { isToken0Expected } from '../../utils'
+import { DAY_SECONDS } from '../../constants'
 
 vi.mock('../../addresses', () => ({
   getAddresses: vi.fn(() => mockAddresses)
@@ -33,7 +34,7 @@ describe('DopplerFactory - Token Ordering Mining', () => {
       numeraire,
     },
     auction: {
-      duration: 7, // days
+      duration: 7 * DAY_SECONDS,
       epochLength: 3600, // 1 hour
       startTick: isToken0Expected(numeraire) ? 92103 : -92103,
       endTick: isToken0Expected(numeraire) ? 69080 : -69080,

--- a/src/__tests__/entities/DopplerFactory.test.ts
+++ b/src/__tests__/entities/DopplerFactory.test.ts
@@ -5,6 +5,7 @@ import { mockAddresses, mockTokenAddress, mockPoolAddress } from '../mocks/addre
 import type { CreateStaticAuctionParams, CreateDynamicAuctionParams, CreateMulticurveParams } from '../../types'
 import { parseEther, keccak256, toHex, decodeAbiParameters, type Address } from 'viem'
 import { MIN_TICK, MAX_TICK, isToken0Expected } from '../../utils'
+import { DAY_SECONDS } from '../../constants'
 
 vi.mock('../../addresses', () => ({
   getAddresses: vi.fn(() => mockAddresses)
@@ -323,7 +324,7 @@ describe('DopplerFactory', () => {
         numeraire: mockAddresses.weth,
       },
       auction: {
-        duration: 7, // days
+        duration: 7 * DAY_SECONDS,
         epochLength: 3600, // 1 hour
         startTick: isToken0Expected(mockAddresses.weth) ? 92103 : -92103, // ~0.0001 ETH per token
         endTick: isToken0Expected(mockAddresses.weth) ? 69080 : -69080, // ~0.001 ETH per token

--- a/src/__tests__/integration/sdk-workflows.test.ts
+++ b/src/__tests__/integration/sdk-workflows.test.ts
@@ -5,6 +5,7 @@ import { mockAddresses, mockTokenAddress, mockPoolAddress } from '../mocks/addre
 import { parseEther, keccak256, toHex, type Address } from 'viem'
 import type { CreateStaticAuctionParams, CreateDynamicAuctionParams } from '../../types'
 import { isToken0Expected } from '../../utils'
+import { DAY_SECONDS } from '../../constants'
 
 vi.mock('../../addresses', () => ({
   getAddresses: vi.fn(() => mockAddresses)
@@ -168,7 +169,7 @@ describe('SDK Workflows Integration Tests', () => {
           numeraire: mockAddresses.weth,
         },
         auction: {
-          duration: 7, // days
+          duration: 7 * DAY_SECONDS,
           epochLength: 3600, // 1 hour
           startTick: 92103,
           endTick: 69080,

--- a/src/__tests__/type-consistency.test.ts
+++ b/src/__tests__/type-consistency.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { CreateDynamicAuctionParams, DynamicAuctionConfig } from '../types'
+import { DAY_SECONDS } from '../constants'
 
 describe('Type Consistency', () => {
   it('should have pool parameters separate from auction config', () => {
@@ -16,7 +17,7 @@ describe('Type Consistency', () => {
         numeraire: '0x0000000000000000000000000000000000000000'
       },
       auction: {
-        duration: 7,
+        duration: 7 * DAY_SECONDS,
         epochLength: 3600,
         startTick: -92103,
         endTick: -69080,

--- a/src/__tests__/v4-compatibility.test.ts
+++ b/src/__tests__/v4-compatibility.test.ts
@@ -5,6 +5,7 @@ import { DynamicAuctionBuilder } from '../builders'
 import { createMockPublicClient, createMockWalletClient } from './mocks/clients'
 import { mockAddresses, mockTokenAddress, mockHookAddress, mockGovernanceAddress, mockTimelockAddress, mockV2PoolAddress, mockAddressesWithExtras } from './mocks/addresses'
 import type { CreateDynamicAuctionParams } from '../types'
+import { DAY_SECONDS } from '../constants'
 
 describe('V4 SDK Compatibility', () => {
   let factory: DopplerFactory
@@ -32,7 +33,7 @@ describe('V4 SDK Compatibility', () => {
         numeraire: "0x0000000000000000000000000000000000000000" as const,
       },
       auction: {
-        duration: 7,
+        duration: 7 * DAY_SECONDS,
         epochLength: 43200, // 12 hours
         startTick: -92203,
         endTick: -91003,

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -366,12 +366,12 @@ export class DynamicAuctionBuilder<C extends SupportedChainId> {
     endTick: number
     minProceeds: bigint
     maxProceeds: bigint
-    durationDays?: number
+    duration?: number
     epochLength?: number
     gamma?: number
     numPdSlugs?: number
   }): this {
-    const duration = params.durationDays ?? DEFAULT_AUCTION_DURATION
+    const duration = params.duration ?? DEFAULT_AUCTION_DURATION
     const epochLength = params.epochLength ?? DEFAULT_EPOCH_LENGTH
     const gamma =
       params.gamma ?? (this.pool ? computeOptimalGamma(params.startTick, params.endTick, duration, epochLength, this.pool.tickSpacing) : undefined)
@@ -393,7 +393,7 @@ export class DynamicAuctionBuilder<C extends SupportedChainId> {
     priceRange: PriceRange
     minProceeds: bigint
     maxProceeds: bigint
-    durationDays?: number
+    duration?: number
     epochLength?: number
     gamma?: number
     tickSpacing?: number // optional; will use pool.tickSpacing if not provided
@@ -409,7 +409,7 @@ export class DynamicAuctionBuilder<C extends SupportedChainId> {
       endTick: ticks.endTick,
       minProceeds: params.minProceeds,
       maxProceeds: params.maxProceeds,
-      durationDays: params.durationDays,
+      duration: params.duration,
       epochLength: params.epochLength,
       gamma: params.gamma,
       numPdSlugs: params.numPdSlugs,

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -20,7 +20,7 @@ import {
   WAD,
   ZERO_ADDRESS,
 } from './constants'
-import { MAX_TICK, MIN_TICK } from './utils'
+import { computeOptimalGamma, MAX_TICK, MIN_TICK } from './utils'
 import type {
   CreateDynamicAuctionParams,
   CreateStaticAuctionParams,
@@ -44,27 +44,6 @@ function computeTicks(priceRange: PriceRange, tickSpacing: number): TickRange {
     Math.ceil(Math.log(priceRange.endPrice) / Math.log(1.0001) / tickSpacing) *
     tickSpacing
   return { startTick, endTick }
-}
-
-function computeOptimalGamma(
-  startTick: number,
-  endTick: number,
-  durationDays: number,
-  epochLength: number,
-  tickSpacing: number,
-): number {
-  const totalEpochs = (durationDays * DAY_SECONDS) / epochLength
-  const tickDelta = Math.abs(endTick - startTick)
-  // Base per-epoch movement in ticks
-  let perEpochTicks = Math.ceil(tickDelta / totalEpochs)
-  // Quantize up to the nearest multiple of tickSpacing
-  const multiples = Math.ceil(perEpochTicks / tickSpacing)
-  let gamma = multiples * tickSpacing
-  gamma = Math.max(tickSpacing, gamma)
-  if (gamma % tickSpacing !== 0) {
-    throw new Error('Computed gamma must be divisible by tick spacing')
-  }
-  return gamma
 }
 
 const MARKET_CAP_PRESET_ORDER = ['low', 'medium', 'high'] as const satisfies readonly MulticurveMarketCapPreset[]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,7 @@ export const SECONDS_PER_YEAR = 365 * SECONDS_PER_DAY
 
 // Default values
 export const DEFAULT_EPOCH_LENGTH = 43200 // 12 hours in seconds (matching V4 SDK)
-export const DEFAULT_AUCTION_DURATION = 7 // 7 days
+export const DEFAULT_AUCTION_DURATION = 7 * SECONDS_PER_DAY // 7 days
 export const DEFAULT_LOCK_DURATION = SECONDS_PER_YEAR // 1 year
 export const DEFAULT_PD_SLUGS = 5 // Default price discovery slugs
 export const DAY_SECONDS = SECONDS_PER_DAY // Alias for consistency

--- a/src/entities/DopplerFactory.ts
+++ b/src/entities/DopplerFactory.ts
@@ -50,7 +50,7 @@ import {
   DEFAULT_V4_INITIAL_PROPOSAL_THRESHOLD,
   DEFAULT_CREATE_GAS_LIMIT,
 } from '../constants'
-import { MIN_TICK, MAX_TICK, isToken0Expected } from '../utils'
+import { computeOptimalGamma, MIN_TICK, MAX_TICK, isToken0Expected } from '../utils'
 import { airlockAbi, bundlerAbi, DERC20Bytecode, DopplerBytecode, DopplerDN404Bytecode } from '../abis'
 
 // Type definition for the custom migration encoder function
@@ -485,7 +485,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     const addresses = getAddresses(this.chainId)
 
     // 1. Calculate gamma if not provided
-    const gamma = params.auction.gamma ?? this.computeOptimalGamma(
+    const gamma = params.auction.gamma ?? computeOptimalGamma(
       params.auction.startTick,
       params.auction.endTick,
       params.auction.duration,
@@ -1465,33 +1465,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
   }
 
   // computeTicks moved to builders. No longer needed here.
-
-  /**
-   * Compute optimal gamma parameter based on price range and time parameters
-   * Gamma determines how much the price can move per epoch during the sale.
-   */
-  private computeOptimalGamma(
-    startTick: number,
-    endTick: number,
-    durationDays: number,
-    epochLength: number,
-    tickSpacing: number
-  ): number {
-    // Calculate total number of epochs
-    const totalEpochs = (durationDays * DAY_SECONDS) / epochLength
-    const tickDelta = Math.abs(endTick - startTick)
-    // Base per-epoch movement in ticks
-    let perEpochTicks = Math.ceil(tickDelta / totalEpochs)
-    // Quantize up to the nearest multiple of tickSpacing
-    const multiples = Math.ceil(perEpochTicks / tickSpacing)
-    let gamma = multiples * tickSpacing
-    // Ensure minimum of one tickSpacing
-    gamma = Math.max(tickSpacing, gamma)
-    if (gamma % tickSpacing !== 0) {
-      throw new Error('Computed gamma must be divisible by tick spacing')
-    }
-    return gamma
-  }
+  // computeOptimalGamma moved to utils.
 
   // -----------------------------
   // Bundler helpers (Static/V3)

--- a/src/entities/DopplerFactory.ts
+++ b/src/entities/DopplerFactory.ts
@@ -36,7 +36,6 @@ import {
   BASIS_POINTS,
   WAD,
   DEFAULT_PD_SLUGS,
-  DAY_SECONDS,
   FLAG_MASK,
   DEFAULT_V3_NUM_POSITIONS,
   DEFAULT_V3_YEARLY_MINT_RATE,
@@ -506,7 +505,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     // Use startTimeOffset if provided, otherwise default to 30 seconds
     const startTimeOffset = params.startTimeOffset ?? 30
     const startTime = blockTimestamp + startTimeOffset
-    const endTime = blockTimestamp + params.auction.duration * DAY_SECONDS + startTimeOffset
+    const endTime = blockTimestamp + params.auction.duration + startTimeOffset
 
     // 3. Prepare hook initialization data
     const dopplerData = {
@@ -1381,8 +1380,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     }
     
     // Validate that total duration is divisible by epoch length
-    const totalDuration = params.auction.duration * DAY_SECONDS
-    if (totalDuration % params.auction.epochLength !== 0) {
+    if (params.auction.duration % params.auction.epochLength !== 0) {
       throw new Error('Epoch length must divide total duration evenly')
     }
     

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,7 +284,7 @@ export interface DynamicAuctionBuildConfig {
   // Time parameters
   startTimeOffset?: number; // Optional - seconds to add to block timestamp (default: 30)
   blockTimestamp?: number; // Optional - specific block timestamp to use (default: fetch latest)
-  duration?: number; // in days (default: 7)
+  duration?: number; // in seconds (default: 604800 = 7 days)
   epochLength?: number; // in seconds (default: 3600)
 
   // Price parameters - must provide either priceRange or tickRange

--- a/src/utils/computeOptimalGamma.ts
+++ b/src/utils/computeOptimalGamma.ts
@@ -1,0 +1,28 @@
+import { DAY_SECONDS } from "../constants"
+
+/**
+ * Compute optimal gamma parameter based on price range and time parameters
+ * Gamma determines how much the price can move per epoch during the sale.
+ */
+export function computeOptimalGamma(
+  startTick: number,
+  endTick: number,
+  durationDays: number,
+  epochLength: number,
+  tickSpacing: number,
+): number {
+  // Calculate total number of epochs
+  const totalEpochs = (durationDays * DAY_SECONDS) / epochLength
+  const tickDelta = Math.abs(endTick - startTick)
+  // Base per-epoch movement in ticks
+  let perEpochTicks = Math.ceil(tickDelta / totalEpochs)
+  // Quantize up to the nearest multiple of tickSpacing
+  const multiples = Math.ceil(perEpochTicks / tickSpacing)
+  let gamma = multiples * tickSpacing
+  // Ensure minimum of one tickSpacing
+  gamma = Math.max(tickSpacing, gamma)
+  if (gamma % tickSpacing !== 0) {
+    throw new Error('Computed gamma must be divisible by tick spacing')
+  }
+  return gamma
+}

--- a/src/utils/computeOptimalGamma.ts
+++ b/src/utils/computeOptimalGamma.ts
@@ -7,12 +7,12 @@ import { DAY_SECONDS } from "../constants"
 export function computeOptimalGamma(
   startTick: number,
   endTick: number,
-  durationDays: number,
+  duration: number,
   epochLength: number,
   tickSpacing: number,
 ): number {
   // Calculate total number of epochs
-  const totalEpochs = (durationDays * DAY_SECONDS) / epochLength
+  const totalEpochs = duration / epochLength
   const tickDelta = Math.abs(endTick - startTick)
   // Base per-epoch movement in ticks
   let perEpochTicks = Math.ceil(tickDelta / totalEpochs)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -50,4 +50,6 @@ export { decodeBalanceDelta } from './balanceDelta'
 
 export { computePoolId } from './poolKey'
 
+export { computeOptimalGamma } from "./computeOptimalGamma"
+
 export { isToken0Expected } from './isToken0Expected'

--- a/test-v4-deployment.ts
+++ b/test-v4-deployment.ts
@@ -3,6 +3,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 import { sepolia } from 'viem/chains'
 import { DopplerSDK } from './src/DopplerSDK'
 import { DynamicAuctionBuilder } from './src/builders'
+import { DAY_SECONDS } from './src/constants'
 
 // Test reproducing the V4 SDK deployment parameters
 async function testV4Deployment() {
@@ -41,7 +42,7 @@ async function testV4Deployment() {
     })
     .poolConfig({ fee: 3000, tickSpacing: 60 })
     .auctionByTicks({
-      durationDays: 7,
+      duration: 7 * DAY_SECONDS,
       epochLength: 43200,
       startTick: -92203,
       endTick: -91003,


### PR DESCRIPTION
For production use days seem fine, but for testing simulations I found it much more convenient to use tiny auctions (e.g. 300secs, 10sec epochs)
Seconds also align duration with epoch, and makes gamma calculation more reusable
To avoid code duplication I also extracted 2 gamma funcs into a single util