### PR TITLE
fix(multicurve): replace misleading poolAddress with poolId in return types

### DIFF
--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -295,7 +295,7 @@ const params = sdk.buildMulticurveAuction()
   .withUserAddress(user)
   .build()
 
-const { poolAddress, tokenAddress } = await sdk.factory.createMulticurve(params)
+const { tokenAddress, poolId } = await sdk.factory.createMulticurve(params)
 
 // Example 2: Using raw ticks (advanced users)
 const paramsRaw = new MulticurveBuilder(chainId)
@@ -314,7 +314,7 @@ const paramsRaw = new MulticurveBuilder(chainId)
   .withUserAddress(user)
   .build()
 
-const { poolAddress, tokenAddress } = await sdk.factory.createMulticurve(params)
+const { tokenAddress, poolId } = await sdk.factory.createMulticurve(params)
 ```
 
 Preset helper usage:
@@ -355,7 +355,7 @@ Pass the built object directly to the factory:
 ```ts
 const { poolAddress, tokenAddress } = await sdk.factory.createStaticAuction(staticParams)
 const { hookAddress, tokenAddress: token2, poolId } = await sdk.factory.createDynamicAuction(dynamicParams)
-const { poolAddress: pool3, tokenAddress: token3 } = await sdk.factory.createMulticurve(multicurveParams)
+const { tokenAddress: token3, poolId: poolId3 } = await sdk.factory.createMulticurve(multicurveParams)
 ```
 
 Notes:

--- a/examples/multicurve-by-marketcap.ts
+++ b/examples/multicurve-by-marketcap.ts
@@ -134,20 +134,20 @@ async function main() {
     // Simulate to preview addresses and get executable
     const simulation = await sdk.factory.simulateCreateMulticurve(params)
     console.log('\nPredicted addresses:')
-    console.log('Token:', simulation.asset)
-    console.log('Pool:', simulation.pool)
+    console.log('Token:', simulation.tokenAddress)
+    console.log('Pool ID:', simulation.poolId)
     console.log('Gas estimate:', simulation.gasEstimate)
 
     // Execute with guaranteed same addresses (uses same salt from simulation)
     const result = await simulation.execute()
 
     console.log('\nMulticurve pool created successfully!')
-    console.log('Token address:', result.tokenAddress, result.tokenAddress === simulation.asset ? '(matches)' : '(MISMATCH)')
-    console.log('Pool address:', result.poolAddress, result.poolAddress === simulation.pool ? '(matches)' : '(MISMATCH)')
+    console.log('Token address:', result.tokenAddress, result.tokenAddress === simulation.tokenAddress ? '(matches)' : '(MISMATCH)')
+    console.log('Pool ID:', result.poolId, result.poolId === simulation.poolId ? '(matches)' : '(MISMATCH)')
     console.log('Transaction:', result.transactionHash)
 
-    // Get the pool instance for monitoring
-    const poolInstance = await sdk.getMulticurvePool(result.poolAddress)
+    // Get the pool instance for monitoring (use token address as the lookup key)
+    const poolInstance = await sdk.getMulticurvePool(result.tokenAddress)
     const state = await poolInstance.getState()
 
     console.log('\nPool Info:')

--- a/examples/multicurve-quote-and-swap.ts
+++ b/examples/multicurve-quote-and-swap.ts
@@ -76,12 +76,12 @@ async function main() {
 
   // 3. Create the pool
   console.log('🔨 Creating pool...')
-  const { poolAddress, tokenAddress, transactionHash } = await sdk.factory.createMulticurve(params)
+  const { tokenAddress, poolId, transactionHash } = await sdk.factory.createMulticurve(params)
 
   console.log('  ✅ Pool created!')
   console.log('  Transaction:', transactionHash)
   console.log('  Token address:', tokenAddress)
-  console.log('  Pool address:', poolAddress)
+  console.log('  Pool ID:', poolId)
   console.log()
 
   // Wait for transaction to be mined

--- a/src/DopplerSDK.ts
+++ b/src/DopplerSDK.ts
@@ -59,10 +59,10 @@ export class DopplerSDK<C extends SupportedChainId = SupportedChainId> {
 
   /**
    * Get a MulticurvePool instance for interacting with a V4 multicurve pool
-   * @param poolAddress The address of the V4 pool
+   * @param tokenAddress The address of the token created by the auction (called "asset" in contracts; V4 pools don't have addresses, so the token is used as the lookup key)
    */
-  async getMulticurvePool(poolAddress: Address): Promise<MulticurvePool> {
-    return new MulticurvePool(this.publicClient, this.walletClient, poolAddress)
+  async getMulticurvePool(tokenAddress: Address): Promise<MulticurvePool> {
+    return new MulticurvePool(this.publicClient, this.walletClient, tokenAddress)
   }
 
   /**

--- a/src/__tests__/entities/MulticurvePool.test.ts
+++ b/src/__tests__/entities/MulticurvePool.test.ts
@@ -15,12 +15,12 @@ vi.mock('../../addresses', async (importOriginal) => {
 })
 
 describe('MulticurvePool', () => {
-  const mockPoolAddress = '0x1234567890123456789012345678901234567890' as Address
+  const mockTokenAddress = '0x1234567890123456789012345678901234567890' as Address
   const mockNumeraire = '0x4200000000000000000000000000000000000006' as Address
   const mockHook = '0xcccccccccccccccccccccccccccccccccccccccc' as Address
   const mockMigratorHook = '0xdddddddddddddddddddddddddddddddddddddddd' as Address
   const mockPoolKey = {
-    currency0: mockPoolAddress,
+    currency0: mockTokenAddress,
     currency1: mockNumeraire,
     fee: 3000,
     tickSpacing: 60,
@@ -35,20 +35,20 @@ describe('MulticurvePool', () => {
   beforeEach(() => {
     publicClient = createMockPublicClient()
     walletClient = createMockWalletClient()
-    multicurvePool = new MulticurvePool(publicClient, walletClient, mockPoolAddress)
+    multicurvePool = new MulticurvePool(publicClient, walletClient, mockTokenAddress)
     vi.clearAllMocks()
   })
 
-  describe('getAddress', () => {
-    it('should return the pool address', () => {
-      expect(multicurvePool.getAddress()).toBe(mockPoolAddress)
+  describe('getTokenAddress', () => {
+    it('should return the token address', () => {
+      expect(multicurvePool.getTokenAddress()).toBe(mockTokenAddress)
     })
   })
 
   describe('getState', () => {
     it('should fetch and return pool state', async () => {
       const mockState = {
-        asset: mockPoolAddress,
+        asset: mockTokenAddress,
         numeraire: mockNumeraire,
         fee: 3000,
         tickSpacing: 60,
@@ -71,7 +71,7 @@ describe('MulticurvePool', () => {
         expect.objectContaining({
           address: mockAddresses.v4MulticurveInitializer,
           functionName: 'getState',
-          args: [mockPoolAddress],
+          args: [mockTokenAddress],
         })
       )
     })
@@ -164,14 +164,14 @@ describe('MulticurvePool', () => {
           [],
           [
             {
-              beneficiary: mockPoolAddress,
+              beneficiary: mockTokenAddress,
               shares: 10n,
             },
           ],
         ] as any)
         .mockResolvedValueOnce([
           migratedPoolKey,
-          mockPoolAddress,
+          mockTokenAddress,
           123,
           3600,
           false,
@@ -209,7 +209,7 @@ describe('MulticurvePool', () => {
     })
 
     it('should throw error if wallet client is not provided', async () => {
-      const multicurvePoolWithoutWallet = new MulticurvePool(publicClient, undefined, mockPoolAddress)
+      const multicurvePoolWithoutWallet = new MulticurvePool(publicClient, undefined, mockTokenAddress)
 
       await expect(multicurvePoolWithoutWallet.collectFees()).rejects.toThrow(
         'Wallet client required to collect fees'
@@ -293,14 +293,14 @@ describe('MulticurvePool', () => {
           [],
           [
             {
-              beneficiary: mockPoolAddress,
+              beneficiary: mockTokenAddress,
               shares: 10n,
             },
           ],
         ] as any)
         .mockResolvedValueOnce([
           migratedPoolKey,
-          mockPoolAddress,
+          mockTokenAddress,
           0,
           3600,
           false,
@@ -344,7 +344,7 @@ describe('MulticurvePool', () => {
           [],
           [
             {
-              beneficiary: mockPoolAddress,
+              beneficiary: mockTokenAddress,
               shares: 10n,
             },
           ],
@@ -352,7 +352,7 @@ describe('MulticurvePool', () => {
         .mockResolvedValueOnce(mockLockerAddress as any)
         .mockResolvedValueOnce([
           migratedPoolKey,
-          mockPoolAddress,
+          mockTokenAddress,
           123,
           3600,
           false,
@@ -413,7 +413,7 @@ describe('MulticurvePool', () => {
 
       const tokenAddress = await multicurvePool.getTokenAddress()
 
-      expect(tokenAddress).toBe(mockPoolAddress)
+      expect(tokenAddress).toBe(mockTokenAddress)
     })
   })
 

--- a/src/__tests__/fork/multicurve-noop-base.test.ts
+++ b/src/__tests__/fork/multicurve-noop-base.test.ts
@@ -125,9 +125,9 @@ maybeDescribe('Fork/Live - Multicurve NoOp Migration on Base', () => {
     expect(createParams.liquidityMigratorData).toBe('0x')
 
     // Simulate the create operation
-    const { asset, pool } = await sdk.factory.simulateCreateMulticurve(params)
-    expect(asset).toMatch(/^0x[a-fA-F0-9]{40}$/)
-    expect(pool).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    const { tokenAddress, poolId } = await sdk.factory.simulateCreateMulticurve(params)
+    expect(tokenAddress).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    expect(poolId).toMatch(/^0x[a-fA-F0-9]{64}$/)
   }, 30_000)
 
   it('creates multicurve auction with negative ticks (-202000 to -188000)', async () => {
@@ -189,9 +189,9 @@ maybeDescribe('Fork/Live - Multicurve NoOp Migration on Base', () => {
     expect(createParams.liquidityMigratorData).toBe('0x')
 
     // Simulate the create operation
-    const { asset, pool } = await sdk.factory.simulateCreateMulticurve(params)
-    expect(asset).toMatch(/^0x[a-fA-F0-9]{40}$/)
-    expect(pool).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    const { tokenAddress, poolId } = await sdk.factory.simulateCreateMulticurve(params)
+    expect(tokenAddress).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    expect(poolId).toMatch(/^0x[a-fA-F0-9]{64}$/)
   }, 30_000)
 
   it('creates multicurve auction using market cap presets', async () => {
@@ -254,8 +254,8 @@ maybeDescribe('Fork/Live - Multicurve NoOp Migration on Base', () => {
     expect(createParams.liquidityMigrator).toBe(addresses.noOpMigrator)
     expect(createParams.liquidityMigratorData).toBe('0x')
 
-    const { asset, pool } = await sdk.factory.simulateCreateMulticurve(params)
-    expect(asset).toMatch(/^0x[a-fA-F0-9]{40}$/)
-    expect(pool).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    const { tokenAddress, poolId } = await sdk.factory.simulateCreateMulticurve(params)
+    expect(tokenAddress).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    expect(poolId).toMatch(/^0x[a-fA-F0-9]{64}$/)
   }, 30_000)
 })

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -127,7 +127,7 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     v3Quoter: '0xC5290058841028F1614F3A6F0F5816cAd0df5E27' as Address,
     lockableV3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].LockableUniswapV3Initializer as Address,
     v4Initializer: '0x8e891d249f1ecbffa6143c03eb1b12843aef09d3' as Address,
-    v4MulticurveInitializer: '0x359b5952a254baaa0105381825daedb8986bb55c' as Address, // From doppler multicurve deployments (Base Sepolia)
+    v4MulticurveInitializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].UniswapV4MulticurveInitializer as Address,
     v4ScheduledMulticurveInitializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].UniswapV4ScheduledMulticurveInitializer as Address, // From Doppler scheduled multicurve deployments (Base Sepolia)
     dopplerLens: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA].DopplerLensQuoter as Address,
     dopplerDeployer: '0x60a039e4add40ca95e0475c11e8a4182d06c9aa0' as Address,


### PR DESCRIPTION
V4 multicurve pools don't have addresses - they exist within the PoolManager and are identified by a poolId (hash of the PoolKey)

- Replace poolAddress with poolId in createMulticurve() and simulateCreateMulticurve()
- Rename asset/pool return fields to tokenAddress/poolId for consistency
- Add computeMulticurvePoolId() helper to derive poolId from PoolKey
- Rename getMulticurvePool(poolAddress) param to getMulticurvePool(tokenAddress)
- Rename MulticurvePool.getAddress() to getTokenAddress()
- Add clarifying comments explaining 'asset' (contract) vs 'tokenAddress' (SDK) terminology
- Update examples, docs, and tests