### PR TITLE
fix: restore dual-format subpath exports

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -118,7 +118,7 @@ const txHash = await factory.create(createParams);
 ### Unified SDK (Recommended: Builder Pattern)
 ```typescript
 import { parseEther } from 'viem'
-import { DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk'
+import { DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk/evm'
 
 // Build params with a fluent, type-safe builder
 const params = new DynamicAuctionBuilder()
@@ -440,7 +440,7 @@ const txHash = await factory.create(createParams);
 
 ### After (Unified SDK)
 ```typescript
-import { DopplerSDK, DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk'
+import { DopplerSDK, DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk/evm'
 import { parseEther } from 'viem'
 
 // Setup (simpler)

--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ yarn add @whetstone-research/doppler-sdk viem
 pnpm add @whetstone-research/doppler-sdk viem
 ```
 
+Import EVM APIs from `@whetstone-research/doppler-sdk/evm`. Solana APIs live under
+`@whetstone-research/doppler-sdk/solana` and React bindings under
+`@whetstone-research/doppler-sdk/solana/react`.
+
 ## Quick Start
 
 ```typescript
-import { DopplerSDK } from '@whetstone-research/doppler-sdk';
+import { DopplerSDK } from '@whetstone-research/doppler-sdk/evm';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { base } from 'viem/chains';
 
@@ -60,7 +64,7 @@ const sdk = new DopplerSDK({
 Static auctions use Uniswap V3 pools with concentrated liquidity in a fixed price range. They're ideal for simple, predictable price discovery.
 
 ```typescript
-import { StaticAuctionBuilder } from '@whetstone-research/doppler-sdk';
+import { StaticAuctionBuilder } from '@whetstone-research/doppler-sdk/evm';
 
 const params = new StaticAuctionBuilder()
   .tokenConfig({
@@ -105,7 +109,7 @@ import {
   StaticAuctionBuilder,
   WAD,
   getAirlockOwner,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 
 // Get the protocol owner (required beneficiary with min 5%)
@@ -164,7 +168,7 @@ Dynamic auctions use Uniswap V4 hooks to implement gradual Dutch auctions where 
 import {
   DynamicAuctionBuilder,
   DAY_SECONDS,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 
 const params = new DynamicAuctionBuilder()
   .tokenConfig({
@@ -299,7 +303,7 @@ Multicurve auctions use a Uniswap V4-style initializer that seeds liquidity acro
 **Standard Multicurve with Migration:**
 
 ```typescript
-import { MulticurveBuilder } from '@whetstone-research/doppler-sdk';
+import { MulticurveBuilder } from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 import { base } from 'viem/chains';
 
@@ -346,7 +350,7 @@ console.log('Token address:', result.tokenAddress);
 **Market Cap Presets (Low / Medium / High):**
 
 ```typescript
-import { MulticurveBuilder, FEE_TIERS } from '@whetstone-research/doppler-sdk';
+import { MulticurveBuilder, FEE_TIERS } from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 import { base } from 'viem/chains';
 
@@ -387,7 +391,7 @@ Pass `presets` to pick a subset (e.g. `['medium', 'high']`) or provide `override
 **Scheduled Multicurve Launch:**
 
 ```typescript
-import { MulticurveBuilder } from '@whetstone-research/doppler-sdk';
+import { MulticurveBuilder } from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 import { base } from 'viem/chains';
 
@@ -438,7 +442,7 @@ Ensure the target chain has the scheduled multicurve initializer whitelisted. If
 **Decay Multicurve Launch (Dynamic Fee):**
 
 ```typescript
-import { MulticurveBuilder } from '@whetstone-research/doppler-sdk';
+import { MulticurveBuilder } from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 import { baseSepolia } from 'viem/chains';
 
@@ -495,7 +499,7 @@ For decay pools, `pool.fee` is always the terminal fee (`endFee`) of the schedul
 When you want fee revenue to flow to specific addresses without migrating liquidity after the auction, use lockable beneficiaries with NoOp migration:
 
 ```typescript
-import { WAD } from '@whetstone-research/doppler-sdk';
+import { WAD } from '@whetstone-research/doppler-sdk/evm';
 
 // Define beneficiaries with shares that sum to WAD (1e18 = 100%)
 // IMPORTANT: Protocol owner must be included with at least 5% shares
@@ -575,7 +579,7 @@ Prefer using the builders to construct `CreateStaticAuctionParams` and `CreateDy
 import {
   StaticAuctionBuilder,
   DynamicAuctionBuilder,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 
 // Dynamic auction via builder
@@ -807,7 +811,7 @@ await token.release();
 Alternatively, you can instantiate directly if needed:
 
 ```typescript
-import { Derc20 } from '@whetstone-research/doppler-sdk';
+import { Derc20 } from '@whetstone-research/doppler-sdk/evm';
 const tokenDirect = new Derc20(publicClient, walletClient, tokenAddress);
 ```
 
@@ -818,7 +822,7 @@ DERC20 extends OpenZeppelin's ERC20Votes. Voting power is tracked via checkpoint
 Basics:
 
 ```ts
-import { Derc20 } from '@whetstone-research/doppler-sdk';
+import { Derc20 } from '@whetstone-research/doppler-sdk/evm';
 
 const token = sdk.getDerc20(tokenAddress);
 
@@ -924,7 +928,7 @@ Notes
 The SDK also provides an ETH wrapper with ERC20-like interface:
 
 ```typescript
-import { Eth } from '@whetstone-research/doppler-sdk';
+import { Eth } from '@whetstone-research/doppler-sdk/evm';
 
 const eth = new Eth(publicClient, walletClient);
 const balance = await eth.getBalanceOf(address);
@@ -1138,7 +1142,7 @@ import {
   DopplerSDK,
   createAirlockBeneficiary,
   getAirlockOwner,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 
 const sdk = new DopplerSDK({ publicClient, chainId });
@@ -1177,7 +1181,7 @@ import {
   isSupportedChainId,
   type SupportedChainId,
   type ChainAddresses,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 
 // Validate and narrow a chain ID
 function ensureSupported(id: number): SupportedChainId {
@@ -1228,7 +1232,7 @@ import {
   StaticAuctionBuilder,
   mineTokenAddress,
   getAddresses,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 import { base } from 'viem/chains';
 
@@ -1296,7 +1300,7 @@ import {
   getAddresses,
   DopplerBytecode,
   DAY_SECONDS,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 import { parseEther, keccak256, encodePacked, encodeAbiParameters } from 'viem';
 import { base } from 'viem/chains';
 
@@ -1391,7 +1395,7 @@ import {
   MulticurveBuilder,
   mineTokenAddress,
   getAddresses,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 import { base } from 'viem/chains';
 
@@ -1521,7 +1525,7 @@ import type {
   PoolInfo,
   HookInfo,
   VestingConfig,
-} from '@whetstone-research/doppler-sdk';
+} from '@whetstone-research/doppler-sdk/evm';
 ```
 
 ## Development

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -320,7 +320,7 @@ const { tokenAddress, poolId } = await sdk.factory.createMulticurve(params)
 
 Preset helper usage:
 ```ts
-import { MulticurveBuilder, FEE_TIERS } from '@whetstone-research/doppler-sdk'
+import { MulticurveBuilder, FEE_TIERS } from '@whetstone-research/doppler-sdk/evm'
 import { parseEther } from 'viem'
 
 const presetParams = new MulticurveBuilder(chainId)
@@ -448,7 +448,7 @@ Phase 2 bid management (position manager):
 - Place/withdraw bids as Uniswap V4 liquidity positions. Use simulation to learn the required token deltas:
 
 ```ts
-import { OpeningAuctionPositionManager } from '@whetstone-research/doppler-sdk'
+import { OpeningAuctionPositionManager } from '@whetstone-research/doppler-sdk/evm'
 import { zeroHash } from 'viem'
 
 const lifecycle = await sdk.getOpeningAuctionLifecycle(initializerAddress)

--- a/docs/gists/builder-encode-createparams.md
+++ b/docs/gists/builder-encode-createparams.md
@@ -3,7 +3,7 @@
 This gist shows how to use the new builder methods to override module addresses and how to call the encode helpers to obtain `CreateParams` objects for both static (V3) and dynamic (V4) auctions. These `CreateParams` match what the old v3/v4 SDKs returned from their respective `encode*` functions.
 
 ```ts
-import { DopplerSDK, StaticAuctionBuilder, DynamicAuctionBuilder, MulticurveBuilder } from '@whetstone-research/doppler-sdk'
+import { DopplerSDK, StaticAuctionBuilder, DynamicAuctionBuilder, MulticurveBuilder } from '@whetstone-research/doppler-sdk/evm'
 import { createPublicClient, http, parseEther } from 'viem'
 import { base } from 'viem/chains'
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-This guide helps you migrate from `doppler-v3-sdk` or `doppler-v4-sdk` to the unified `@whetstone-research/doppler-sdk` using the builder pattern.
+This guide helps you migrate from `doppler-v3-sdk` or `doppler-v4-sdk` to the EVM entrypoint of `@whetstone-research/doppler-sdk` using the builder pattern.
 
 ## Overview of Changes
 
@@ -14,7 +14,7 @@ The new SDK consolidates both V3 and V4 functionality into a single package with
 
 ## Installation
 
-Remove the old packages and install the new unified SDK:
+Remove the old packages and install the new SDK package:
 
 ```bash
 # Remove old packages
@@ -50,7 +50,7 @@ const factory = new ReadWriteFactory(signer, chainId);
 
 ### After (Unified SDK)
 ```typescript
-import { DopplerSDK } from '@whetstone-research/doppler-sdk';
+import { DopplerSDK } from '@whetstone-research/doppler-sdk/evm';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { base } from 'viem/chains';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -115,7 +115,7 @@ const { poolAddress, tokenAddress } = await factory.create({
 
 #### After (Builder pattern)
 ```typescript
-import { StaticAuctionBuilder } from '@whetstone-research/doppler-sdk'
+import { StaticAuctionBuilder } from '@whetstone-research/doppler-sdk/evm'
 
 const params = new StaticAuctionBuilder()
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/token' })
@@ -181,7 +181,7 @@ const { hookAddress, tokenAddress } = await factory.create({
 
 #### After (Builder pattern)
 ```typescript
-import { DynamicAuctionBuilder, DAY_SECONDS } from '@whetstone-research/doppler-sdk'
+import { DynamicAuctionBuilder, DAY_SECONDS } from '@whetstone-research/doppler-sdk/evm'
 
 const params = new DynamicAuctionBuilder()
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/token' })
@@ -241,7 +241,7 @@ const balance = await token.balanceOf(address);
 
 ### After (Unified SDK)
 ```typescript
-import { Derc20 } from '@whetstone-research/doppler-sdk';
+import { Derc20 } from '@whetstone-research/doppler-sdk/evm';
 
 const token = new Derc20(publicClient, walletClient, tokenAddress);
 const balance = await token.getBalanceOf(address);

--- a/docs/quotes-and-swaps.md
+++ b/docs/quotes-and-swaps.md
@@ -1,6 +1,6 @@
-# Quotes and Swaps (Unified SDK)
+# Quotes and Swaps (EVM SDK)
 
-This guide shows how to get price quotes and execute swaps using the unified `@whetstone-research/doppler-sdk` across Uniswap V2, V3, and V4 (including Doppler dynamic auctions).
+This guide shows how to get price quotes and execute swaps using the EVM entrypoint of `@whetstone-research/doppler-sdk` across Uniswap V2, V3, and V4 (including Doppler dynamic auctions).
 
 - Quoting uses the SDK `Quoter` for V2/V3/V4.
 - Executing swaps uses the Uniswap Universal Router. For convenience, we show examples with the `doppler-router` helpers used in the miniapp.
@@ -8,7 +8,7 @@ This guide shows how to get price quotes and execute swaps using the unified `@w
 ## Setup
 
 ```ts
-import { DopplerSDK, Quoter, getAddresses, DYNAMIC_FEE_FLAG } from '@whetstone-research/doppler-sdk'
+import { DopplerSDK, Quoter, getAddresses, DYNAMIC_FEE_FLAG } from '@whetstone-research/doppler-sdk/evm'
 import { createPublicClient, createWalletClient, http, parseUnits } from 'viem'
 import { base } from 'viem/chains'
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -148,6 +148,9 @@ npm install doppler-router
 npm install graphql-request
 ```
 
+Use the EVM entrypoint when importing examples from the published package:
+`@whetstone-research/doppler-sdk/evm`.
+
 2. Set environment variables (use your preferred method):
 
 ```bash
@@ -166,7 +169,7 @@ npx tsx examples/static-auction-v2.ts
 ### SDK Initialization
 
 ```typescript
-import { DopplerSDK } from 'doppler-sdk';
+import { DopplerSDK } from '@whetstone-research/doppler-sdk/evm';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { baseSepolia } from 'viem/chains';
 

--- a/examples/auction-monitoring.ts
+++ b/examples/auction-monitoring.ts
@@ -9,7 +9,7 @@
 import './env';
 
 // UNCOMMENT IF RUNNING LOCALLY
-// import { DopplerSDK } from '@whetstone-research/doppler-sdk';
+// import { DopplerSDK } from '@whetstone-research/doppler-sdk/evm';
 
 import { DopplerSDK } from '../src/evm';
 import { http, formatEther, type Address, createPublicClient } from 'viem';

--- a/examples/dynamic-auction-v4.ts
+++ b/examples/dynamic-auction-v4.ts
@@ -9,7 +9,7 @@
 import './env';
 
 // UNCOMMENT IF RUNNING LOCALLY
-// import { DopplerSDK, DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk';
+// import { DopplerSDK, DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk/evm';
 
 import { DAY_SECONDS, DopplerSDK } from '../src/evm';
 

--- a/examples/price-quoter.ts
+++ b/examples/price-quoter.ts
@@ -9,7 +9,7 @@
 import './env';
 
 // UNCOMMENT IF RUNNING LOCALLY
-// import { DopplerSDK } from '@whetstone-research/doppler-sdk';
+// import { DopplerSDK } from '@whetstone-research/doppler-sdk/evm';
 import { DopplerSDK } from '../src/evm';
 
 import {

--- a/examples/static-auction-v2.ts
+++ b/examples/static-auction-v2.ts
@@ -9,7 +9,7 @@
 import './env';
 
 // UNCOMMENT IF RUNNING LOCALLY
-// import { DopplerSDK, StaticAuctionBuilder } from '@whetstone-research/doppler-sdk';
+// import { DopplerSDK, StaticAuctionBuilder } from '@whetstone-research/doppler-sdk/evm';
 
 import { DopplerSDK } from '../src/evm';
 import {

--- a/examples/token-interaction.ts
+++ b/examples/token-interaction.ts
@@ -9,7 +9,7 @@
 import './env';
 
 // UNCOMMENT IF RUNNING LOCALLY
-// import { Derc20, Eth } from '@whetstone-research/doppler-sdk';
+// import { Derc20, Eth } from '@whetstone-research/doppler-sdk/evm';
 
 import { Derc20, Eth } from '../src/evm';
 import {

--- a/package.json
+++ b/package.json
@@ -10,16 +10,19 @@
   },
   "exports": {
     "./evm": {
+      "types": "./dist/evm/index.d.ts",
       "import": "./dist/evm/index.js",
-      "types": "./dist/evm/index.d.ts"
+      "require": "./dist/evm/index.cjs"
     },
     "./solana": {
+      "types": "./dist/solana/index.d.ts",
       "import": "./dist/solana/index.js",
-      "types": "./dist/solana/index.d.ts"
+      "require": "./dist/solana/index.cjs"
     },
     "./solana/react": {
+      "types": "./dist/solana/react/index.d.ts",
       "import": "./dist/solana/react/index.js",
-      "types": "./dist/solana/react/index.d.ts"
+      "require": "./dist/solana/react/index.cjs"
     }
   },
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     'solana/index': 'src/solana/index.ts',
     'solana/react/index': 'src/solana/react/index.ts',
   },
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   splitting: true,
   clean: true,


### PR DESCRIPTION
Publish ESM and CJS builds for the evm, solana, and solana/react entrypoints so CommonJS and plain Node consumers resolve correctly. Update docs and examples to use the official subpath imports.