### PR TITLE
[codex] add derc20 v2 cliff vesting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ console.log('Pool address:', result.poolAddress);
 console.log('Token address:', result.tokenAddress);
 ```
 
+If you set `cliffDuration > 0`, the SDK now automatically uses the DERC20 V2 factory and exposes schedule-aware token reads via `sdk.getDerc20V2(tokenAddress)`.
+
 > **Tick spacing reminder:** When you provide ticks manually via `poolByTicks`, make sure both `startTick` and `endTick` are exact multiples of the fee tier's tick spacing (100→1, 500→10, 3000→60, 10000→200). The SDK now validates this locally and will fail fast if the ticks are misaligned.
 
 ### Static Auction with Lockable Beneficiaries (V3)

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -52,6 +52,8 @@ Methods (chainable):
     - @deprecated: Use `withMarketCapRange()` instead for more intuitive configuration
 - withVesting({ duration?, cliffDuration?, recipients?, amounts? } | undefined)
   - Omit to disable vesting. Default duration if provided but undefined is `DEFAULT_V3_VESTING_DURATION`.
+  - `cliffDuration > 0` automatically routes standard tokens through the DERC20 V2 factory (`CloneDERC20VotesV2Factory`).
+  - Cliff vesting requires `duration >= 1 day` and `cliffDuration <= duration`.
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
 - withGovernance(GovernanceConfig | { useDefaults: true } | { noOp: true } | undefined)
@@ -76,6 +78,7 @@ Validation highlights:
 - `initialSupply > 0`, `numTokensToSell > 0`, and `numTokensToSell <= initialSupply`
 - If vesting set, there must be tokens reserved (`initialSupply - numTokensToSell > 0`)
 - For V4 migration config (if chosen), beneficiary percentages must sum to 10000
+- Use `sdk.getDerc20V2(tokenAddress)` for schedule-aware reads and release flows on cliffed / multi-schedule tokens
 
 Examples:
 ```ts

--- a/src/evm/DopplerSDK.ts
+++ b/src/evm/DopplerSDK.ts
@@ -21,7 +21,7 @@ import {
   OpeningAuctionPositionManager,
 } from './entities/auction';
 import { Quoter } from './entities/quoter';
-import { Derc20 } from './entities/token';
+import { Derc20, Derc20V2 } from './entities/token';
 import {
   StaticAuctionBuilder,
   DynamicAuctionBuilder,
@@ -220,6 +220,14 @@ export class DopplerSDK<C extends SupportedChainId = SupportedChainId> {
    */
   getDerc20(tokenAddress: Address): Derc20 {
     return new Derc20(this.publicClient, this.walletClient, tokenAddress);
+  }
+
+  /**
+   * Get a DERC20 V2 token instance for interacting with cliffed / multi-schedule vesting tokens
+   * @param tokenAddress The address of the DERC20 V2 token
+   */
+  getDerc20V2(tokenAddress: Address): Derc20V2 {
+    return new Derc20V2(this.publicClient, this.walletClient, tokenAddress);
   }
 
   /**

--- a/src/evm/abis/index.ts
+++ b/src/evm/abis/index.ts
@@ -732,6 +732,90 @@ export const derc20Abi = [
   },
 ] as const;
 
+export const derc20V2Abi = [
+  ...derc20Abi,
+  {
+    type: 'function',
+    name: 'computeAvailableVestedAmount',
+    inputs: [
+      { name: 'beneficiary', type: 'address', internalType: 'address' },
+      { name: 'scheduleId', type: 'uint256', internalType: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getScheduleIdsOf',
+    inputs: [{ name: 'beneficiary', type: 'address', internalType: 'address' }],
+    outputs: [{ name: '', type: 'uint256[]', internalType: 'uint256[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'release',
+    inputs: [{ name: 'scheduleId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'releaseFor',
+    inputs: [
+      { name: 'beneficiary', type: 'address', internalType: 'address' },
+      { name: 'scheduleId', type: 'uint256', internalType: 'uint256' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'releaseFor',
+    inputs: [
+      { name: 'beneficiary', type: 'address', internalType: 'address' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'totalAllocatedOf',
+    inputs: [{ name: 'beneficiary', type: 'address', internalType: 'address' }],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'vestingOf',
+    inputs: [
+      { name: 'beneficiary', type: 'address', internalType: 'address' },
+      { name: 'scheduleId', type: 'uint256', internalType: 'uint256' },
+    ],
+    outputs: [
+      { name: 'totalAmount', type: 'uint256', internalType: 'uint256' },
+      { name: 'releasedAmount', type: 'uint256', internalType: 'uint256' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'vestingScheduleCount',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'vestingSchedules',
+    inputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      { name: 'cliff', type: 'uint64', internalType: 'uint64' },
+      { name: 'duration', type: 'uint64', internalType: 'uint64' },
+    ],
+    stateMutability: 'view',
+  },
+] as const;
+
 export const uniswapV4InitializerAbi = [
   {
     type: 'function',

--- a/src/evm/abis/index.ts
+++ b/src/evm/abis/index.ts
@@ -771,9 +771,7 @@ export const derc20V2Abi = [
   {
     type: 'function',
     name: 'releaseFor',
-    inputs: [
-      { name: 'beneficiary', type: 'address', internalType: 'address' },
-    ],
+    inputs: [{ name: 'beneficiary', type: 'address', internalType: 'address' }],
     outputs: [],
     stateMutability: 'nonpayable',
   },

--- a/src/evm/addresses.ts
+++ b/src/evm/addresses.ts
@@ -24,6 +24,8 @@ export interface ChainAddresses {
   // Core contracts
   airlock: Address;
   tokenFactory: Address;
+  derc20V2Factory?: Address;
+  derc20V2Implementation?: Address;
 
   // Static auction contracts (V3)
   v3Initializer: Address;
@@ -110,6 +112,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .Airlock as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .CloneERC20Factory as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.MAINNET,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.MAINNET,
+      'CloneDERC20VotesV2',
+    ),
     v3Initializer: ZERO_ADDRESS,
     v3Quoter: ZERO_ADDRESS,
     v4Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
@@ -156,6 +166,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .Airlock as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.ETH_SEPOLIA]
       .CloneERC20Factory as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.ETH_SEPOLIA,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.ETH_SEPOLIA,
+      'CloneDERC20VotesV2',
+    ),
     v3Initializer: ZERO_ADDRESS,
     v3Quoter: ZERO_ADDRESS,
     v4Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.ETH_SEPOLIA]
@@ -200,6 +218,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     airlock: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].Airlock as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .TokenFactory80 as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.BASE,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.BASE,
+      'CloneDERC20VotesV2',
+    ),
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .UniswapV3Initializer as Address,
     v3Quoter: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a' as Address,
@@ -256,6 +282,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .Airlock as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
       .TokenFactory80 as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.BASE_SEPOLIA,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.BASE_SEPOLIA,
+      'CloneDERC20VotesV2',
+    ),
     doppler404Factory: '0xdd8cea2890f1b3498436f19ec8da8fecc2cb7af7' as Address,
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
       .UniswapV3Initializer as Address,
@@ -322,6 +356,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     airlock: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK].Airlock as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK]
       .TokenFactory as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.INK,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.INK,
+      'CloneDERC20VotesV2',
+    ),
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.INK]
       .UniswapV3Initializer as Address,
     v3Quoter: '0x96b572D2d880cf2Fa2563651BD23ADE6f5516652' as Address,
@@ -349,6 +391,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .Airlock as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN]
       .TokenFactory as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.UNICHAIN,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.UNICHAIN,
+      'CloneDERC20VotesV2',
+    ),
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN]
       .UniswapV3Initializer as Address,
     v3Quoter: '0x385A5cf5F83e99f7BB2852b6A19C3538b9FA7658' as Address,
@@ -379,6 +429,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     airlock: '0x651ab94B4777e2e4cdf96082d90C65bd947b73A4' as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN_SEPOLIA]
       .TokenFactory as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.UNICHAIN_SEPOLIA,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.UNICHAIN_SEPOLIA,
+      'CloneDERC20VotesV2',
+    ),
     v3Initializer: '0x7Fb9a622186B4660A5988C223ebb9d3690dD5007' as Address,
     v3Quoter: '0x6Dd37329A1A225a6Fca658265D460423DCafBF89' as Address,
     v4Initializer: '0x992375478626E67F4e639d3298EbCAaE51C3dF0b' as Address,
@@ -408,6 +466,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .Airlock as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_TESTNET]
       .TokenFactory80 as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.MONAD_TESTNET,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.MONAD_TESTNET,
+      'CloneDERC20VotesV2',
+    ),
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_TESTNET]
       .UniswapV3Initializer as Address,
     v3Quoter: ZERO_ADDRESS,
@@ -443,6 +509,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .Airlock as Address,
     tokenFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
       .TokenFactory80 as Address,
+    derc20V2Factory: getGeneratedAddress(
+      CHAIN_IDS.MONAD_MAINNET,
+      'CloneDERC20VotesV2Factory',
+    ),
+    derc20V2Implementation: getGeneratedAddress(
+      CHAIN_IDS.MONAD_MAINNET,
+      'CloneDERC20VotesV2',
+    ),
     v3Initializer: ZERO_ADDRESS,
     v3Quoter: '0x66266174564170519409d8853898f065c719536b' as Address,
     v4Initializer: ZERO_ADDRESS,

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -405,7 +405,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     tokenFactory: Address,
   ): Hash {
     if (tokenFactoryData.kind === 'v2') {
-      return this.computeSoladyCloneInitCodeHash(tokenFactoryData.implementation);
+      return this.computeSoladyCloneInitCodeHash(
+        tokenFactoryData.implementation,
+      );
     }
 
     const initData = encodeAbiParameters(
@@ -442,7 +444,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       encodePacked(
         ['bytes', 'bytes'],
         [
-          isTokenFactory80 ? (DERC2080Bytecode as Hex) : (DERC20Bytecode as Hex),
+          isTokenFactory80
+            ? (DERC2080Bytecode as Hex)
+            : (DERC20Bytecode as Hex),
           initData,
         ],
       ),
@@ -602,8 +606,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         tokenFactory: resolvedTokenFactory,
         addresses,
       });
-      tokenFactoryData =
-        this.encodeStandardTokenFactoryData(standardTokenFactoryData);
+      tokenFactoryData = this.encodeStandardTokenFactoryData(
+        standardTokenFactoryData,
+      );
     }
 
     // 4. Encode governance factory data
@@ -3661,8 +3666,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         tokenFactory: resolvedTokenFactory,
         addresses,
       });
-      tokenFactoryData =
-        this.encodeStandardTokenFactoryData(standardTokenFactoryData);
+      tokenFactoryData = this.encodeStandardTokenFactoryData(
+        standardTokenFactoryData,
+      );
     }
 
     // Governance factory data
@@ -4078,9 +4084,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       throw new Error('Vesting duration cannot be negative');
     }
     if (cliffDuration > duration) {
-      throw new Error(
-        'Vesting cliff duration cannot exceed vesting duration',
-      );
+      throw new Error('Vesting cliff duration cannot exceed vesting duration');
     }
     if (
       cliffDuration > 0 &&

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -24,6 +24,8 @@ import type {
   TokenConfig,
   Doppler404TokenConfig,
   StandardTokenConfig,
+  SaleConfig,
+  VestingConfig,
   SupportedChainId,
   CreateParams,
   MulticurveBundleExactInResult,
@@ -133,6 +135,47 @@ type NormalizedRehypeHookConfig = {
   farTick?: number;
 };
 
+type StandardTokenFactoryMode = 'legacy' | 'v2';
+
+type LegacyStandardTokenFactoryData = {
+  kind: 'legacy';
+  name: string;
+  symbol: string;
+  initialSupply: bigint;
+  airlock: Address;
+  yearlyMintRate: bigint;
+  vestingDuration: bigint;
+  recipients: Address[];
+  amounts: bigint[];
+  tokenURI: string;
+};
+
+type V2VestingSchedule = {
+  cliff: bigint;
+  duration: bigint;
+};
+
+type V2StandardTokenFactoryData = {
+  kind: 'v2';
+  name: string;
+  symbol: string;
+  initialSupply: bigint;
+  airlock: Address;
+  yearlyMintRate: bigint;
+  schedules: V2VestingSchedule[];
+  beneficiaries: Address[];
+  scheduleIds: bigint[];
+  amounts: bigint[];
+  tokenURI: string;
+  implementation: Address;
+};
+
+type StandardTokenFactoryData =
+  | LegacyStandardTokenFactoryData
+  | V2StandardTokenFactoryData;
+
+const DERC20_V2_MIN_VESTING_DURATION = 24 * 60 * 60;
+
 export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
   private publicClient: SupportedPublicClient;
   private walletClient?: WalletClient;
@@ -149,6 +192,261 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     this.publicClient = publicClient;
     this.walletClient = walletClient;
     this.chainId = chainId;
+  }
+
+  private usesDerc20V2Vesting(vesting?: VestingConfig): boolean {
+    return (vesting?.cliffDuration ?? 0) > 0;
+  }
+
+  private resolveVestingAllocations(args: {
+    sale: SaleConfig;
+    vesting?: VestingConfig;
+    userAddress: Address;
+  }): { recipients: Address[]; amounts: bigint[] } {
+    if (!args.vesting) {
+      return { recipients: [], amounts: [] };
+    }
+
+    if (args.vesting.recipients && args.vesting.amounts) {
+      return {
+        recipients: args.vesting.recipients,
+        amounts: args.vesting.amounts,
+      };
+    }
+
+    return {
+      recipients: [args.userAddress],
+      amounts: [args.sale.initialSupply - args.sale.numTokensToSell],
+    };
+  }
+
+  private resolveStandardTokenFactoryMode(args: {
+    vesting?: VestingConfig;
+    tokenFactory: Address;
+    addresses: ReturnType<typeof getAddresses>;
+  }): StandardTokenFactoryMode {
+    if (this.usesDerc20V2Vesting(args.vesting)) {
+      return 'v2';
+    }
+
+    const v2Factory = args.addresses.derc20V2Factory;
+    if (
+      v2Factory &&
+      args.tokenFactory.toLowerCase() === v2Factory.toLowerCase()
+    ) {
+      return 'v2';
+    }
+
+    return 'legacy';
+  }
+
+  private assertStandardTokenFactoryCompatibility(args: {
+    token: TokenConfig;
+    vesting?: VestingConfig;
+    tokenFactory: Address;
+    addresses: ReturnType<typeof getAddresses>;
+  }): void {
+    if (
+      this.isDoppler404Token(args.token) ||
+      !this.usesDerc20V2Vesting(args.vesting)
+    ) {
+      return;
+    }
+
+    const v2Factory = args.addresses.derc20V2Factory;
+    if (!v2Factory || v2Factory === ZERO_ADDRESS) {
+      throw new Error(
+        'Cliff vesting requires the DERC20 V2 factory, but no V2 factory is configured for this chain.',
+      );
+    }
+
+    if (args.tokenFactory.toLowerCase() !== v2Factory.toLowerCase()) {
+      throw new Error(
+        'Cliff vesting requires the DERC20 V2 factory. Remove the tokenFactory override or point it at the chain DERC20 V2 factory.',
+      );
+    }
+  }
+
+  private buildStandardTokenFactoryData(args: {
+    token: StandardTokenConfig;
+    sale: SaleConfig;
+    vesting?: VestingConfig;
+    userAddress: Address;
+    airlock: Address;
+    tokenFactory: Address;
+    addresses: ReturnType<typeof getAddresses>;
+  }): StandardTokenFactoryData {
+    const { recipients, amounts } = this.resolveVestingAllocations(args);
+    const yearlyMintRate =
+      args.token.yearlyMintRate ?? DEFAULT_V4_YEARLY_MINT_RATE;
+    const mode = this.resolveStandardTokenFactoryMode({
+      vesting: args.vesting,
+      tokenFactory: args.tokenFactory,
+      addresses: args.addresses,
+    });
+
+    if (mode === 'v2') {
+      const implementation = args.addresses.derc20V2Implementation;
+      if (!implementation || implementation === ZERO_ADDRESS) {
+        throw new Error(
+          'DERC20 V2 implementation address not configured for this chain.',
+        );
+      }
+
+      const schedules =
+        args.vesting === undefined
+          ? []
+          : [
+              {
+                cliff: BigInt(args.vesting.cliffDuration ?? 0),
+                duration: BigInt(args.vesting.duration ?? 0),
+              },
+            ];
+
+      return {
+        kind: 'v2',
+        name: args.token.name,
+        symbol: args.token.symbol,
+        initialSupply: args.sale.initialSupply,
+        airlock: args.airlock,
+        yearlyMintRate,
+        schedules,
+        beneficiaries: recipients,
+        scheduleIds: recipients.map(() => 0n),
+        amounts,
+        tokenURI: args.token.tokenURI,
+        implementation,
+      };
+    }
+
+    return {
+      kind: 'legacy',
+      name: args.token.name,
+      symbol: args.token.symbol,
+      initialSupply: args.sale.initialSupply,
+      airlock: args.airlock,
+      yearlyMintRate,
+      vestingDuration: BigInt(args.vesting?.duration ?? 0),
+      recipients,
+      amounts,
+      tokenURI: args.token.tokenURI,
+    };
+  }
+
+  private encodeStandardTokenFactoryData(
+    tokenFactoryData: StandardTokenFactoryData,
+  ): Hex {
+    if (tokenFactoryData.kind === 'v2') {
+      return encodeAbiParameters(
+        [
+          { type: 'string' },
+          { type: 'string' },
+          { type: 'uint256' },
+          {
+            type: 'tuple[]',
+            components: [
+              { type: 'uint64', name: 'cliff' },
+              { type: 'uint64', name: 'duration' },
+            ],
+          },
+          { type: 'address[]' },
+          { type: 'uint256[]' },
+          { type: 'uint256[]' },
+          { type: 'string' },
+        ],
+        [
+          tokenFactoryData.name,
+          tokenFactoryData.symbol,
+          tokenFactoryData.yearlyMintRate,
+          tokenFactoryData.schedules.map((schedule) => ({
+            cliff: schedule.cliff,
+            duration: schedule.duration,
+          })),
+          tokenFactoryData.beneficiaries,
+          tokenFactoryData.scheduleIds,
+          tokenFactoryData.amounts,
+          tokenFactoryData.tokenURI,
+        ],
+      );
+    }
+
+    return encodeAbiParameters(
+      [
+        { type: 'string' },
+        { type: 'string' },
+        { type: 'uint256' },
+        { type: 'uint256' },
+        { type: 'address[]' },
+        { type: 'uint256[]' },
+        { type: 'string' },
+      ],
+      [
+        tokenFactoryData.name,
+        tokenFactoryData.symbol,
+        tokenFactoryData.yearlyMintRate,
+        tokenFactoryData.vestingDuration,
+        tokenFactoryData.recipients,
+        tokenFactoryData.amounts,
+        tokenFactoryData.tokenURI,
+      ],
+    );
+  }
+
+  private computeSoladyCloneInitCodeHash(implementation: Address): Hash {
+    return keccak256(
+      `0x602c3d8160093d39f33d3d3d3d363d3d37363d73${implementation.slice(
+        2,
+      )}5af43d3d93803e602a57fd5bf3`,
+    );
+  }
+
+  private computeStandardTokenInitHash(
+    tokenFactoryData: StandardTokenFactoryData,
+    tokenFactory: Address,
+  ): Hash {
+    if (tokenFactoryData.kind === 'v2') {
+      return this.computeSoladyCloneInitCodeHash(tokenFactoryData.implementation);
+    }
+
+    const initData = encodeAbiParameters(
+      [
+        { type: 'string' },
+        { type: 'string' },
+        { type: 'uint256' },
+        { type: 'address' },
+        { type: 'address' },
+        { type: 'uint256' },
+        { type: 'uint256' },
+        { type: 'address[]' },
+        { type: 'uint256[]' },
+        { type: 'string' },
+      ],
+      [
+        tokenFactoryData.name,
+        tokenFactoryData.symbol,
+        tokenFactoryData.initialSupply,
+        tokenFactoryData.airlock,
+        tokenFactoryData.airlock,
+        tokenFactoryData.yearlyMintRate,
+        tokenFactoryData.vestingDuration,
+        tokenFactoryData.recipients,
+        tokenFactoryData.amounts,
+        tokenFactoryData.tokenURI,
+      ],
+    );
+
+    const isTokenFactory80 =
+      tokenFactory.toLowerCase() === TOKEN_FACTORY_80_ADDRESS;
+
+    return keccak256(
+      encodePacked(
+        ['bytes', 'bytes'],
+        [
+          isTokenFactory80 ? (DERC2080Bytecode as Hex) : (DERC20Bytecode as Hex),
+          initData,
+        ],
+      ),
+    );
   }
 
   /**
@@ -259,11 +557,30 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       overrides: params.modules,
     });
 
+    const resolvedTokenFactory: Address | undefined =
+      params.modules?.tokenFactory ??
+      (this.isDoppler404Token(params.token)
+        ? (addresses.doppler404Factory as Address | undefined)
+        : this.usesDerc20V2Vesting(params.vesting)
+          ? addresses.derc20V2Factory
+          : addresses.tokenFactory);
+
+    if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
+      throw new Error(
+        'Token factory address not configured. Provide an explicit address via builder.withTokenFactory(...) or ensure chain config includes a valid factory.',
+      );
+    }
+    this.assertStandardTokenFactoryCompatibility({
+      token: params.token,
+      vesting: params.vesting,
+      tokenFactory: resolvedTokenFactory,
+      addresses,
+    });
+
     // 3. Encode token parameters (standard vs Doppler404)
     let tokenFactoryData: Hex;
     if (this.isDoppler404Token(params.token)) {
       const token404 = params.token;
-      // Doppler404 expects: name, symbol, baseURI, unit
       const baseURI = token404.baseURI;
       const unit = token404.unit !== undefined ? BigInt(token404.unit) : 1000n;
       tokenFactoryData = encodeAbiParameters(
@@ -276,49 +593,17 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         [params.token.name, params.token.symbol, baseURI, unit],
       );
     } else {
-      const tokenStd = params.token as StandardTokenConfig;
-      const vestingDuration = params.vesting?.duration ?? BigInt(0);
-      const yearlyMintRate =
-        tokenStd.yearlyMintRate ?? DEFAULT_V4_YEARLY_MINT_RATE;
-
-      // Handle vesting recipients and amounts
-      let vestingRecipients: Address[] = [];
-      let vestingAmounts: bigint[] = [];
-
-      if (params.vesting) {
-        if (params.vesting.recipients && params.vesting.amounts) {
-          // Use provided recipients and amounts
-          vestingRecipients = params.vesting.recipients;
-          vestingAmounts = params.vesting.amounts;
-        } else {
-          // Default: vest all non-sold tokens to userAddress
-          vestingRecipients = [params.userAddress];
-          vestingAmounts = [
-            params.sale.initialSupply - params.sale.numTokensToSell,
-          ];
-        }
-      }
-
-      tokenFactoryData = encodeAbiParameters(
-        [
-          { type: 'string' },
-          { type: 'string' },
-          { type: 'uint256' },
-          { type: 'uint256' },
-          { type: 'address[]' },
-          { type: 'uint256[]' },
-          { type: 'string' },
-        ],
-        [
-          tokenStd.name,
-          tokenStd.symbol,
-          yearlyMintRate,
-          BigInt(vestingDuration),
-          vestingRecipients,
-          vestingAmounts,
-          tokenStd.tokenURI,
-        ],
-      );
+      const standardTokenFactoryData = this.buildStandardTokenFactoryData({
+        token: params.token as StandardTokenConfig,
+        sale: params.sale,
+        vesting: params.vesting,
+        userAddress: params.userAddress,
+        airlock: params.modules?.airlock ?? addresses.airlock,
+        tokenFactory: resolvedTokenFactory,
+        addresses,
+      });
+      tokenFactoryData =
+        this.encodeStandardTokenFactoryData(standardTokenFactoryData);
     }
 
     // 4. Encode governance factory data
@@ -391,19 +676,6 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     })();
 
     // 5. Generate a unique salt
-    // Resolve token factory with override priority
-    const resolvedTokenFactory: Address | undefined =
-      params.modules?.tokenFactory ??
-      (this.isDoppler404Token(params.token)
-        ? (addresses.doppler404Factory as Address | undefined)
-        : addresses.tokenFactory);
-
-    if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
-      throw new Error(
-        'Token factory address not configured. Provide an explicit address via builder.withTokenFactory(...) or ensure chain config includes a valid factory.',
-      );
-    }
-
     // Build the base CreateParams for the V3-style ABI; salt will be mined below
     const baseCreateParams = {
       initialSupply: params.sale.initialSupply,
@@ -817,7 +1089,26 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       }
     }
 
-    const vestingDuration = params.vesting?.duration ?? BigInt(0);
+    const resolvedTokenFactoryDyn: Address | undefined =
+      params.modules?.tokenFactory ??
+      (this.isDoppler404Token(params.token)
+        ? (addresses.doppler404Factory as Address | undefined)
+        : this.usesDerc20V2Vesting(params.vesting)
+          ? addresses.derc20V2Factory
+          : addresses.tokenFactory);
+
+    if (!resolvedTokenFactoryDyn || resolvedTokenFactoryDyn === ZERO_ADDRESS) {
+      throw new Error(
+        'Token factory address not configured. Provide an explicit address via builder.withTokenFactory(...) or ensure chain config includes a valid factory.',
+      );
+    }
+    this.assertStandardTokenFactoryCompatibility({
+      token: params.token,
+      vesting: params.vesting,
+      tokenFactory: resolvedTokenFactoryDyn,
+      addresses,
+    });
+
     const tokenFactoryData = this.isDoppler404Token(params.token)
       ? (() => {
           const t = params.token as Doppler404TokenConfig;
@@ -828,53 +1119,17 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
             unit: t.unit !== undefined ? BigInt(t.unit) : 1000n,
           };
         })()
-      : (() => {
-          const t = params.token as StandardTokenConfig;
-
-          // Handle vesting recipients and amounts
-          let vestingRecipients: Address[] = [];
-          let vestingAmounts: bigint[] = [];
-
-          if (params.vesting) {
-            if (params.vesting.recipients && params.vesting.amounts) {
-              // Use provided recipients and amounts
-              vestingRecipients = params.vesting.recipients;
-              vestingAmounts = params.vesting.amounts;
-            } else {
-              // Default: vest all non-sold tokens to userAddress
-              vestingRecipients = [params.userAddress];
-              vestingAmounts = [
-                params.sale.initialSupply - params.sale.numTokensToSell,
-              ];
-            }
-          }
-
-          return {
-            name: t.name,
-            symbol: t.symbol,
-            initialSupply: params.sale.initialSupply,
-            airlock: addresses.airlock,
-            yearlyMintRate: t.yearlyMintRate ?? DEFAULT_V4_YEARLY_MINT_RATE,
-            vestingDuration: BigInt(vestingDuration),
-            recipients: vestingRecipients,
-            amounts: vestingAmounts,
-            tokenURI: t.tokenURI,
-          };
-        })();
+      : this.buildStandardTokenFactoryData({
+          token: params.token as StandardTokenConfig,
+          sale: params.sale,
+          vesting: params.vesting,
+          userAddress: params.userAddress,
+          airlock: params.modules?.airlock ?? addresses.airlock,
+          tokenFactory: resolvedTokenFactoryDyn,
+          addresses,
+        });
 
     // 5. Mine hook address with appropriate flags
-    // Resolve token factory with override priority (works for both standard and doppler404 variants)
-    const resolvedTokenFactoryDyn: Address | undefined =
-      params.modules?.tokenFactory ??
-      (this.isDoppler404Token(params.token)
-        ? (addresses.doppler404Factory as Address | undefined)
-        : addresses.tokenFactory);
-
-    if (!resolvedTokenFactoryDyn || resolvedTokenFactoryDyn === ZERO_ADDRESS) {
-      throw new Error(
-        'Token factory address not configured. Provide an explicit address via builder.withTokenFactory(...) or ensure chain config includes a valid factory.',
-      );
-    }
 
     const [
       salt,
@@ -1325,7 +1580,26 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       }
     }
 
-    const vestingDuration = params.vesting?.duration ?? BigInt(0);
+    const resolvedTokenFactory: Address | undefined =
+      params.modules?.tokenFactory ??
+      (this.isDoppler404Token(params.token)
+        ? (addresses.doppler404Factory as Address | undefined)
+        : this.usesDerc20V2Vesting(params.vesting)
+          ? addresses.derc20V2Factory
+          : addresses.tokenFactory);
+
+    if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
+      throw new Error(
+        'Token factory address not configured. Provide an explicit address via builder.withTokenFactory(...) or ensure chain config includes a valid factory.',
+      );
+    }
+    this.assertStandardTokenFactoryCompatibility({
+      token: params.token,
+      vesting: params.vesting,
+      tokenFactory: resolvedTokenFactory,
+      addresses,
+    });
+
     const tokenFactoryData = this.isDoppler404Token(params.token)
       ? (() => {
           const t = params.token as Doppler404TokenConfig;
@@ -1336,47 +1610,15 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
             unit: t.unit !== undefined ? BigInt(t.unit) : 1000n,
           };
         })()
-      : (() => {
-          const t = params.token as StandardTokenConfig;
-          let vestingRecipients: Address[] = [];
-          let vestingAmounts: bigint[] = [];
-
-          if (params.vesting) {
-            if (params.vesting.recipients && params.vesting.amounts) {
-              vestingRecipients = params.vesting.recipients;
-              vestingAmounts = params.vesting.amounts;
-            } else {
-              vestingRecipients = [params.userAddress];
-              vestingAmounts = [
-                params.sale.initialSupply - params.sale.numTokensToSell,
-              ];
-            }
-          }
-
-          return {
-            name: t.name,
-            symbol: t.symbol,
-            initialSupply: params.sale.initialSupply,
-            airlock: params.modules?.airlock ?? addresses.airlock,
-            yearlyMintRate: t.yearlyMintRate ?? DEFAULT_V4_YEARLY_MINT_RATE,
-            vestingDuration: BigInt(vestingDuration),
-            recipients: vestingRecipients,
-            amounts: vestingAmounts,
-            tokenURI: t.tokenURI,
-          };
-        })();
-
-    const resolvedTokenFactory: Address | undefined =
-      params.modules?.tokenFactory ??
-      (this.isDoppler404Token(params.token)
-        ? (addresses.doppler404Factory as Address | undefined)
-        : addresses.tokenFactory);
-
-    if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
-      throw new Error(
-        'Token factory address not configured. Provide an explicit address via builder.withTokenFactory(...) or ensure chain config includes a valid factory.',
-      );
-    }
+      : this.buildStandardTokenFactoryData({
+          token: params.token as StandardTokenConfig,
+          sale: params.sale,
+          vesting: params.vesting,
+          userAddress: params.userAddress,
+          airlock: params.modules?.airlock ?? addresses.airlock,
+          tokenFactory: resolvedTokenFactory,
+          addresses,
+        });
 
     const auctionTokens =
       (params.sale.numTokensToSell *
@@ -2413,17 +2655,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           baseURI: string;
           unit?: bigint;
         }
-      | {
-          name: string;
-          symbol: string;
-          initialSupply: bigint;
-          airlock: Address;
-          yearlyMintRate: bigint;
-          vestingDuration: bigint;
-          recipients: Address[];
-          amounts: bigint[];
-          tokenURI: string;
-        };
+      | StandardTokenFactoryData;
     airlock: Address;
     initialSupply: bigint;
     tokenVariant: 'standard' | 'doppler404';
@@ -2491,39 +2723,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
               [t.name, t.symbol, t.baseURI, t.unit ?? 1000n],
             );
           })()
-        : (() => {
-            const t = params.tokenFactoryData as {
-              name: string;
-              symbol: string;
-              initialSupply: bigint;
-              airlock: Address;
-              yearlyMintRate: bigint;
-              vestingDuration: bigint;
-              recipients: Address[];
-              amounts: bigint[];
-              tokenURI: string;
-            };
-            return encodeAbiParameters(
-              [
-                { type: 'string' },
-                { type: 'string' },
-                { type: 'uint256' },
-                { type: 'uint256' },
-                { type: 'address[]' },
-                { type: 'uint256[]' },
-                { type: 'string' },
-              ],
-              [
-                t.name,
-                t.symbol,
-                t.yearlyMintRate,
-                t.vestingDuration,
-                t.recipients,
-                t.amounts,
-                t.tokenURI,
-              ],
-            );
-          })();
+        : this.encodeStandardTokenFactoryData(
+            params.tokenFactoryData as StandardTokenFactoryData,
+          );
 
     let tokenInitHash: Hash;
     if (params.tokenVariant === 'doppler404') {
@@ -2557,53 +2759,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         ),
       );
     } else {
-      const t = params.tokenFactoryData as {
-        name: string;
-        symbol: string;
-        yearlyMintRate: bigint;
-        vestingDuration: bigint;
-        recipients: Address[];
-        amounts: bigint[];
-        tokenURI: string;
-      };
-      const initData = encodeAbiParameters(
-        [
-          { type: 'string' },
-          { type: 'string' },
-          { type: 'uint256' },
-          { type: 'address' },
-          { type: 'address' },
-          { type: 'uint256' },
-          { type: 'uint256' },
-          { type: 'address[]' },
-          { type: 'uint256[]' },
-          { type: 'string' },
-        ],
-        [
-          t.name,
-          t.symbol,
-          params.initialSupply,
-          params.airlock,
-          params.airlock,
-          t.yearlyMintRate,
-          t.vestingDuration,
-          t.recipients,
-          t.amounts,
-          t.tokenURI,
-        ],
-      );
-      const isTokenFactory80 =
-        params.tokenFactory.toLowerCase() === TOKEN_FACTORY_80_ADDRESS;
-      tokenInitHash = keccak256(
-        encodePacked(
-          ['bytes', 'bytes'],
-          [
-            isTokenFactory80
-              ? (DERC2080Bytecode as Hex)
-              : (DERC20Bytecode as Hex),
-            initData,
-          ],
-        ),
+      tokenInitHash = this.computeStandardTokenInitHash(
+        params.tokenFactoryData as StandardTokenFactoryData,
+        params.tokenFactory,
       );
     }
 
@@ -3460,6 +3618,25 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       );
     }
 
+    const resolvedTokenFactory: Address | undefined =
+      params.modules?.tokenFactory ??
+      (this.isDoppler404Token(params.token)
+        ? (addresses.doppler404Factory as Address | undefined)
+        : this.usesDerc20V2Vesting(params.vesting)
+          ? addresses.derc20V2Factory
+          : addresses.tokenFactory);
+    if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
+      throw new Error(
+        'Token factory address not configured. Provide an explicit address or ensure chain config includes a valid factory.',
+      );
+    }
+    this.assertStandardTokenFactoryCompatibility({
+      token: params.token,
+      vesting: params.vesting,
+      tokenFactory: resolvedTokenFactory,
+      addresses,
+    });
+
     // Token factory data (standard vs 404)
     let tokenFactoryData: Hex;
     if (this.isDoppler404Token(params.token)) {
@@ -3475,49 +3652,17 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         [token404.name, token404.symbol, token404.baseURI, unit],
       );
     } else {
-      const tokenStd = params.token as StandardTokenConfig;
-      const vestingDuration = params.vesting?.duration ?? BigInt(0);
-      const yearlyMintRate =
-        tokenStd.yearlyMintRate ?? DEFAULT_V4_YEARLY_MINT_RATE;
-
-      // Handle vesting recipients and amounts
-      let vestingRecipients: Address[] = [];
-      let vestingAmounts: bigint[] = [];
-
-      if (params.vesting) {
-        if (params.vesting.recipients && params.vesting.amounts) {
-          // Use provided recipients and amounts
-          vestingRecipients = params.vesting.recipients;
-          vestingAmounts = params.vesting.amounts;
-        } else {
-          // Default: vest all non-sold tokens to userAddress
-          vestingRecipients = [params.userAddress];
-          vestingAmounts = [
-            params.sale.initialSupply - params.sale.numTokensToSell,
-          ];
-        }
-      }
-
-      tokenFactoryData = encodeAbiParameters(
-        [
-          { type: 'string' },
-          { type: 'string' },
-          { type: 'uint256' },
-          { type: 'uint256' },
-          { type: 'address[]' },
-          { type: 'uint256[]' },
-          { type: 'string' },
-        ],
-        [
-          tokenStd.name,
-          tokenStd.symbol,
-          yearlyMintRate,
-          BigInt(vestingDuration),
-          vestingRecipients,
-          vestingAmounts,
-          tokenStd.tokenURI,
-        ],
-      );
+      const standardTokenFactoryData = this.buildStandardTokenFactoryData({
+        token: params.token as StandardTokenConfig,
+        sale: params.sale,
+        vesting: params.vesting,
+        userAddress: params.userAddress,
+        airlock: params.modules?.airlock ?? addresses.airlock,
+        tokenFactory: resolvedTokenFactory,
+        addresses,
+      });
+      tokenFactoryData =
+        this.encodeStandardTokenFactoryData(standardTokenFactoryData);
     }
 
     // Governance factory data
@@ -3555,16 +3700,6 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
 
     // Resolve module addresses
     const salt = this.generateRandomSalt(params.userAddress);
-    const resolvedTokenFactory: Address | undefined =
-      params.modules?.tokenFactory ??
-      (this.isDoppler404Token(params.token)
-        ? (addresses.doppler404Factory as Address | undefined)
-        : addresses.tokenFactory);
-    if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
-      throw new Error(
-        'Token factory address not configured. Provide an explicit address or ensure chain config includes a valid factory.',
-      );
-    }
 
     const resolvedInitializer: Address | undefined = (() => {
       if (useDopplerHookInitializer) {
@@ -3925,6 +4060,64 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     return rounded;
   }
 
+  private validateVestingConfig(
+    sale: SaleConfig,
+    vesting?: VestingConfig,
+  ): void {
+    if (!vesting) {
+      return;
+    }
+
+    const cliffDuration = vesting.cliffDuration ?? 0;
+    const duration = vesting.duration ?? 0;
+
+    if (cliffDuration < 0) {
+      throw new Error('Vesting cliff duration cannot be negative');
+    }
+    if (duration < 0) {
+      throw new Error('Vesting duration cannot be negative');
+    }
+    if (cliffDuration > duration) {
+      throw new Error(
+        'Vesting cliff duration cannot exceed vesting duration',
+      );
+    }
+    if (
+      cliffDuration > 0 &&
+      duration > 0 &&
+      duration < DERC20_V2_MIN_VESTING_DURATION
+    ) {
+      throw new Error(
+        `Vesting duration must be 0 or at least ${DERC20_V2_MIN_VESTING_DURATION} seconds when using cliffs`,
+      );
+    }
+
+    if (vesting.recipients && vesting.amounts) {
+      if (vesting.recipients.length !== vesting.amounts.length) {
+        throw new Error(
+          'Vesting recipients and amounts arrays must have the same length',
+        );
+      }
+      if (vesting.recipients.length === 0) {
+        throw new Error('Vesting recipients array cannot be empty');
+      }
+
+      const totalVested = vesting.amounts.reduce((sum, amt) => sum + amt, 0n);
+      const availableForVesting = sale.initialSupply - sale.numTokensToSell;
+      if (totalVested > availableForVesting) {
+        throw new Error(
+          `Total vesting amount (${totalVested}) exceeds available tokens (${availableForVesting})`,
+        );
+      }
+      return;
+    }
+
+    const vestedAmount = sale.initialSupply - sale.numTokensToSell;
+    if (vestedAmount <= 0n) {
+      throw new Error('No tokens available for vesting');
+    }
+  }
+
   private validateStaticAuctionParams(params: CreateStaticAuctionParams): void {
     // Validate token parameters
     if (!params.token.name || params.token.name.trim().length === 0) {
@@ -3973,41 +4166,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       throw new Error('Cannot sell more tokens than initial supply');
     }
 
-    // Validate vesting if provided
-    if (params.vesting) {
-      // Validate recipients and amounts arrays match
-      if (params.vesting.recipients && params.vesting.amounts) {
-        if (
-          params.vesting.recipients.length !== params.vesting.amounts.length
-        ) {
-          throw new Error(
-            'Vesting recipients and amounts arrays must have the same length',
-          );
-        }
-        if (params.vesting.recipients.length === 0) {
-          throw new Error('Vesting recipients array cannot be empty');
-        }
-        // Validate total vested amount doesn't exceed available tokens
-        const totalVested = params.vesting.amounts.reduce(
-          (sum, amt) => sum + amt,
-          BigInt(0),
-        );
-        const availableForVesting =
-          params.sale.initialSupply - params.sale.numTokensToSell;
-        if (totalVested > availableForVesting) {
-          throw new Error(
-            `Total vesting amount (${totalVested}) exceeds available tokens (${availableForVesting})`,
-          );
-        }
-      } else {
-        // Default case: validate there are tokens available for vesting
-        const vestedAmount =
-          params.sale.initialSupply - params.sale.numTokensToSell;
-        if (vestedAmount <= BigInt(0)) {
-          throw new Error('No tokens available for vesting');
-        }
-      }
-    }
+    this.validateVestingConfig(params.sale, params.vesting);
+
+    this.validateVestingConfig(params.sale, params.vesting);
 
     // Validate migration config
     if (params.migration.type === 'dopplerHook') {
@@ -4094,6 +4255,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     if (params.sale.numTokensToSell > params.sale.initialSupply) {
       throw new Error('Cannot sell more tokens than initial supply');
     }
+
+    this.validateVestingConfig(params.sale, params.vesting);
 
     // Validate auction parameters
     if (params.auction.duration <= 0) {
@@ -4390,34 +4553,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     // Validate initializer mode / compatibility and mode-specific constraints.
     this.resolveMulticurveInitializerMode(params);
 
-    // Validate vesting if provided
-    if (params.vesting) {
-      // Validate recipients and amounts arrays match
-      if (params.vesting.recipients && params.vesting.amounts) {
-        if (
-          params.vesting.recipients.length !== params.vesting.amounts.length
-        ) {
-          throw new Error(
-            'Vesting recipients and amounts arrays must have the same length',
-          );
-        }
-        if (params.vesting.recipients.length === 0) {
-          throw new Error('Vesting recipients array cannot be empty');
-        }
-        // Validate total vested amount doesn't exceed available tokens
-        const totalVested = params.vesting.amounts.reduce(
-          (sum, amt) => sum + amt,
-          BigInt(0),
-        );
-        const availableForVesting =
-          params.sale.initialSupply - params.sale.numTokensToSell;
-        if (totalVested > availableForVesting) {
-          throw new Error(
-            `Total vesting amount (${totalVested}) exceeds available tokens (${availableForVesting})`,
-          );
-        }
-      }
-    }
+    this.validateVestingConfig(params.sale, params.vesting);
 
     // Validate pool beneficiaries if provided
     if (params.pool.beneficiaries && params.pool.beneficiaries.length > 0) {
@@ -4844,17 +4980,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           baseURI: string;
           unit?: bigint;
         }
-      | {
-          name: string;
-          symbol: string;
-          initialSupply: bigint;
-          airlock: Address;
-          yearlyMintRate: bigint;
-          vestingDuration: bigint;
-          recipients: Address[];
-          amounts: bigint[];
-          tokenURI: string;
-        };
+      | StandardTokenFactoryData;
     poolInitializer: Address;
     poolInitializerData: {
       minimumProceeds: bigint;
@@ -4982,47 +5108,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
               [t.name, t.symbol, t.baseURI, t.unit ?? 1000n],
             );
           })()
-        : (() => {
-            const {
-              name,
-              symbol,
-              yearlyMintRate,
-              vestingDuration,
-              recipients,
-              amounts,
-              tokenURI,
-            } = params.tokenFactoryData as {
-              name: string;
-              symbol: string;
-              initialSupply: bigint;
-              airlock: Address;
-              yearlyMintRate: bigint;
-              vestingDuration: bigint;
-              recipients: Address[];
-              amounts: bigint[];
-              tokenURI: string;
-            };
-            return encodeAbiParameters(
-              [
-                { type: 'string' },
-                { type: 'string' },
-                { type: 'uint256' },
-                { type: 'uint256' },
-                { type: 'address[]' },
-                { type: 'uint256[]' },
-                { type: 'string' },
-              ],
-              [
-                name,
-                symbol,
-                yearlyMintRate,
-                vestingDuration,
-                recipients,
-                amounts,
-                tokenURI,
-              ],
-            );
-          })();
+        : this.encodeStandardTokenFactoryData(
+            params.tokenFactoryData as StandardTokenFactoryData,
+          );
 
     // Compute token init hash; use DN404 bytecode if tokenVariant is doppler404
     let tokenInitHash: Hash | undefined;
@@ -5053,62 +5141,50 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         ),
       );
     } else {
-      const {
-        name,
-        symbol,
-        yearlyMintRate,
-        vestingDuration,
-        recipients,
-        amounts,
-        tokenURI,
-      } = params.tokenFactoryData as {
-        name: string;
-        symbol: string;
-        initialSupply: bigint;
-        airlock: Address;
-        yearlyMintRate: bigint;
-        vestingDuration: bigint;
-        recipients: Address[];
-        amounts: bigint[];
-        tokenURI: string;
-      };
-      const { airlock, initialSupply } = params;
-      const initHashData = encodeAbiParameters(
-        [
-          { type: 'string' },
-          { type: 'string' },
-          { type: 'uint256' },
-          { type: 'address' },
-          { type: 'address' },
-          { type: 'uint256' },
-          { type: 'uint256' },
-          { type: 'address[]' },
-          { type: 'uint256[]' },
-          { type: 'string' },
-        ],
-        [
-          name,
-          symbol,
-          initialSupply,
-          airlock,
-          airlock,
-          yearlyMintRate,
-          vestingDuration,
-          recipients,
-          amounts,
-          tokenURI,
-        ],
-      );
-      // Use DERC2080Bytecode for TokenFactory80, DERC20Bytecode otherwise
-      const isTokenFactory80 =
-        params.tokenFactory.toLowerCase() === TOKEN_FACTORY_80_ADDRESS;
-      const bytecode = isTokenFactory80
-        ? (DERC2080Bytecode as Hex)
-        : ((params.customDerc20Bytecode as Hex) ?? (DERC20Bytecode as Hex));
+      const standardTokenFactoryData =
+        params.tokenFactoryData as StandardTokenFactoryData;
+      if (standardTokenFactoryData.kind === 'v2') {
+        tokenInitHash = this.computeStandardTokenInitHash(
+          standardTokenFactoryData,
+          params.tokenFactory,
+        );
+      } else {
+        const initHashData = encodeAbiParameters(
+          [
+            { type: 'string' },
+            { type: 'string' },
+            { type: 'uint256' },
+            { type: 'address' },
+            { type: 'address' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+            { type: 'address[]' },
+            { type: 'uint256[]' },
+            { type: 'string' },
+          ],
+          [
+            standardTokenFactoryData.name,
+            standardTokenFactoryData.symbol,
+            standardTokenFactoryData.initialSupply,
+            standardTokenFactoryData.airlock,
+            standardTokenFactoryData.airlock,
+            standardTokenFactoryData.yearlyMintRate,
+            standardTokenFactoryData.vestingDuration,
+            standardTokenFactoryData.recipients,
+            standardTokenFactoryData.amounts,
+            standardTokenFactoryData.tokenURI,
+          ],
+        );
+        const isTokenFactory80 =
+          params.tokenFactory.toLowerCase() === TOKEN_FACTORY_80_ADDRESS;
+        const bytecode = isTokenFactory80
+          ? (DERC2080Bytecode as Hex)
+          : ((params.customDerc20Bytecode as Hex) ?? (DERC20Bytecode as Hex));
 
-      tokenInitHash = keccak256(
-        encodePacked(['bytes', 'bytes'], [bytecode, initHashData]),
-      );
+        tokenInitHash = keccak256(
+          encodePacked(['bytes', 'bytes'], [bytecode, initHashData]),
+        );
+      }
     }
 
     // Use the exact flags from V4 SDK

--- a/src/evm/entities/token/derc20/Derc20.ts
+++ b/src/evm/entities/token/derc20/Derc20.ts
@@ -8,14 +8,14 @@ import { SupportedPublicClient } from '../../../types';
  * and minting-related state information.
  */
 export class Derc20 {
-  private publicClient: SupportedPublicClient;
-  private walletClient?: WalletClient;
-  private address: Address;
-  private get rpc(): PublicClient {
+  protected publicClient: SupportedPublicClient;
+  protected walletClient?: WalletClient;
+  protected address: Address;
+  protected get rpc(): PublicClient {
     return this.publicClient as PublicClient;
   }
 
-  private static splitSignature(signature: `0x${string}`): {
+  protected static splitSignature(signature: `0x${string}`): {
     v: number;
     r: `0x${string}`;
     s: `0x${string}`;

--- a/src/evm/entities/token/derc20/Derc20V2.ts
+++ b/src/evm/entities/token/derc20/Derc20V2.ts
@@ -109,22 +109,27 @@ export class Derc20V2 extends Derc20 {
       throw new Error('Wallet client required for write operations');
     }
 
-    const { request } =
-      scheduleId === undefined
-        ? await this.rpc.simulateContract({
-            address: this.address,
-            abi: derc20V2Abi,
-            functionName: 'releaseFor',
-            args: [beneficiary],
-            account: this.walletClient.account,
-          })
-        : await this.rpc.simulateContract({
-            address: this.address,
-            abi: derc20V2Abi,
-            functionName: 'releaseFor',
-            args: [beneficiary, scheduleId],
-            account: this.walletClient.account,
-          });
+    if (scheduleId === undefined) {
+      const { request } = await this.rpc.simulateContract({
+        address: this.address,
+        abi: derc20V2Abi,
+        functionName: 'releaseFor',
+        args: [beneficiary],
+        account: this.walletClient.account,
+      });
+
+      return await this.walletClient.writeContract(
+        options?.gas ? { ...request, gas: options.gas } : request,
+      );
+    }
+
+    const { request } = await this.rpc.simulateContract({
+      address: this.address,
+      abi: derc20V2Abi,
+      functionName: 'releaseFor',
+      args: [beneficiary, scheduleId],
+      account: this.walletClient.account,
+    });
 
     return await this.walletClient.writeContract(
       options?.gas ? { ...request, gas: options.gas } : request,

--- a/src/evm/entities/token/derc20/Derc20V2.ts
+++ b/src/evm/entities/token/derc20/Derc20V2.ts
@@ -1,0 +1,133 @@
+import type { Address } from 'viem';
+import { derc20V2Abi } from '../../../abis';
+import { Derc20 } from './Derc20';
+
+export class Derc20V2 extends Derc20 {
+  async getVestingScheduleCount(): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: derc20V2Abi,
+      functionName: 'vestingScheduleCount',
+    });
+  }
+
+  async getVestingSchedule(scheduleId: bigint): Promise<{
+    cliffDuration: bigint;
+    duration: bigint;
+  }> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: derc20V2Abi,
+      functionName: 'vestingSchedules',
+      args: [scheduleId],
+    });
+
+    return {
+      cliffDuration: BigInt(result[0]),
+      duration: BigInt(result[1]),
+    };
+  }
+
+  async getScheduleIdsOf(beneficiary: Address): Promise<bigint[]> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: derc20V2Abi,
+      functionName: 'getScheduleIdsOf',
+      args: [beneficiary],
+    });
+    return Array.from(result);
+  }
+
+  async getTotalAllocatedOf(beneficiary: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: derc20V2Abi,
+      functionName: 'totalAllocatedOf',
+      args: [beneficiary],
+    });
+  }
+
+  async getAvailableVestedAmountForSchedule(
+    beneficiary: Address,
+    scheduleId: bigint,
+  ): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: derc20V2Abi,
+      functionName: 'computeAvailableVestedAmount',
+      args: [beneficiary, scheduleId],
+    });
+  }
+
+  async getVestingDataForSchedule(
+    beneficiary: Address,
+    scheduleId: bigint,
+  ): Promise<{
+    totalAmount: bigint;
+    releasedAmount: bigint;
+  }> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: derc20V2Abi,
+      functionName: 'vestingOf',
+      args: [beneficiary, scheduleId],
+    });
+
+    return {
+      totalAmount: result[0],
+      releasedAmount: result[1],
+    };
+  }
+
+  async releaseSchedule(
+    scheduleId: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    if (!this.walletClient) {
+      throw new Error('Wallet client required for write operations');
+    }
+
+    const { request } = await this.rpc.simulateContract({
+      address: this.address,
+      abi: derc20V2Abi,
+      functionName: 'release',
+      args: [scheduleId],
+      account: this.walletClient.account,
+    });
+
+    return await this.walletClient.writeContract(
+      options?.gas ? { ...request, gas: options.gas } : request,
+    );
+  }
+
+  async releaseFor(
+    beneficiary: Address,
+    scheduleId?: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    if (!this.walletClient) {
+      throw new Error('Wallet client required for write operations');
+    }
+
+    const { request } =
+      scheduleId === undefined
+        ? await this.rpc.simulateContract({
+            address: this.address,
+            abi: derc20V2Abi,
+            functionName: 'releaseFor',
+            args: [beneficiary],
+            account: this.walletClient.account,
+          })
+        : await this.rpc.simulateContract({
+            address: this.address,
+            abi: derc20V2Abi,
+            functionName: 'releaseFor',
+            args: [beneficiary, scheduleId],
+            account: this.walletClient.account,
+          });
+
+    return await this.walletClient.writeContract(
+      options?.gas ? { ...request, gas: options.gas } : request,
+    );
+  }
+}

--- a/src/evm/entities/token/derc20/index.ts
+++ b/src/evm/entities/token/derc20/index.ts
@@ -1,1 +1,2 @@
 export { Derc20 } from './Derc20';
+export { Derc20V2 } from './Derc20V2';

--- a/src/evm/entities/token/index.ts
+++ b/src/evm/entities/token/index.ts
@@ -1,2 +1,2 @@
-export { Derc20 } from './derc20';
+export { Derc20, Derc20V2 } from './derc20';
 export { Eth } from './eth';

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -22,7 +22,7 @@ export {
 export { Quoter } from './entities/quoter';
 
 // Export token entities
-export { Derc20, Eth } from './entities/token';
+export { Derc20, Derc20V2, Eth } from './entities/token';
 
 // Export builders and common interface
 export {

--- a/src/evm/utils/tokenAddressMiner.ts
+++ b/src/evm/utils/tokenAddressMiner.ts
@@ -16,7 +16,7 @@ import {
 
 const DEFAULT_MAX_ITERATIONS = 1_000_000;
 
-export type TokenVariant = 'standard' | 'doppler404';
+export type TokenVariant = 'standard' | 'standard-v2' | 'doppler404';
 
 // TokenFactory80 has the same deterministic CREATE2 address across all chains where it is deployed.
 const TOKEN_FACTORY_80_ADDRESS =
@@ -48,6 +48,7 @@ export interface TokenAddressMiningParams {
   tokenData: Hex;
   tokenVariant?: TokenVariant;
   customBytecode?: Hex;
+  v2Implementation?: Address;
   maxIterations?: number;
   startSalt?: bigint;
   hook?: TokenAddressHookConfig;
@@ -70,12 +71,32 @@ const STANDARD_TOKEN_DATA_ABI = [
   { type: 'string' },
 ] as const;
 
+const STANDARD_TOKEN_V2_DATA_ABI = [
+  { type: 'string' },
+  { type: 'string' },
+  { type: 'uint256' },
+  {
+    type: 'tuple[]',
+    components: [
+      { type: 'uint64', name: 'cliff' },
+      { type: 'uint64', name: 'duration' },
+    ],
+  },
+  { type: 'address[]' },
+  { type: 'uint256[]' },
+  { type: 'uint256[]' },
+  { type: 'string' },
+] as const;
+
 const DOPPLER404_TOKEN_DATA_ABI = [
   { type: 'string' },
   { type: 'string' },
   { type: 'string' },
   { type: 'uint256' },
 ] as const;
+
+const DEFAULT_DERC20_V2_IMPLEMENTATION =
+  '0x4BBfed1c27CDE12eF6638251D81ab4e3be7556b7' as const;
 
 function normalizeHexFragment(
   value: string,
@@ -167,6 +188,14 @@ function computeCreate2AddressFast(buffer: Uint8Array): string {
   return '0x' + hash.slice(-40).toLowerCase();
 }
 
+function computeSoladyCloneInitCodeHash(implementation: Address): Hash {
+  return keccak256(
+    `0x602c3d8160093d39f33d3d3d3d363d3d37363d73${implementation.slice(
+      2,
+    )}5af43d3d93803e602a57fd5bf3`,
+  ) as Hash;
+}
+
 function buildTokenInitHash(params: {
   variant: TokenVariant;
   tokenFactory: Address;
@@ -175,6 +204,7 @@ function buildTokenInitHash(params: {
   recipient: Address;
   owner: Address;
   customBytecode?: Hex;
+  v2Implementation?: Address;
 }): Hash {
   const {
     variant,
@@ -184,6 +214,7 @@ function buildTokenInitHash(params: {
     recipient,
     owner,
     customBytecode,
+    v2Implementation,
   } = params;
 
   if (variant === 'doppler404') {
@@ -210,6 +241,13 @@ function buildTokenInitHash(params: {
         [customBytecode ?? (DopplerDN404Bytecode as Hex), initHashData],
       ),
     ) as Hash;
+  }
+
+  if (variant === 'standard-v2') {
+    decodeAbiParameters(STANDARD_TOKEN_V2_DATA_ABI, tokenData);
+    return computeSoladyCloneInitCodeHash(
+      v2Implementation ?? DEFAULT_DERC20_V2_IMPLEMENTATION,
+    );
   }
 
   const [
@@ -320,6 +358,7 @@ export function mineTokenAddress(
     recipient,
     owner,
     customBytecode,
+    v2Implementation: params.v2Implementation,
   });
 
   const hookConfig = hook

--- a/src/evm/utils/tokenAddressMiner.ts
+++ b/src/evm/utils/tokenAddressMiner.ts
@@ -95,9 +95,6 @@ const DOPPLER404_TOKEN_DATA_ABI = [
   { type: 'uint256' },
 ] as const;
 
-const DEFAULT_DERC20_V2_IMPLEMENTATION =
-  '0x4BBfed1c27CDE12eF6638251D81ab4e3be7556b7' as const;
-
 function normalizeHexFragment(
   value: string,
   label: 'prefix' | 'suffix',
@@ -245,9 +242,13 @@ function buildTokenInitHash(params: {
 
   if (variant === 'standard-v2') {
     decodeAbiParameters(STANDARD_TOKEN_V2_DATA_ABI, tokenData);
-    return computeSoladyCloneInitCodeHash(
-      v2Implementation ?? DEFAULT_DERC20_V2_IMPLEMENTATION,
-    );
+    if (!v2Implementation) {
+      throw new Error(
+        'TokenAddressMiner: v2Implementation is required for standard-v2 tokens',
+      );
+    }
+
+    return computeSoladyCloneInitCodeHash(v2Implementation);
   }
 
   const [

--- a/test/evm/fork/base-sepolia/multicurve-cliff-vesting.base-sepolia.test.ts
+++ b/test/evm/fork/base-sepolia/multicurve-cliff-vesting.base-sepolia.test.ts
@@ -1,0 +1,221 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { type Address } from 'viem'
+import {
+  CHAIN_IDS,
+  DopplerSDK,
+  WAD,
+  airlockAbi,
+  getAddresses,
+} from '../../../../src/evm'
+import { DAY_SECONDS } from '../../../../src/evm/constants'
+import {
+  delay,
+  getAnvilManager,
+  getForkClients,
+  getRpcEnvVar,
+  hasRpcUrl,
+  isAnvilForkEnabled,
+  mineToTimestamp,
+} from '../../utils'
+
+describe('Multicurve cliff vesting (Base Sepolia fork)', () => {
+  if (!isAnvilForkEnabled()) {
+    it.skip('requires ANVIL_FORK_ENABLED=true')
+    return
+  }
+
+  if (!hasRpcUrl(CHAIN_IDS.BASE_SEPOLIA)) {
+    it.skip(`requires ${getRpcEnvVar(CHAIN_IDS.BASE_SEPOLIA)} env var`)
+    return
+  }
+
+  const chainId = CHAIN_IDS.BASE_SEPOLIA
+  const addresses = getAddresses(chainId)
+  const anvilManager = getAnvilManager()
+  const cliffDuration = 90n * BigInt(DAY_SECONDS)
+  const vestingDuration = 180n * BigInt(DAY_SECONDS)
+
+  let publicClient: ReturnType<typeof getForkClients>['publicClient']
+  let walletClient: ReturnType<typeof getForkClients>['walletClient']
+  let testClient: ReturnType<typeof getForkClients>['testClient']
+  let account: ReturnType<typeof getForkClients>['account']
+  let sdk: DopplerSDK
+  let modulesWhitelisted = false
+  let moduleStates: {
+    initializer?: number
+    migrator?: number
+    tokenFactory?: number
+    governanceFactory?: number
+  } = {}
+
+  beforeAll(async () => {
+    await anvilManager.start(chainId)
+
+    const clients = getForkClients(chainId, 0, { timeout: 90_000 })
+    publicClient = clients.publicClient
+    walletClient = clients.walletClient
+    testClient = clients.testClient
+    account = clients.account
+    sdk = new DopplerSDK({ publicClient, walletClient, chainId })
+
+    try {
+      const [initializerState, migratorState, tokenFactoryState, governanceState] =
+        await Promise.all([
+          publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v4MulticurveInitializer!],
+          }),
+          publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.v2Migrator],
+          }),
+          publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.derc20V2Factory!],
+          }),
+          publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [addresses.noOpGovernanceFactory!],
+          }),
+        ])
+
+      moduleStates = {
+        initializer: Number(initializerState),
+        migrator: Number(migratorState),
+        tokenFactory: Number(tokenFactoryState),
+        governanceFactory: Number(governanceState),
+      }
+      modulesWhitelisted =
+        moduleStates.initializer === 3 &&
+        moduleStates.migrator === 4 &&
+        moduleStates.tokenFactory === 1 &&
+        moduleStates.governanceFactory === 2
+    } catch (err) {
+      console.info(
+        'module state check failed (will skip):',
+        err instanceof Error ? err.message : err
+      )
+    }
+  }, 60_000)
+
+  afterAll(async () => {
+    await anvilManager.stop(chainId)
+  })
+
+  it('creates a cliffed V2 token and releases vested tokens after the cliff', async () => {
+    expect(moduleStates.tokenFactory).toBe(1)
+    expect(moduleStates.governanceFactory).toBe(2)
+    expect(moduleStates.initializer).toBe(3)
+    expect(moduleStates.migrator).toBe(4)
+    expect(modulesWhitelisted).toBe(true)
+
+    const liquidAmount = 900_000n * WAD
+    const vestedAmount = 100_000n * WAD
+
+    const params = sdk
+      .buildMulticurveAuction()
+      .tokenConfig({
+        type: 'standard',
+        name: 'Fork Cliff Vest',
+        symbol: 'FCV',
+        tokenURI: 'ipfs://fork-cliff-vest',
+      })
+      .saleConfig({
+        initialSupply: liquidAmount + vestedAmount,
+        numTokensToSell: liquidAmount,
+        numeraire: addresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: Array.from({ length: 5 }, (_, index) => ({
+          tickLower: index * 16_000,
+          tickUpper: 240_000,
+          numPositions: 10,
+          shares: WAD / 5n,
+        })),
+      })
+      .withVesting({
+        duration: vestingDuration,
+        cliffDuration: Number(cliffDuration),
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(account.address)
+      .withV4MulticurveInitializer(addresses.v4MulticurveInitializer!)
+      .build()
+
+    const sim = await sdk.factory.simulateCreateMulticurve(params)
+    expect(sim.tokenAddress).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    expect(sim.poolId).toMatch(/^0x[a-fA-F0-9]{64}$/)
+    expect(sim.createParams.tokenFactory).toBe(addresses.derc20V2Factory)
+
+    let mining = true
+    const miner = (async () => {
+      while (mining) {
+        try {
+          await testClient.mine({ blocks: 1 })
+        } catch {}
+        await delay(150)
+      }
+    })()
+
+    let result: Awaited<ReturnType<typeof sdk.factory.createMulticurve>>
+    try {
+      result = await sdk.factory.createMulticurve(params)
+    } finally {
+      mining = false
+      await miner
+    }
+
+    expect(result.tokenAddress).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    expect(result.poolId).toMatch(/^0x[a-fA-F0-9]{64}$/)
+
+    const token = sdk.getDerc20V2(result.tokenAddress as Address)
+    expect(await token.getVestingScheduleCount()).toBe(1n)
+    expect(await token.getVestingSchedule(0n)).toEqual({
+      cliffDuration,
+      duration: vestingDuration,
+    })
+    expect(await token.getScheduleIdsOf(account.address)).toEqual([0n])
+    expect(await token.getTotalAllocatedOf(account.address)).toBe(vestedAmount)
+    expect(await token.getVestingDataForSchedule(account.address, 0n)).toEqual({
+      totalAmount: vestedAmount,
+      releasedAmount: 0n,
+    })
+    expect(await token.getBalanceOf(account.address)).toBe(0n)
+    expect(await token.getAvailableVestedAmount(account.address)).toBe(0n)
+
+    const vestingStart = await token.getVestingStart()
+    await mineToTimestamp(testClient, vestingStart + cliffDuration - 1n)
+    expect(await token.getAvailableVestedAmount(account.address)).toBe(0n)
+
+    await mineToTimestamp(testClient, vestingStart + cliffDuration + 1n)
+    const expectedReleased = (vestedAmount * (cliffDuration + 1n)) / vestingDuration
+    expect(
+      await token.getAvailableVestedAmountForSchedule(account.address, 0n)
+    ).toBe(expectedReleased)
+    expect(await token.getAvailableVestedAmount(account.address)).toBe(
+      expectedReleased
+    )
+
+    const releaseTx = await token.releaseSchedule(0n)
+    await testClient.mine({ blocks: 1 })
+    await publicClient.waitForTransactionReceipt({ hash: releaseTx })
+
+    expect(await token.getVestingDataForSchedule(account.address, 0n)).toEqual({
+      totalAmount: vestedAmount,
+      releasedAmount: expectedReleased,
+    })
+    expect(await token.getBalanceOf(account.address)).toBe(expectedReleased)
+    expect(await token.getAvailableVestedAmount(account.address)).toBe(0n)
+  }, 120_000)
+})

--- a/test/evm/setup/fixtures/addresses.ts
+++ b/test/evm/setup/fixtures/addresses.ts
@@ -8,6 +8,12 @@ export const mockAddresses: ChainAddresses = {
   tokenFactory: getAddress(
     '0x2000000000000000000000000000000000000002',
   ) as Address,
+  derc20V2Factory: getAddress(
+    '0x2000000000000000000000000000000000000003',
+  ) as Address,
+  derc20V2Implementation: getAddress(
+    '0x2000000000000000000000000000000000000004',
+  ) as Address,
   v3Initializer: getAddress(
     '0x3000000000000000000000000000000000000003',
   ) as Address,

--- a/test/evm/setup/vitest.setup.ts
+++ b/test/evm/setup/vitest.setup.ts
@@ -12,7 +12,7 @@ import { expect } from 'vitest'
 import { isAddress, isHash } from 'viem'
 
 // Load .env files from project root (check multiple common names)
-const projectRoot = resolve(__dirname, '../..')
+const projectRoot = resolve(__dirname, '../../..')
 const envFiles = ['.env.local', '.env', '.env.development']
 for (const file of envFiles) {
   const envPath = resolve(projectRoot, file)

--- a/test/evm/unit/entities/Derc20V2.test.ts
+++ b/test/evm/unit/entities/Derc20V2.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { parseEther, type Address } from 'viem';
+import { Derc20V2 } from '../../../../src/evm/entities/token/derc20/Derc20V2';
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+} from '../../setup/fixtures/clients';
+import { mockTokenAddress } from '../../setup/fixtures/addresses';
+
+describe('Derc20V2', () => {
+  let derc20V2: Derc20V2;
+  let publicClient: ReturnType<typeof createMockPublicClient>;
+  let walletClient: ReturnType<typeof createMockWalletClient>;
+
+  const beneficiary = '0x1234567890123456789012345678901234567890' as Address;
+
+  beforeEach(() => {
+    publicClient = createMockPublicClient();
+    walletClient = createMockWalletClient();
+    derc20V2 = new Derc20V2(publicClient, walletClient, mockTokenAddress);
+  });
+
+  it('reads the vesting schedule count', async () => {
+    vi.mocked(publicClient.readContract).mockResolvedValueOnce(2n);
+
+    await expect(derc20V2.getVestingScheduleCount()).resolves.toBe(2n);
+    expect(publicClient.readContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'vestingScheduleCount',
+    });
+  });
+
+  it('reads an individual vesting schedule', async () => {
+    vi.mocked(publicClient.readContract).mockResolvedValueOnce([90n, 180n] as any);
+
+    await expect(derc20V2.getVestingSchedule(0n)).resolves.toEqual({
+      cliffDuration: 90n,
+      duration: 180n,
+    });
+    expect(publicClient.readContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'vestingSchedules',
+      args: [0n],
+    });
+  });
+
+  it('reads schedule ids for a beneficiary', async () => {
+    vi.mocked(publicClient.readContract).mockResolvedValueOnce([0n, 1n] as any);
+
+    await expect(derc20V2.getScheduleIdsOf(beneficiary)).resolves.toEqual([
+      0n,
+      1n,
+    ]);
+    expect(publicClient.readContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'getScheduleIdsOf',
+      args: [beneficiary],
+    });
+  });
+
+  it('reads the total allocated amount for a beneficiary', async () => {
+    const allocated = parseEther('100000');
+    vi.mocked(publicClient.readContract).mockResolvedValueOnce(allocated);
+
+    await expect(derc20V2.getTotalAllocatedOf(beneficiary)).resolves.toBe(
+      allocated,
+    );
+    expect(publicClient.readContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'totalAllocatedOf',
+      args: [beneficiary],
+    });
+  });
+
+  it('reads the vested amount available for a schedule', async () => {
+    const available = parseEther('1234');
+    vi.mocked(publicClient.readContract).mockResolvedValueOnce(available);
+
+    await expect(
+      derc20V2.getAvailableVestedAmountForSchedule(beneficiary, 0n),
+    ).resolves.toBe(available);
+    expect(publicClient.readContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'computeAvailableVestedAmount',
+      args: [beneficiary, 0n],
+    });
+  });
+
+  it('reads vesting data for a schedule', async () => {
+    const totalAmount = parseEther('10000');
+    const releasedAmount = parseEther('2500');
+    vi.mocked(publicClient.readContract).mockResolvedValueOnce([
+      totalAmount,
+      releasedAmount,
+    ] as any);
+
+    await expect(
+      derc20V2.getVestingDataForSchedule(beneficiary, 0n),
+    ).resolves.toEqual({
+      totalAmount,
+      releasedAmount,
+    });
+    expect(publicClient.readContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'vestingOf',
+      args: [beneficiary, 0n],
+    });
+  });
+
+  it('releases vested tokens for the caller under a schedule', async () => {
+    const txHash =
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+    vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
+      request: {
+        address: mockTokenAddress,
+        functionName: 'release',
+        args: [0n],
+      },
+    } as any);
+    vi.mocked(walletClient.writeContract).mockResolvedValueOnce(
+      txHash as `0x${string}`,
+    );
+
+    await expect(derc20V2.releaseSchedule(0n)).resolves.toBe(txHash);
+    expect(publicClient.simulateContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'release',
+      args: [0n],
+      account: walletClient.account,
+    });
+  });
+
+  it('releases all vested tokens for a beneficiary', async () => {
+    const txHash =
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+
+    vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
+      request: {
+        address: mockTokenAddress,
+        functionName: 'releaseFor',
+        args: [beneficiary],
+      },
+    } as any);
+    vi.mocked(walletClient.writeContract).mockResolvedValueOnce(
+      txHash as `0x${string}`,
+    );
+
+    await expect(derc20V2.releaseFor(beneficiary)).resolves.toBe(txHash);
+    expect(publicClient.simulateContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'releaseFor',
+      args: [beneficiary],
+      account: walletClient.account,
+    });
+  });
+
+  it('releases vested tokens for a beneficiary under a specific schedule', async () => {
+    const txHash =
+      '0xfedcfedcfedcfedcfedcfedcfedcfedcfedcfedcfedcfedcfedcfedcfedcfedc';
+
+    vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
+      request: {
+        address: mockTokenAddress,
+        functionName: 'releaseFor',
+        args: [beneficiary, 1n],
+      },
+    } as any);
+    vi.mocked(walletClient.writeContract).mockResolvedValueOnce(
+      txHash as `0x${string}`,
+    );
+
+    await expect(derc20V2.releaseFor(beneficiary, 1n)).resolves.toBe(txHash);
+    expect(publicClient.simulateContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'releaseFor',
+      args: [beneficiary, 1n],
+      account: walletClient.account,
+    });
+  });
+
+  it('throws on write methods without a wallet client', async () => {
+    const readOnly = new Derc20V2(publicClient, undefined, mockTokenAddress);
+
+    await expect(readOnly.releaseSchedule(0n)).rejects.toThrow(
+      'Wallet client required for write operations',
+    );
+    await expect(readOnly.releaseFor(beneficiary)).rejects.toThrow(
+      'Wallet client required for write operations',
+    );
+  });
+});

--- a/test/evm/unit/entities/DopplerFactory.vestingV2.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.vestingV2.test.ts
@@ -1,0 +1,377 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { decodeAbiParameters, getAddress, parseEther, type Address } from 'viem';
+import { DAY_SECONDS, WAD } from '../../../../src/evm/constants';
+import {
+  DynamicAuctionBuilder,
+  MulticurveBuilder,
+  OpeningAuctionBuilder,
+  StaticAuctionBuilder,
+} from '../../../../src/evm/builders';
+import { DopplerFactory } from '../../../../src/evm/entities/DopplerFactory';
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+} from '../../setup/fixtures/clients';
+import { mockAddresses } from '../../setup/fixtures/addresses';
+
+vi.mock('../../../../src/evm/addresses', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../src/evm/addresses')>();
+  return {
+    ...actual,
+    getAddresses: vi.fn(() => mockAddresses),
+  };
+});
+
+const userAddress = '0x1234567890123456789012345678901234567890' as Address;
+const secondaryRecipient =
+  '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address;
+
+const STANDARD_TOKEN_V2_DATA_ABI = [
+  { type: 'string' },
+  { type: 'string' },
+  { type: 'uint256' },
+  {
+    type: 'tuple[]',
+    components: [
+      { type: 'uint64', name: 'cliff' },
+      { type: 'uint64', name: 'duration' },
+    ],
+  },
+  { type: 'address[]' },
+  { type: 'uint256[]' },
+  { type: 'uint256[]' },
+  { type: 'string' },
+] as const;
+
+function decodeV2TokenFactoryData(data: `0x${string}`) {
+  return decodeAbiParameters(STANDARD_TOKEN_V2_DATA_ABI, data) as readonly [
+    string,
+    string,
+    bigint,
+    readonly { cliff: bigint; duration: bigint }[],
+    readonly Address[],
+    readonly bigint[],
+    readonly bigint[],
+    string,
+  ];
+}
+
+describe('DopplerFactory V2 cliff vesting', () => {
+  let factory: DopplerFactory;
+
+  beforeEach(() => {
+    factory = new DopplerFactory(
+      createMockPublicClient(),
+      createMockWalletClient(),
+      1,
+    );
+  });
+
+  it('uses the V2 factory for static auctions with cliffs', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Static Cliff',
+        symbol: 'STCL',
+        tokenURI: 'ipfs://static-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({
+        startTick: -120000,
+        endTick: -60000,
+        fee: 3000,
+      })
+      .withVesting({
+        duration: 180n * BigInt(DAY_SECONDS),
+        cliffDuration: 90 * DAY_SECONDS,
+        recipients: [userAddress, secondaryRecipient],
+        amounts: [parseEther('60000'), parseEther('40000')],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
+    expect(decoded[0]).toBe('Static Cliff');
+    expect(decoded[1]).toBe('STCL');
+    expect(decoded[3]).toEqual([
+      { cliff: 90n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+    ]);
+    expect(decoded[4]).toEqual([
+      getAddress(userAddress),
+      getAddress(secondaryRecipient),
+    ]);
+    expect(decoded[5]).toEqual([0n, 0n]);
+    expect(decoded[6]).toEqual([parseEther('60000'), parseEther('40000')]);
+  });
+
+  it('uses the V2 factory for dynamic auctions with cliffs', async () => {
+    const params = DynamicAuctionBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Dynamic Cliff',
+        symbol: 'DYCL',
+        tokenURI: 'ipfs://dynamic-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .withMarketCapRange({
+        marketCap: { start: 500_000, min: 50_000 },
+        numerairePrice: 3000,
+        minProceeds: parseEther('100'),
+        maxProceeds: parseEther('10000'),
+        fee: 3000,
+        tickSpacing: 10,
+        duration: 7 * DAY_SECONDS,
+        epochLength: 3600,
+      })
+      .withVesting({
+        duration: 180n * BigInt(DAY_SECONDS),
+        cliffDuration: 90 * DAY_SECONDS,
+        recipients: [userAddress],
+        amounts: [parseEther('100000')],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV4', fee: 3000, tickSpacing: 10 })
+      .withUserAddress(userAddress)
+      .build();
+
+    const { createParams } = await factory.encodeCreateDynamicAuctionParams(
+      params,
+    );
+    const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
+    expect(decoded[3]).toEqual([
+      { cliff: 90n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+    ]);
+    expect(decoded[4]).toEqual([userAddress]);
+    expect(decoded[5]).toEqual([0n]);
+    expect(decoded[6]).toEqual([parseEther('100000')]);
+  });
+
+  it('uses the V2 factory for opening auctions with cliffs', async () => {
+    const publicClient = createMockPublicClient();
+    vi.mocked(publicClient.readContract)
+      .mockResolvedValueOnce(mockAddresses.poolManager as any)
+      .mockResolvedValueOnce(mockAddresses.dopplerDeployer as any);
+    factory = new DopplerFactory(publicClient, createMockWalletClient(), 1);
+
+    const params = OpeningAuctionBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Opening Cliff',
+        symbol: 'OPCL',
+        tokenURI: 'ipfs://opening-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .openingAuctionConfig({
+        auctionDuration: DAY_SECONDS,
+        minAcceptableTickToken0: -120000,
+        minAcceptableTickToken1: -120000,
+        incentiveShareBps: 100,
+        tickSpacing: 10,
+        fee: 3000,
+        minLiquidity: 1000n,
+        shareToAuctionBps: 8000,
+      })
+      .dopplerConfig({
+        minProceeds: parseEther('100'),
+        maxProceeds: parseEther('10000'),
+        startTick: -60000,
+        endTick: -120000,
+        duration: 7 * DAY_SECONDS,
+        epochLength: 3600,
+        fee: 3000,
+        tickSpacing: 10,
+      })
+      .withVesting({
+        duration: 180n * BigInt(DAY_SECONDS),
+        cliffDuration: 90 * DAY_SECONDS,
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .withOpeningAuctionInitializer(mockAddresses.v4Initializer)
+      .build();
+
+    const { createParams } = await factory.encodeCreateOpeningAuctionParams(
+      params,
+    );
+    const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
+    expect(decoded[3]).toEqual([
+      { cliff: 90n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+    ]);
+    expect(decoded[4]).toEqual([userAddress]);
+    expect(decoded[5]).toEqual([0n]);
+    expect(decoded[6]).toEqual([parseEther('100000')]);
+  });
+
+  it('uses the V2 factory for multicurve auctions with cliffs', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Multicurve Cliff',
+        symbol: 'MUCL',
+        tokenURI: 'ipfs://multicurve-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        duration: 180n * BigInt(DAY_SECONDS),
+        cliffDuration: 90 * DAY_SECONDS,
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = factory.encodeCreateMulticurveParams(params);
+    const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
+    expect(decoded[3]).toEqual([
+      { cliff: 90n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+    ]);
+    expect(decoded[4]).toEqual([userAddress]);
+    expect(decoded[5]).toEqual([0n]);
+    expect(decoded[6]).toEqual([parseEther('100000')]);
+  });
+
+  it('rejects cliff durations greater than the vesting duration', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Bad Cliff',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        duration: 89n * BigInt(DAY_SECONDS),
+        cliffDuration: 90 * DAY_SECONDS,
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+      'Vesting cliff duration cannot exceed vesting duration',
+    );
+  });
+
+  it('rejects cliff vesting durations shorter than one day', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Short Cliff',
+        symbol: 'SHRT',
+        tokenURI: 'ipfs://short-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        duration: 3600n,
+        cliffDuration: 1800,
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+      `Vesting duration must be 0 or at least ${DAY_SECONDS} seconds when using cliffs`,
+    );
+  });
+
+  it('rejects legacy tokenFactory overrides when cliffs are requested', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Legacy Override',
+        symbol: 'LEGO',
+        tokenURI: 'ipfs://legacy-override',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({
+        startTick: -120000,
+        endTick: -60000,
+        fee: 3000,
+      })
+      .withVesting({
+        duration: 180n * BigInt(DAY_SECONDS),
+        cliffDuration: 90 * DAY_SECONDS,
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .withTokenFactory(mockAddresses.tokenFactory)
+      .build();
+
+    await expect(factory.encodeCreateStaticAuctionParams(params)).rejects.toThrow(
+      'Cliff vesting requires the DERC20 V2 factory. Remove the tokenFactory override or point it at the chain DERC20 V2 factory.',
+    );
+  });
+});

--- a/test/evm/unit/token-address-miner.test.ts
+++ b/test/evm/unit/token-address-miner.test.ts
@@ -253,6 +253,36 @@ describe('mineTokenAddress', () => {
     expect(manualAddress).toBe(result.tokenAddress)
   })
 
+  it('throws when standard-v2 mining is attempted without a v2 implementation address', () => {
+    const tokenData = encodeAbiParameters(
+      STANDARD_TOKEN_V2_ABI,
+      [
+        'Vanity Token V2',
+        'VNY2',
+        1000n,
+        [{ cliff: 90n, duration: 180n }],
+        [RECIPIENT],
+        [0n],
+        [100n],
+        'ipfs://token-v2',
+      ]
+    )
+
+    expect(() =>
+      mineTokenAddress({
+        prefix: '0',
+        tokenFactory: TOKEN_FACTORY,
+        initialSupply: 1_000_000n,
+        recipient: RECIPIENT,
+        owner: OWNER,
+        tokenData,
+        tokenVariant: 'standard-v2',
+      })
+    ).toThrow(
+      'TokenAddressMiner: v2Implementation is required for standard-v2 tokens'
+    )
+  })
+
   it('mines a matching prefix and suffix together', () => {
     const initialSupply = 1_000_000n
     const tokenData = encodeAbiParameters(

--- a/test/evm/unit/token-address-miner.test.ts
+++ b/test/evm/unit/token-address-miner.test.ts
@@ -27,6 +27,23 @@ const STANDARD_TOKEN_ABI = [
   { type: 'string' },
 ] as const
 
+const STANDARD_TOKEN_V2_ABI = [
+  { type: 'string' },
+  { type: 'string' },
+  { type: 'uint256' },
+  {
+    type: 'tuple[]',
+    components: [
+      { type: 'uint64', name: 'cliff' },
+      { type: 'uint64', name: 'duration' },
+    ],
+  },
+  { type: 'address[]' },
+  { type: 'uint256[]' },
+  { type: 'uint256[]' },
+  { type: 'string' },
+] as const
+
 const DOPPLER404_TOKEN_ABI = [
   { type: 'string' },
   { type: 'string' },
@@ -34,12 +51,22 @@ const DOPPLER404_TOKEN_ABI = [
   { type: 'uint256' },
 ] as const
 
+const V2_IMPLEMENTATION = '0x4BBfed1c27CDE12eF6638251D81ab4e3be7556b7' as Address
+
 function computeCreate2Address(salt: Hash, initCodeHash: Hash, deployer: Address): Address {
   const encoded = encodePacked(
     ['bytes1', 'address', 'bytes32', 'bytes32'],
     ['0xff', deployer, salt, initCodeHash]
   )
   return getAddress(`0x${keccak256(encoded).slice(-40)}`)
+}
+
+function computeSoladyCloneInitCodeHash(implementation: Address): Hash {
+  return keccak256(
+    `0x602c3d8160093d39f33d3d3d3d363d3d37363d73${implementation.slice(
+      2
+    )}5af43d3d93803e602a57fd5bf3`
+  ) as Hash
 }
 
 describe('mineTokenAddress', () => {
@@ -190,6 +217,40 @@ describe('mineTokenAddress', () => {
 
     expect(result.tokenAddress.slice(2).toLowerCase().endsWith('0')).toBe(true)
     expect(result.iterations).toBeGreaterThan(0)
+  })
+
+  it('mines standard-v2 token addresses using the clone init code hash', () => {
+    const initialSupply = 1_000_000n
+    const tokenData = encodeAbiParameters(
+      STANDARD_TOKEN_V2_ABI,
+      [
+        'Vanity Token V2',
+        'VNY2',
+        1000n,
+        [{ cliff: 90n, duration: 180n }],
+        [RECIPIENT],
+        [0n],
+        [100n],
+        'ipfs://token-v2',
+      ]
+    )
+
+    const result = mineTokenAddress({
+      prefix: '0',
+      tokenFactory: TOKEN_FACTORY,
+      initialSupply,
+      recipient: RECIPIENT,
+      owner: OWNER,
+      tokenData,
+      tokenVariant: 'standard-v2',
+      v2Implementation: V2_IMPLEMENTATION,
+    })
+
+    expect(result.tokenAddress.slice(2).toLowerCase().startsWith('0')).toBe(true)
+
+    const initHash = computeSoladyCloneInitCodeHash(V2_IMPLEMENTATION)
+    const manualAddress = computeCreate2Address(result.salt, initHash, TOKEN_FACTORY)
+    expect(manualAddress).toBe(result.tokenAddress)
   })
 
   it('mines a matching prefix and suffix together', () => {


### PR DESCRIPTION
## Summary
- route standard token launches with `cliffDuration` to the DERC20 V2 factory and add a first-class `Derc20V2` SDK entity
- update CREATE2 mining, chain addresses, and builder/factory encoding so cliff vesting works across static, dynamic, opening-auction, and multicurve flows
- add unit and Base Sepolia fork coverage for cliff vesting and fix fork env loading from repo-root `.env.local`

## Why
`cliffDuration` was already accepted on the SDK side, but the legacy standard-token path silently dropped it. The contracts support cliff schedules on the V2 token path, so the SDK needed to select that path and encode the right vesting data end to end.

## Impact
Users can now create standard-token launches that allocate to a beneficiary, hold tokens through a cliff, and vest them linearly afterward. The SDK also exposes the V2 token read/write surface needed to inspect schedules and release vested balances.

## Validation
- `pnpm vitest run test/evm/unit/entities/Derc20V2.test.ts test/evm/unit/entities/DopplerFactory.vestingV2.test.ts test/evm/unit/token-address-miner.test.ts test/evm/unit/entities/Derc20.test.ts test/evm/unit/entities/DopplerFactory.test.ts test/evm/unit/entities/DopplerFactory.openingAuction.test.ts test/evm/unit/entities/DopplerFactory.openingAuction.openingMiner.test.ts test/evm/unit/token-address-miner-multicurve.test.ts`
- `TEST_CHAIN=base-sepolia pnpm vitest run --config vitest.fork.config.ts test/evm/fork/base-sepolia/multicurve-cliff-vesting.base-sepolia.test.ts`

## Base Sepolia
- whitelisted `CloneDERC20VotesV2Factory` in the Airlock owner helper flow so the fork test can use the V2 path
- tx: `0x0e11851560d5e1f366baa18fb2d6393f5c7719ec5f54b51d7fbc8bbd878b1a1c`