### PR TITLE
feat: support 'max' as market cap end value for multicurve

### DIFF
--- a/src/__tests__/utils/marketCapHelpers.test.ts
+++ b/src/__tests__/utils/marketCapHelpers.test.ts
@@ -311,7 +311,7 @@ describe('marketCapHelpers', () => {
           tokenDecimals: 18,
           numeraireDecimals: 18,
         });
-      }).toThrow('Market cap values must be positive');
+      }).toThrow('Lower market cap must be positive');
     });
 
     it('should throw on zero market caps', () => {
@@ -325,7 +325,7 @@ describe('marketCapHelpers', () => {
           tokenDecimals: 18,
           numeraireDecimals: 18,
         });
-      }).toThrow('Market cap values must be positive');
+      }).toThrow('Lower market cap must be positive');
     });
 
     it('should throw when range is too narrow', () => {
@@ -401,7 +401,7 @@ describe('marketCapHelpers', () => {
           tokenDecimals: 18,
           numeraireDecimals: 18,
         });
-      }).toThrow('Market cap values must be positive');
+      }).toThrow('Start market cap must be positive');
     });
 
     it('should handle ETH numeraire scenario', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,7 +403,7 @@ export interface DynamicAuctionTickParams {
  */
 export interface MulticurveTickRangeParams {
   marketCapLower: number;
-  marketCapUpper: number;
+  marketCapUpper: number | 'max';
   tokenSupply: bigint;
   numerairePriceUSD: number;
   tickSpacing: number;
@@ -447,8 +447,8 @@ export interface MulticurveMarketCapRangeCurve {
   marketCap: {
     /** Start market cap in USD (for the first curve, this is the launch price) */
     start: number;
-    /** End market cap in USD */
-    end: number;
+    /** End market cap in USD, or 'max' for MAX_TICK rounded to tick spacing */
+    end: number | 'max';
   };
   /** Number of liquidity positions in this curve */
   numPositions: number;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -70,6 +70,7 @@ export {
   applyTickOffsets,
   validateMarketCapParameters,
   tickToMarketCap,
+  getMaxTickRounded,
 } from './marketCapHelpers';
 export type {
   MarketCapRange,


### PR DESCRIPTION
Allow 'max' string literal for marketCap.end to resolve to MAX_TICK rounded down to tick spacing. Useful for curves that should extend to the maximum possible price range.