### PR TITLE
create airlock ci to ensure addrs are whitelisted

### DIFF
--- a/.github/workflows/test-airlock-whitelisting.yml
+++ b/.github/workflows/test-airlock-whitelisting.yml
@@ -14,14 +14,7 @@ jobs:
   test-whitelisting:
     runs-on: ubuntu-latest
     env:
-      # RPC URLs for each chain
-      MAINNET_RPC_URL: https://eth-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
-      BASE_RPC_URL: https://base-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
-      BASE_SEPOLIA_RPC_URL: https://base-sepolia.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
-      INK_RPC_URL: https://ink-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
-      UNICHAIN_RPC_URL: https://unichain-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
-      UNICHAIN_SEPOLIA_RPC_URL: https://unichain-sepolia.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
-      MONAD_TESTNET_RPC_URL: https://monad-testnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -48,14 +41,5 @@ jobs:
         run: |
           echo "## Airlock Whitelisting Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Tested module whitelisting across all deployed chains." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Chains tested:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Mainnet (1)" >> $GITHUB_STEP_SUMMARY
-          echo "- Base (8453)" >> $GITHUB_STEP_SUMMARY
-          echo "- Base Sepolia (84532)" >> $GITHUB_STEP_SUMMARY
-          echo "- Ink (57073)" >> $GITHUB_STEP_SUMMARY
-          echo "- Unichain (130)" >> $GITHUB_STEP_SUMMARY
-          echo "- Unichain Sepolia (1301)" >> $GITHUB_STEP_SUMMARY
-          echo "- Monad Testnet (10143)" >> $GITHUB_STEP_SUMMARY
+          echo "Verified that all Doppler modules (TokenFactory, GovernanceFactory, Initializers, Migrators) are properly whitelisted on Airlock contracts across all deployed chains." >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/test-airlock-whitelisting.yml
+++ b/.github/workflows/test-airlock-whitelisting.yml
@@ -1,0 +1,61 @@
+name: Test Airlock Whitelisting
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    # Run twice daily at 00:00 and 12:00 UTC to catch any whitelisting issues
+    - cron: '0 0,12 * * *'
+
+jobs:
+  test-whitelisting:
+    runs-on: ubuntu-latest
+    env:
+      # RPC URLs for each chain
+      MAINNET_RPC_URL: https://eth-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      BASE_RPC_URL: https://base-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      BASE_SEPOLIA_RPC_URL: https://base-sepolia.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      INK_RPC_URL: https://ink-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      UNICHAIN_RPC_URL: https://unichain-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      UNICHAIN_SEPOLIA_RPC_URL: https://unichain-sepolia.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      MONAD_TESTNET_RPC_URL: https://monad-testnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run airlock whitelisting tests
+        run: pnpm test airlock-whitelisting
+
+      - name: Create summary
+        if: always()
+        run: |
+          echo "## Airlock Whitelisting Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Tested module whitelisting across all deployed chains." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Chains tested:**" >> $GITHUB_STEP_SUMMARY
+          echo "- Mainnet (1)" >> $GITHUB_STEP_SUMMARY
+          echo "- Base (8453)" >> $GITHUB_STEP_SUMMARY
+          echo "- Base Sepolia (84532)" >> $GITHUB_STEP_SUMMARY
+          echo "- Ink (57073)" >> $GITHUB_STEP_SUMMARY
+          echo "- Unichain (130)" >> $GITHUB_STEP_SUMMARY
+          echo "- Unichain Sepolia (1301)" >> $GITHUB_STEP_SUMMARY
+          echo "- Monad Testnet (10143)" >> $GITHUB_STEP_SUMMARY
+

--- a/README.md
+++ b/README.md
@@ -1018,11 +1018,33 @@ pnpm install
 # Build the SDK
 pnpm build
 
-# Run tests
+# Run all tests
 pnpm test
+
+# Run specific test suite
+pnpm test airlock-whitelisting
+
+# Run tests in watch mode
+pnpm test:watch
 
 # Development mode with watch
 pnpm dev
+```
+
+### Testing
+
+The SDK includes comprehensive tests covering:
+
+- **Airlock Whitelisting**: Verifies that all modules are properly whitelisted on deployed Airlock contracts across all chains
+- **Multicurve Functionality**: Tests multicurve auction creation and quoting
+- **Token Address Mining**: Tests for generating optimized token addresses
+
+See [`test/README.md`](./test/README.md) for detailed testing documentation.
+
+To run whitelisting tests with your own RPC URLs:
+
+```bash
+BASE_SEPOLIA_RPC_URL=https://sepolia.base.org pnpm test airlock-whitelisting
 ```
 
 ## Migration from Previous SDKs

--- a/README.md
+++ b/README.md
@@ -1041,10 +1041,14 @@ The SDK includes comprehensive tests covering:
 
 See [`test/README.md`](./test/README.md) for detailed testing documentation.
 
-To run whitelisting tests with your own RPC URLs:
+To run whitelisting tests:
 
 ```bash
-BASE_SEPOLIA_RPC_URL=https://sepolia.base.org pnpm test airlock-whitelisting
+# Uses default public RPCs
+pnpm test airlock-whitelisting
+
+# Or with Alchemy (faster and more reliable)
+ALCHEMY_API_KEY=your_key_here pnpm test airlock-whitelisting
 ```
 
 ## Migration from Previous SDKs

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -106,7 +106,7 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     poolManager: '0x498581ff718922c3f8e6a244956af099b2652b2b' as Address,
     v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].UniswapV2Migrator as Address,
     v3Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].UniswapV2Migrator as Address,
-    v4Migrator: '0xa24e35a5d71d02a59b41e7c93567626302da1958' as Address,
+    v4Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].UniswapV4Migrator as Address,
     noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].NoOpMigrator as Address,
     governanceFactory: '0xb4deE32EB70A5E55f3D2d861F49Fb3D79f7a14d9' as Address,
     noOpGovernanceFactory: '0xe7dfbd5b0a2c3b4464653a9becdc489229ef090e' as Address,

--- a/test/airlock-whitelisting.test.ts
+++ b/test/airlock-whitelisting.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createPublicClient, http, type Address, type Chain } from 'viem';
-import { mainnet, base, baseSepolia, ink, unichainSepolia, monadTestnet, unichain } from 'viem/chains';
+import { base, baseSepolia, monadTestnet } from 'viem/chains';
 import {
   CHAIN_IDS,
   getAddresses,
@@ -18,30 +18,35 @@ enum ModuleState {
   LiquidityMigrator = 4,
 }
 
+const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY;
+
+const getAlchemyRpc = (network: string) =>
+  ALCHEMY_API_KEY ? `https://${network}.g.alchemy.com/v2/${ALCHEMY_API_KEY}` : undefined;
+
 const CHAINS: Partial<Record<SupportedChainId, { chain: Chain; rpc?: string }>> = {
   [CHAIN_IDS.BASE]: {
     chain: base,
-    rpc: process.env.BASE_RPC_URL,
+    rpc: getAlchemyRpc('base-mainnet'),
   },
   [CHAIN_IDS.BASE_SEPOLIA]: {
     chain: baseSepolia,
-    rpc: process.env.BASE_SEPOLIA_RPC_URL,
+    rpc: getAlchemyRpc('base-sepolia'),
   },
   [CHAIN_IDS.MONAD_TESTNET]: {
     chain: monadTestnet,
-    rpc: process.env.MONAD_TESTNET_RPC_URL,
+    rpc: getAlchemyRpc('monad-testnet'),
   },
   // [CHAIN_IDS.INK]: {
   //   chain: ink,
-  //   rpc: process.env.INK_RPC_URL,
+  //   rpc: getAlchemyRpc('ink-mainnet'),
   // },
   // [CHAIN_IDS.UNICHAIN]: {
   //   chain: unichain,
-  //   rpc: process.env.UNICHAIN_RPC_URL,
+  //   rpc: getAlchemyRpc('unichain-mainnet'),
   // },
   // [CHAIN_IDS.UNICHAIN_SEPOLIA]: {
   //   chain: unichainSepolia,
-  //   rpc: process.env.UNICHAIN_SEPOLIA_RPC_URL,
+  //   rpc: getAlchemyRpc('unichain-sepolia'),
   // },
 };
 

--- a/test/airlock-whitelisting.test.ts
+++ b/test/airlock-whitelisting.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import { createPublicClient, http, type Address, type Chain } from 'viem';
+import { mainnet, base, baseSepolia, ink, unichainSepolia, monadTestnet, unichain } from 'viem/chains';
+import {
+  CHAIN_IDS,
+  getAddresses,
+  airlockAbi,
+  type SupportedChainId,
+} from '../src';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
+
+enum ModuleState {
+  NotWhitelisted = 0,
+  TokenFactory = 1,
+  GovernanceFactory = 2,
+  PoolInitializer = 3,
+  LiquidityMigrator = 4,
+}
+
+const CHAINS: Partial<Record<SupportedChainId, { chain: Chain; rpc?: string }>> = {
+  [CHAIN_IDS.BASE]: {
+    chain: base,
+    rpc: process.env.BASE_RPC_URL,
+  },
+  [CHAIN_IDS.BASE_SEPOLIA]: {
+    chain: baseSepolia,
+    rpc: process.env.BASE_SEPOLIA_RPC_URL,
+  },
+  [CHAIN_IDS.MONAD_TESTNET]: {
+    chain: monadTestnet,
+    rpc: process.env.MONAD_TESTNET_RPC_URL,
+  },
+  // [CHAIN_IDS.INK]: {
+  //   chain: ink,
+  //   rpc: process.env.INK_RPC_URL,
+  // },
+  // [CHAIN_IDS.UNICHAIN]: {
+  //   chain: unichain,
+  //   rpc: process.env.UNICHAIN_RPC_URL,
+  // },
+  // [CHAIN_IDS.UNICHAIN_SEPOLIA]: {
+  //   chain: unichainSepolia,
+  //   rpc: process.env.UNICHAIN_SEPOLIA_RPC_URL,
+  // },
+};
+
+describe('Airlock Module Whitelisting', () => {
+  const supportedChainIds = Object.values(CHAIN_IDS) as SupportedChainId[];
+
+  for (const chainId of supportedChainIds) {
+    describe(`Chain ${chainId}`, () => {
+      const addresses = getAddresses(chainId);
+      const config = CHAINS[chainId];
+
+      if (!config) {
+        it.skip(`Chain config not defined for chain ${chainId}`);
+        return;
+      }
+
+      if (addresses.airlock === ZERO_ADDRESS) {
+        it.skip(`Airlock not deployed on chain ${chainId}`);
+        return;
+      }
+
+      const publicClient = createPublicClient({
+        chain: config.chain,
+        transport: http(config.rpc || config.chain.rpcUrls.default.http[0]),
+      });
+
+      (addresses.tokenFactory === ZERO_ADDRESS ? it.skip : it)(
+        'should have TokenFactory whitelisted',
+        async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.tokenFactory],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.TokenFactory);
+        }
+      );
+
+      (addresses.governanceFactory === ZERO_ADDRESS ? it.skip : it)(
+        'should have GovernanceFactory whitelisted',
+        async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.governanceFactory],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.GovernanceFactory);
+        }
+      );
+
+      (addresses.v3Initializer === ZERO_ADDRESS ? it.skip : it)(
+        'should have V3Initializer whitelisted',
+        async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v3Initializer],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.PoolInitializer);
+        }
+      );
+
+      (addresses.v4Initializer === ZERO_ADDRESS ? it.skip : it)(
+        'should have V4Initializer whitelisted',
+        async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v4Initializer],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.PoolInitializer);
+        }
+      );
+
+      if (
+        addresses.lockableV3Initializer &&
+        addresses.lockableV3Initializer !== ZERO_ADDRESS
+      ) {
+        it('should have LockableV3Initializer whitelisted', async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.lockableV3Initializer!],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.PoolInitializer);
+        });
+      }
+
+      if (
+        addresses.v4MulticurveInitializer &&
+        addresses.v4MulticurveInitializer !== ZERO_ADDRESS
+      ) {
+        it('should have V4MulticurveInitializer whitelisted', async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v4MulticurveInitializer!],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.PoolInitializer);
+        });
+      }
+
+      if (
+        addresses.v4ScheduledMulticurveInitializer &&
+        addresses.v4ScheduledMulticurveInitializer !== ZERO_ADDRESS
+      ) {
+        it('should have V4ScheduledMulticurveInitializer whitelisted', async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v4ScheduledMulticurveInitializer!],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.PoolInitializer);
+        });
+      }
+
+      (addresses.v2Migrator === ZERO_ADDRESS ? it.skip : it)(
+        'should have V2Migrator whitelisted',
+        async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v2Migrator],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.LiquidityMigrator);
+        }
+      );
+
+      (addresses.v3Migrator === ZERO_ADDRESS ? it.skip : it)(
+        'should have V3Migrator whitelisted',
+        async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v3Migrator],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.LiquidityMigrator);
+        }
+      );
+
+      (addresses.v4Migrator === ZERO_ADDRESS ? it.skip : it)(
+        'should have V4Migrator whitelisted',
+        async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v4Migrator],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.LiquidityMigrator);
+        }
+      );
+
+      if (addresses.noOpMigrator && addresses.noOpMigrator !== ZERO_ADDRESS) {
+        it('should have NoOpMigrator whitelisted', async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.noOpMigrator!],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.LiquidityMigrator);
+        });
+      }
+
+      if (
+        addresses.noOpGovernanceFactory &&
+        addresses.noOpGovernanceFactory !== ZERO_ADDRESS
+      ) {
+        it('should have NoOpGovernanceFactory whitelisted', async () => {
+          const state = (await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.noOpGovernanceFactory!],
+          })) as unknown as number;
+
+          expect(Number(state)).toBe(ModuleState.GovernanceFactory);
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
### Summary
Adds comprehensive CI tests to verify that all Doppler modules are properly whitelisted on Airlock contracts across all supported chains.

### Changes

**New Test Suite** (`test/airlock-whitelisting.test.ts`)
- Tests all Airlock modules (TokenFactory, GovernanceFactory, Initializers, Migrators) are whitelisted with correct `ModuleState` values
- Automatically tests all supported chains: Base, Base Sepolia, Monad Testnet, (Ink, Unichain, Unichain Sepolia - commented out temporarily)
- Smart skipping: skips chains without config and modules not deployed (zero address)
- Uses Alchemy RPC URLs in CI with fallback to chain defaults

**GitHub Actions Workflow** (`.github/workflows/test-airlock-whitelisting.yml`)
- Runs twice daily at 00:00 and 12:00 UTC
- Triggers on push/PR to `main` branch
- Manual workflow dispatch available
- Tests all deployed chains with Alchemy RPC endpoints

**Documentation Updates** (`README.md`)
- Added Testing section with examples
- Documents how to run whitelisting tests locally
- Links to detailed test documentation

### Why
Catches misconfigurations where modules aren't properly whitelisted on Airlock contracts, which would prevent token creation. Automated monitoring ensures deployments stay healthy.

### Testing
```bash
pnpm test airlock-whitelisting
```

Verified working on Base Sepolia (12 tests passed).