### PR TITLE
auto calculate tick spacing

### DIFF
--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -191,12 +191,12 @@ Examples:
 const params = sdk.buildDynamicAuction()
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000_000'), numTokensToSell: parseEther('500_000_000'), numeraire: WETH })
-  .poolConfig({ fee: 3000, tickSpacing: 60 }) // Required BEFORE withMarketCapRange!
   .withMarketCapRange({
     marketCap: { start: 500_000, min: 50_000 }, // $500k start, descends to $50k floor
     numerairePrice: 3000, // ETH = $3000 USD
     minProceeds: parseEther('100'), // Min 100 ETH to graduate
     maxProceeds: parseEther('5000'), // Cap at 5000 ETH
+    fee: 3000, // 0.3% fee tier (tickSpacing=60 derived automatically)
     // duration: 7 * DAY_SECONDS,   // Optional: defaults to 7 days
     // epochLength: 3600,           // Optional: defaults to 1 hour
   })
@@ -205,12 +205,12 @@ const params = sdk.buildDynamicAuction()
   .withUserAddress(user)
   .build()
 
-// Example 2: Using price range (legacy)
-const paramsLegacy = new DynamicAuctionBuilder()
+// Example 2: Using raw ticks (for advanced users or custom fee/tickSpacing)
+const paramsManual = new DynamicAuctionBuilder()
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000'), numTokensToSell: parseEther('900_000'), numeraire: weth })
-  .poolConfig({ fee: 3000, tickSpacing: 60 })
-  .auctionByPriceRange({ priceRange: { startPrice: 0.0001, endPrice: 0.001 }, minProceeds: parseEther('100'), maxProceeds: parseEther('1000') })
+  .poolConfig({ fee: 3000, tickSpacing: 60 }) // Use poolConfig() + auctionByTicks() for manual config
+  .auctionByTicks({ startTick: 100000, endTick: 200000, minProceeds: parseEther('100'), maxProceeds: parseEther('1000') })
   .withGovernance({ useDefaults: true })
   .withMigration({ type: 'uniswapV2' })
   .withUserAddress(user)

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -141,12 +141,13 @@ Methods (chainable):
 - Price configuration methods (use one, not multiple):
   - **withMarketCapRange({ marketCap, numerairePrice, minProceeds, maxProceeds, ... })** ⭐ Recommended
     - Configure via dollar-denominated market cap targets
-    - Requires both `saleConfig()` AND `poolConfig()` to be called first
+    - Requires `saleConfig()` to be called first (for numeraire and tokenSupply)
     - Handles all tick math and token ordering internally
+    - Uses fixed tickSpacing of 30 (max allowed by Doppler contract)
     - Required: `marketCap: { start, min }`, `numerairePrice`, `minProceeds`, `maxProceeds`
       - `start` = auction launch price (high), `min` = floor price the auction descends to (low)
-    - Optional: `duration`, `epochLength`, `gamma`, `numPdSlugs`, `tokenDecimals`, `numeraireDecimals`
-    - Defaults: `duration = 7 days`, `epochLength = 1 hour`, `numPdSlugs = 5`
+    - Optional: `fee`, `duration`, `epochLength`, `gamma`, `numPdSlugs`, `tokenDecimals`, `numeraireDecimals`
+    - Defaults: `fee = 10000 (1%)`, `duration = 7 days`, `epochLength = 1 hour`, `numPdSlugs = 5`
   - auctionByTicks({ startTick, endTick, minProceeds, maxProceeds, duration?, epochLength?, gamma?, numPdSlugs? })
     - Defaults: `duration = DEFAULT_AUCTION_DURATION (604800)`, `epochLength = DEFAULT_EPOCH_LENGTH (43200)`, `numPdSlugs` optional
     - If `gamma` omitted, computed from ticks, duration, epoch length, and `tickSpacing`
@@ -196,7 +197,7 @@ const params = sdk.buildDynamicAuction()
     numerairePrice: 3000, // ETH = $3000 USD
     minProceeds: parseEther('100'), // Min 100 ETH to graduate
     maxProceeds: parseEther('5000'), // Cap at 5000 ETH
-    fee: 3000, // 0.3% fee tier (tickSpacing=60 derived automatically)
+    // fee: 10000,                  // Optional: defaults to 1% (tickSpacing is always 30)
     // duration: 7 * DAY_SECONDS,   // Optional: defaults to 7 days
     // epochLength: 3600,           // Optional: defaults to 1 hour
   })
@@ -209,7 +210,7 @@ const params = sdk.buildDynamicAuction()
 const paramsManual = new DynamicAuctionBuilder()
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000'), numTokensToSell: parseEther('900_000'), numeraire: weth })
-  .poolConfig({ fee: 3000, tickSpacing: 60 }) // Use poolConfig() + auctionByTicks() for manual config
+  .poolConfig({ fee: 3000, tickSpacing: 10 }) // Use poolConfig() + auctionByTicks() for manual config (tickSpacing <= 30)
   .auctionByTicks({ startTick: 100000, endTick: 200000, minProceeds: parseEther('100'), maxProceeds: parseEther('1000') })
   .withGovernance({ useDefaults: true })
   .withMigration({ type: 'uniswapV2' })

--- a/examples/dynamic-auction-by-marketcap.ts
+++ b/examples/dynamic-auction-by-marketcap.ts
@@ -9,7 +9,7 @@
  *
  * Key requirements:
  * - saleConfig() must be called before withMarketCapRange()
- * - poolConfig() must also be called before withMarketCapRange() (for tickSpacing)
+ * - tickSpacing is automatically derived from fee (no need to call poolConfig())
  */
 
 import { DopplerSDK, DAY_SECONDS } from '../src'
@@ -60,7 +60,8 @@ async function main() {
   console.log('')
 
   // Build dynamic auction using market cap range instead of raw ticks
-  // Note: both saleConfig() AND poolConfig() are required before withMarketCapRange()
+  // Note: saleConfig() must be called before withMarketCapRange()
+  // tickSpacing is automatically derived from fee (no poolConfig() needed!)
   const params = sdk
     .buildDynamicAuction()
     .tokenConfig({
@@ -73,7 +74,6 @@ async function main() {
       numTokensToSell: parseEther('500000000'), // 500 million for sale
       numeraire: '0x4200000000000000000000000000000000000006', // WETH on Base
     })
-    .poolConfig({ fee: 3000, tickSpacing: 10 }) // Required before withMarketCapRange!
     // Use market cap range - converts to ticks internally
     // Dutch auction: starts at high price (start), descends to floor (min)
     .withMarketCapRange({
@@ -81,6 +81,7 @@ async function main() {
       numerairePrice: ethPriceUsd, // Live ETH price from CoinGecko
       minProceeds: parseEther('100'), // Min 100 ETH to graduate
       maxProceeds: parseEther('5000'), // Cap at 5000 ETH
+      fee: 3000,                      // 0.3% fee tier (tickSpacing=60 derived automatically)
       numPdSlugs: 15,                 // Price discovery slugs
       // Optional overrides (defaults shown):
       // duration: 7 * DAY_SECONDS,   // 7 day auction
@@ -92,7 +93,7 @@ async function main() {
     .withMigration({
       type: 'uniswapV4',
       fee: 3000,
-      tickSpacing: 10,
+      tickSpacing: 60,  // Must match pool tickSpacing (derived from fee: 3000)
       streamableFees: {
         lockDuration: 365 * 24 * 60 * 60, // 1 year
         beneficiaries: [

--- a/examples/dynamic-auction-by-marketcap.ts
+++ b/examples/dynamic-auction-by-marketcap.ts
@@ -93,7 +93,7 @@ async function main() {
     .withMigration({
       type: 'uniswapV4',
       fee: 3000,
-      tickSpacing: 60,  // Must match pool tickSpacing (derived from fee: 3000)
+      tickSpacing: 60,  // Post-migration pool tickSpacing (standard Uniswap V4, no MAX_TICK_SPACING constraint)
       streamableFees: {
         lockDuration: 365 * 24 * 60 * 60, // 1 year
         beneficiaries: [

--- a/src/__tests__/builders/MarketCapRange.test.ts
+++ b/src/__tests__/builders/MarketCapRange.test.ts
@@ -139,7 +139,7 @@ describe('Builder withMarketCapRange ordering', () => {
           numerairePrice: 3000,
           minProceeds: parseEther('10'),
           maxProceeds: parseEther('1000'),
-          fee: 10000, // 1% fee tier
+          fee: 500, // 0.05% fee tier
         })
         .withGovernance({ type: 'default' })
         .withMigration({ type: 'uniswapV2' })
@@ -147,9 +147,29 @@ describe('Builder withMarketCapRange ordering', () => {
 
       const params = builder.build()
 
-      expect(params.pool.fee).toBe(10000)
+      expect(params.pool.fee).toBe(500)
       // tickSpacing is always 30 (max) for withMarketCapRange
       expect(params.pool.tickSpacing).toBe(30)
+    })
+
+    it('throws for invalid fee tier in withMarketCapRange', () => {
+      const builder = DynamicAuctionBuilder.forChain(CHAIN_IDS.BASE)
+        .tokenConfig({ name: 'Test', symbol: 'TST', tokenURI: 'ipfs://test' })
+        .saleConfig({
+          initialSupply: parseEther('1000000000'),
+          numTokensToSell: parseEther('900000000'),
+          numeraire: WETH,
+        })
+
+      expect(() =>
+        builder.withMarketCapRange({
+          marketCap: { start: 100_000, min: 10_000 },
+          numerairePrice: 3000,
+          minProceeds: parseEther('10'),
+          maxProceeds: parseEther('1000'),
+          fee: 1234 as any, // invalid fee tier
+        })
+      ).toThrow('Invalid fee tier: 1234. Must be one of: 100, 500, 3000, 10000')
     })
   })
 

--- a/src/__tests__/builders/MarketCapRange.test.ts
+++ b/src/__tests__/builders/MarketCapRange.test.ts
@@ -120,10 +120,10 @@ describe('Builder withMarketCapRange ordering', () => {
       expect(params.auction.startTick).toBeDefined()
       expect(params.auction.endTick).toBeDefined()
       expect(params.auction.startTick).toBeLessThan(params.auction.endTick)
-      // Verify fee was derived (default is MEDIUM = 3000)
-      // tickSpacing is clamped to 10 for dynamic auctions (Doppler.sol MAX_TICK_SPACING = 30)
-      expect(params.pool.fee).toBe(3000)
-      expect(params.pool.tickSpacing).toBe(10)
+      // Verify fee was derived (default is HIGH = 10000 / 1%)
+      // tickSpacing is always 30 (max) for withMarketCapRange
+      expect(params.pool.fee).toBe(10000)
+      expect(params.pool.tickSpacing).toBe(30)
     })
 
     it('allows specifying custom fee in withMarketCapRange', () => {
@@ -148,8 +148,8 @@ describe('Builder withMarketCapRange ordering', () => {
       const params = builder.build()
 
       expect(params.pool.fee).toBe(10000)
-      // tickSpacing is clamped to 10 for dynamic auctions (Doppler.sol MAX_TICK_SPACING = 30)
-      expect(params.pool.tickSpacing).toBe(10)
+      // tickSpacing is always 30 (max) for withMarketCapRange
+      expect(params.pool.tickSpacing).toBe(30)
     })
   })
 

--- a/src/__tests__/entities/DopplerFactory.governance.test.ts
+++ b/src/__tests__/entities/DopplerFactory.governance.test.ts
@@ -92,13 +92,13 @@ describe('DopplerFactory governance encoding', () => {
       },
       pool: {
         fee: 3000,
-        tickSpacing: 60,
+        tickSpacing: 10, // Must be <= 30 for dynamic auctions (Doppler.sol MAX_TICK_SPACING)
       },
       governance: { type: 'noOp' },
       migration: {
         type: 'uniswapV4',
         fee: 3000,
-        tickSpacing: 60,
+        tickSpacing: 10, // Must be <= 30 for dynamic auctions (Doppler.sol MAX_TICK_SPACING)
         streamableFees: {
           lockDuration: 7 * 24 * 60 * 60,
           beneficiaries: [{ beneficiary: account.address, shares: parseEther('1') }],

--- a/src/__tests__/entities/DopplerFactory.mining.test.ts
+++ b/src/__tests__/entities/DopplerFactory.mining.test.ts
@@ -47,7 +47,7 @@ describe('DopplerFactory - Token Ordering Mining', () => {
     },
     pool: {
       fee: 3000,
-      tickSpacing: 60,
+      tickSpacing: 10, // Must be <= 30 for dynamic auctions (Doppler.sol MAX_TICK_SPACING)
     },
     governance: { type: 'default' },
     migration: { type: 'uniswapV2' },

--- a/src/__tests__/entities/DopplerFactory.test.ts
+++ b/src/__tests__/entities/DopplerFactory.test.ts
@@ -351,13 +351,13 @@ describe('DopplerFactory', () => {
       },
       pool: {
         fee: 3000,
-        tickSpacing: 60,
+        tickSpacing: 10, // Must be <= 30 for dynamic auctions (Doppler.sol MAX_TICK_SPACING)
       },
       governance: { noOp: true },
       migration: {
         type: 'uniswapV4',
         fee: 3000,
-        tickSpacing: 60,
+        tickSpacing: 10, // Must be <= 30 for dynamic auctions (Doppler.sol MAX_TICK_SPACING)
         streamableFees: {
           lockDuration: 365 * 24 * 60 * 60, // 1 year
           beneficiaries: [

--- a/src/__tests__/integration/sdk-workflows.test.ts
+++ b/src/__tests__/integration/sdk-workflows.test.ts
@@ -182,13 +182,13 @@ describe('SDK Workflows Integration Tests', () => {
         },
         pool: {
           fee: 3000,
-          tickSpacing: 60,
+          tickSpacing: 10, // Must be <= 30 for dynamic auctions (Doppler.sol MAX_TICK_SPACING)
         },
         governance: { noOp: true },
         migration: {
           type: 'uniswapV4',
           fee: 3000,
-          tickSpacing: 60,
+          tickSpacing: 10, // Must be <= 30 for dynamic auctions (Doppler.sol MAX_TICK_SPACING)
           streamableFees: {
             lockDuration: 365 * 24 * 60 * 60,
             beneficiaries: [

--- a/src/__tests__/type-consistency.test.ts
+++ b/src/__tests__/type-consistency.test.ts
@@ -26,7 +26,7 @@ describe('Type Consistency', () => {
       },
       pool: {
         fee: 3000,
-        tickSpacing: 60
+        tickSpacing: 10 // Must be <= 30 for dynamic auctions (Doppler.sol MAX_TICK_SPACING)
       },
       governance: { noOp: true },
       migration: {
@@ -37,7 +37,7 @@ describe('Type Consistency', () => {
 
     // Verify pool parameters are in the pool object
     expect(params.pool.fee).toBe(3000)
-    expect(params.pool.tickSpacing).toBe(60)
+    expect(params.pool.tickSpacing).toBe(10)
     
     // Verify auction config doesn't have fee or tickSpacing
     const auctionConfig: DynamicAuctionConfig = params.auction

--- a/src/builders/DynamicAuctionBuilder.ts
+++ b/src/builders/DynamicAuctionBuilder.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_V4_YEARLY_MINT_RATE,
   DOPPLER_MAX_TICK_SPACING,
   FEE_TIERS,
+  VALID_FEE_TIERS,
   ZERO_ADDRESS,
 } from '../constants'
 import {
@@ -219,6 +220,14 @@ export class DynamicAuctionBuilder<C extends SupportedChainId>
     // Default fee is HIGH (1%) for Dutch auctions
     // tickSpacing is always MAX (30) for withMarketCapRange convenience method
     const fee = params.fee ?? FEE_TIERS.HIGH
+    
+    // Validate fee is a standard tier
+    if (!VALID_FEE_TIERS.includes(fee)) {
+      throw new Error(
+        `Invalid fee tier: ${fee}. Must be one of: ${VALID_FEE_TIERS.join(', ')}`
+      )
+    }
+    
     const tickSpacing = DOPPLER_MAX_TICK_SPACING
 
     // Set pool config internally

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,12 @@ export const FEE_TIERS = {
   HIGH: 10000     // 1.00%
 } as const
 
+/** Valid fee tier values (100, 500, 3000, 10000) */
+export type FeeTier = typeof FEE_TIERS[keyof typeof FEE_TIERS]
+
+/** Array of valid fee tiers for validation */
+export const VALID_FEE_TIERS: readonly FeeTier[] = [100, 500, 3000, 10000] as const
+
 // Tick spacings for different fee tiers (standard Uniswap mapping)
 export const TICK_SPACINGS = {
   100: 1,
@@ -26,18 +32,6 @@ export const TICK_SPACINGS = {
  * @see Doppler.sol line 159: `int24 constant MAX_TICK_SPACING = 30`
  */
 export const DOPPLER_MAX_TICK_SPACING = 30
-
-/** 
- * Tick spacings for dynamic auctions, constrained by DOPPLER_MAX_TICK_SPACING.
- * Higher fee tiers (3000, 10000) are clamped to tickSpacing = 10 since their
- * standard values (60, 200) exceed the Doppler contract's MAX_TICK_SPACING = 30.
- */
-export const DYNAMIC_AUCTION_TICK_SPACINGS = {
-  100: 1,
-  500: 10,
-  3000: 10,  // clamped from 60
-  10000: 10, // clamped from 200
-} as const
 
 // Time constants
 export const SECONDS_PER_DAY = 86400

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,12 +13,30 @@ export const FEE_TIERS = {
   HIGH: 10000     // 1.00%
 } as const
 
-// Tick spacings for different fee tiers
+// Tick spacings for different fee tiers (standard Uniswap mapping)
 export const TICK_SPACINGS = {
   100: 1,
   500: 10,
   3000: 60,
   10000: 200
+} as const
+
+/** 
+ * Maximum tick spacing allowed by Doppler.sol for dynamic (Dutch) auctions.
+ * @see Doppler.sol line 159: `int24 constant MAX_TICK_SPACING = 30`
+ */
+export const DOPPLER_MAX_TICK_SPACING = 30
+
+/** 
+ * Tick spacings for dynamic auctions, constrained by DOPPLER_MAX_TICK_SPACING.
+ * Higher fee tiers (3000, 10000) are clamped to tickSpacing = 10 since their
+ * standard values (60, 200) exceed the Doppler contract's MAX_TICK_SPACING = 30.
+ */
+export const DYNAMIC_AUCTION_TICK_SPACINGS = {
+  100: 1,
+  500: 10,
+  3000: 10,  // clamped from 60
+  10000: 10, // clamped from 200
 } as const
 
 // Time constants
@@ -89,3 +107,6 @@ export const DOPPLER_FLAGS = BigInt(
 // V4 Dynamic Fee Flag
 export const DYNAMIC_FEE_FLAG = 0x800000 // 8388608 in decimal
 export const FEE_AMOUNT_MASK = 0xFFFFFF // Mask to extract actual fee from dynamic fee
+
+// Valid fee tiers for dynamic auctions (those with tickSpacing <= DOPPLER_MAX_TICK_SPACING)
+export const DYNAMIC_AUCTION_VALID_FEES = [100, 500, 3000, 10000] as const

--- a/src/entities/DopplerFactory.ts
+++ b/src/entities/DopplerFactory.ts
@@ -48,6 +48,7 @@ import {
   DEFAULT_CREATE_GAS_LIMIT,
   DEFAULT_V3_FEE,
   TICK_SPACINGS,
+  DOPPLER_MAX_TICK_SPACING,
 } from '../constants'
 import { computeOptimalGamma, MIN_TICK, MAX_TICK, isToken0Expected } from '../utils'
 import { airlockAbi, bundlerAbi, DERC20Bytecode, DopplerBytecode, DopplerDN404Bytecode, v4MulticurveInitializerAbi } from '../abis'
@@ -1536,6 +1537,16 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     }
     if (params.pool.tickSpacing <= 0) {
       throw new Error('Tick spacing must be positive')
+    }
+    
+    // Validate tick spacing against Doppler contract constraint
+    // @see Doppler.sol line 159: `int24 constant MAX_TICK_SPACING = 30`
+    if (params.pool.tickSpacing > DOPPLER_MAX_TICK_SPACING) {
+      throw new Error(
+        `Dynamic auctions require tickSpacing <= ${DOPPLER_MAX_TICK_SPACING} (Doppler.sol MAX_TICK_SPACING). ` +
+        `Got tickSpacing=${params.pool.tickSpacing}. ` +
+        `Use withMarketCapRange() which handles this automatically, or use a smaller tickSpacing with poolConfig().`
+      )
     }
     
     // Validate that total duration is divisible by epoch length

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,9 @@ export {
   FLAG_MASK,
   DOPPLER_FLAGS,
   DYNAMIC_FEE_FLAG,
-  FEE_AMOUNT_MASK
+  FEE_AMOUNT_MASK,
+  DOPPLER_MAX_TICK_SPACING,
+  DYNAMIC_AUCTION_TICK_SPACINGS,
 } from './constants'
 
 // Export utility functions (includes MIN_SQRT_RATIO and MAX_SQRT_RATIO from tickMath)

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,8 @@ export {
   DYNAMIC_FEE_FLAG,
   FEE_AMOUNT_MASK,
   DOPPLER_MAX_TICK_SPACING,
-  DYNAMIC_AUCTION_TICK_SPACINGS,
+  VALID_FEE_TIERS,
+  type FeeTier,
 } from './constants'
 
 // Export utility functions (includes MIN_SQRT_RATIO and MAX_SQRT_RATIO from tickMath)

--- a/src/types.ts
+++ b/src/types.ts
@@ -329,6 +329,8 @@ export interface DynamicAuctionMarketCapConfig {
   tokenDecimals?: number;
   /** Numeraire decimals (default: 18) */
   numeraireDecimals?: number;
+  /** Fee tier in basis points (e.g., 3000 for 0.3%). Default: 3000 */
+  fee?: number;
   /** Minimum proceeds required for successful auction */
   minProceeds: bigint;
   /** Maximum proceeds cap for the auction */

--- a/src/types.ts
+++ b/src/types.ts
@@ -329,7 +329,7 @@ export interface DynamicAuctionMarketCapConfig {
   tokenDecimals?: number;
   /** Numeraire decimals (default: 18) */
   numeraireDecimals?: number;
-  /** Fee tier in basis points (e.g., 3000 for 0.3%). Default: 3000 */
+  /** Fee tier in basis points (e.g., 10000 for 1%). Default: 10000 (1%) */
   fee?: number;
   /** Minimum proceeds required for successful auction */
   minProceeds: bigint;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { CHAIN_IDS, type SupportedChainId } from './addresses';
 // Re-export SupportedChainId so consumers can import from this module
 export { type SupportedChainId } from './addresses';
 import type { Address, WalletClient } from 'viem';
+import type { FeeTier } from './constants';
 
 export type SupportedChain =
   | typeof base
@@ -329,8 +330,8 @@ export interface DynamicAuctionMarketCapConfig {
   tokenDecimals?: number;
   /** Numeraire decimals (default: 18) */
   numeraireDecimals?: number;
-  /** Fee tier in basis points (e.g., 10000 for 1%). Default: 10000 (1%) */
-  fee?: number;
+  /** Fee tier (100, 500, 3000, or 10000). Default: 10000 (1%) */
+  fee?: FeeTier;
   /** Minimum proceeds required for successful auction */
   minProceeds: bigint;
   /** Maximum proceeds cap for the auction */


### PR DESCRIPTION
the goal of "withMarketCapRange" and "withCurves" was to abstract away tick math, so it makes no sense to have user define tick spacing. this PR auto calcs tick spacing for dutch auction and clamps below 30 (max allowed)