### PR TITLE
[codex] support per-beneficiary vesting schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ console.log('Token address:', result.tokenAddress);
 
 If you set `cliffDuration > 0` or provide `schedules`, the SDK automatically uses the DERC20 V2 factory and exposes schedule-aware token reads via `sdk.getDerc20V2(tokenAddress)`. When `schedules` is provided, omit `scheduleIds` to assign one schedule per recipient in order, or provide `scheduleIds` to reuse schedules across beneficiaries.
 
+For a runnable example, see [examples/multicurve-per-beneficiary-vesting.ts](./examples/multicurve-per-beneficiary-vesting.ts).
+
 > **Tick spacing reminder:** When you provide ticks manually via `poolByTicks`, make sure both `startTick` and `endTick` are exact multiples of the fee tier's tick spacing (100→1, 500→10, 3000→60, 10000→200). The SDK now validates this locally and will fail fast if the ticks are misaligned.
 
 ### Static Auction with Lockable Beneficiaries (V3)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ const params = new StaticAuctionBuilder()
     // Optional: specify multiple recipients and amounts
     // recipients: ['0xTeam...', '0xAdvisor...'],
     // amounts: [parseEther('50000000'), parseEther('50000000')]
+    // Optional: define per-beneficiary schedules on the DERC20 V2 path
+    // schedules: [
+    //   { duration: BigInt(180 * 24 * 60 * 60), cliffDuration: 30 * 24 * 60 * 60 },
+    //   { duration: BigInt(365 * 24 * 60 * 60), cliffDuration: 90 * 24 * 60 * 60 },
+    // ],
+    // Optional: if omitted, one schedule is assigned per recipient in order
+    // scheduleIds: [0, 1]
   })
   .withMigration({ type: 'uniswapV2' })
   .withUserAddress('0x...')
@@ -98,7 +105,7 @@ console.log('Pool address:', result.poolAddress);
 console.log('Token address:', result.tokenAddress);
 ```
 
-If you set `cliffDuration > 0`, the SDK now automatically uses the DERC20 V2 factory and exposes schedule-aware token reads via `sdk.getDerc20V2(tokenAddress)`.
+If you set `cliffDuration > 0` or provide `schedules`, the SDK automatically uses the DERC20 V2 factory and exposes schedule-aware token reads via `sdk.getDerc20V2(tokenAddress)`. When `schedules` is provided, omit `scheduleIds` to assign one schedule per recipient in order, or provide `scheduleIds` to reuse schedules across beneficiaries.
 
 > **Tick spacing reminder:** When you provide ticks manually via `poolByTicks`, make sure both `startTick` and `endTick` are exact multiples of the fee tier's tick spacing (100→1, 500→10, 3000→60, 10000→200). The SDK now validates this locally and will fail fast if the ticks are misaligned.
 

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -50,12 +50,14 @@ Methods (chainable):
   - poolByPriceRange({ priceRange, fee?, numPositions?, maxShareToBeSold? })
     - Computes ticks from `priceRange` using inferred `tickSpacing` from `fee`
     - @deprecated: Use `withMarketCapRange()` instead for more intuitive configuration
-- withVesting({ duration?, cliffDuration?, recipients?, amounts? } | undefined)
+- withVesting({ duration?, cliffDuration?, recipients?, amounts?, schedules?, scheduleIds? } | undefined)
   - Omit to disable vesting. Default duration if provided but undefined is `DEFAULT_V3_VESTING_DURATION`.
-  - `cliffDuration > 0` automatically routes standard tokens through the DERC20 V2 factory (`CloneDERC20VotesV2Factory`).
+  - `cliffDuration > 0` or `schedules` automatically routes standard tokens through the DERC20 V2 factory (`CloneDERC20VotesV2Factory`).
   - Cliff vesting requires `duration >= 1 day` and `cliffDuration <= duration`.
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
+  - `schedules`: Optional array of `{ duration, cliffDuration }` schedule definitions for DERC20 V2 vesting.
+  - `scheduleIds`: Optional array mapping each recipient to an entry in `schedules`. If omitted, the SDK assigns a single shared schedule to all recipients when `schedules.length === 1`, or one schedule per recipient in order when `schedules.length === recipients.length`.
 - withGovernance(GovernanceConfig | { useDefaults: true } | { noOp: true } | undefined)
 - withMigration(MigrationConfig)
 - withUserAddress(address)
@@ -125,6 +127,28 @@ const paramsMultiVest = new StaticAuctionBuilder()
   .withMigration({ type: 'uniswapV2' })
   .withUserAddress(user)
   .build()
+
+// Example 4: Per-beneficiary vesting schedules (DERC20 V2)
+const paramsPerSchedule = new StaticAuctionBuilder()
+  .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
+  .saleConfig({ initialSupply: parseEther('1_000_000_000'), numTokensToSell: parseEther('900_000_000'), numeraire: weth })
+  .withMarketCapRange({
+    marketCap: { start: 50_000, end: 5_000_000 },
+    numerairePrice: 3000,
+  })
+  .withVesting({
+    recipients: ['0xTeam...', '0xAdvisor...', '0xTreasury...'],
+    amounts: [parseEther('30_000_000'), parseEther('20_000_000'), parseEther('50_000_000')],
+    schedules: [
+      { duration: BigInt(180*24*60*60), cliffDuration: 30 * 24 * 60 * 60 },
+      { duration: BigInt(365*24*60*60), cliffDuration: 90 * 24 * 60 * 60 },
+    ],
+    scheduleIds: [0, 1, 1],
+  })
+  .withGovernance()
+  .withMigration({ type: 'uniswapV2' })
+  .withUserAddress(user)
+  .build()
 ```
 
 ---
@@ -157,7 +181,7 @@ Methods (chainable):
   - auctionByPriceRange({ priceRange, minProceeds, maxProceeds, duration?, epochLength?, gamma?, tickSpacing?, numPdSlugs? })
     - Uses `pool.tickSpacing` unless `tickSpacing` is provided here
     - @deprecated: Use `withMarketCapRange()` instead for more intuitive configuration
-- withVesting({ duration?, cliffDuration?, recipients?, amounts? } | undefined)
+- withVesting({ duration?, cliffDuration?, recipients?, amounts?, schedules?, scheduleIds? } | undefined)
   - Omit to disable vesting. Default duration if provided but undefined is `0` for dynamic auctions.
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
@@ -251,7 +275,7 @@ Methods (chainable):
     - Defaults: `fee = FEE_TIERS.LOW (500)`, `tickSpacing` inferred, and all three presets selected
     - `overrides` (per preset) let you tweak ticks, numPositions, or shares while preserving tier ordering
     - Automatically appends a filler curve when the selected presets sum to < 100%, keeping total shares at exactly 1e18
-- withVesting({ duration?, cliffDuration?, recipients?, amounts? } | undefined)
+- withVesting({ duration?, cliffDuration?, recipients?, amounts?, schedules?, scheduleIds? } | undefined)
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
 - withGovernance(GovernanceConfig)
@@ -364,7 +388,7 @@ Methods (chainable):
 - dopplerConfig({ minProceeds, maxProceeds, startTick, endTick, duration?, epochLength?, gamma?, numPdSlugs?, fee?, tickSpacing? })
   - Defaults: `duration = 7 days`, `epochLength = 12 hours`, `numPdSlugs = 5`, `fee = 10000`, `tickSpacing = 30`
   - `gamma` is computed automatically when omitted
-- withVesting({ duration?, cliffDuration?, recipients?, amounts? } | undefined)
+- withVesting({ duration?, cliffDuration?, recipients?, amounts?, schedules?, scheduleIds? } | undefined)
 - withGovernance(GovernanceOption)
   - Optional in builder; defaults to no-op on no-op-enabled chains, default governance otherwise
 - withMigration(MigrationConfig)

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,6 +56,10 @@ Get price quotes across different Uniswap versions for optimal trading.
 
 Create a multicurve auction that queues until a future start time using the scheduled initializer on Base.
 
+### 12a. [Per-Beneficiary Vesting Schedules](./multicurve-per-beneficiary-vesting.ts)
+
+Create a multicurve auction whose vesting beneficiaries use different cliff and vesting schedules on the DERC20 V2 path. Demonstrates `schedules`, `scheduleIds`, and reading the assigned schedule data back from `sdk.getDerc20V2(...)`.
+
 ### 13. [Multicurve Vanity Launch (Market Cap)](./multicurve-vanity-by-marketcap.ts)
 
 Create a multicurve pool and mine a salt so the deployed token address ends with a chosen hex suffix (identifier). Launches on-chain (requires RPC + PRIVATE_KEY).

--- a/examples/multicurve-per-beneficiary-vesting.ts
+++ b/examples/multicurve-per-beneficiary-vesting.ts
@@ -1,0 +1,177 @@
+/**
+ * Example: Create a Multicurve Auction with Per-Beneficiary Vesting Schedules
+ *
+ * Demonstrates DERC20 V2 vesting where different beneficiaries can use
+ * different cliff and vesting schedules, and multiple beneficiaries can share
+ * the same schedule via scheduleIds.
+ *
+ * This script simulates by default. Set EXECUTE=1 to broadcast on Base Sepolia.
+ */
+import './env';
+
+import { CHAIN_IDS, DopplerSDK, WAD, getAddresses } from '../src/evm';
+import {
+  createPublicClient,
+  createWalletClient,
+  getAddress,
+  http,
+  parseEther,
+  type Address,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { baseSepolia } from 'viem/chains';
+
+const privateKey = process.env.PRIVATE_KEY as `0x${string}`;
+const rpcUrl = process.env.RPC_URL ?? baseSepolia.rpcUrls.default.http[0];
+const shouldExecute = process.env.EXECUTE === '1';
+
+if (!privateKey) throw new Error('PRIVATE_KEY is not set');
+
+async function main() {
+  const account = privateKeyToAccount(privateKey);
+  const chainId = CHAIN_IDS.BASE_SEPOLIA;
+  const addresses = getAddresses(chainId);
+
+  const publicClient = createPublicClient({
+    chain: baseSepolia,
+    transport: http(rpcUrl),
+  });
+  const walletClient = createWalletClient({
+    chain: baseSepolia,
+    transport: http(rpcUrl),
+    account,
+  });
+
+  const sdk = new DopplerSDK({
+    publicClient,
+    walletClient,
+    chainId,
+  });
+
+  const teamWallet = account.address;
+  const advisorWallet = getAddress(
+    '0x00000000000000000000000000000000000000A1',
+  );
+  const treasuryWallet = getAddress(
+    '0x00000000000000000000000000000000000000B2',
+  );
+
+  const recipients: Address[] = [teamWallet, advisorWallet, treasuryWallet];
+  const amounts = [
+    parseEther('30000'),
+    parseEther('20000'),
+    parseEther('50000'),
+  ];
+  const teamSchedule = {
+    duration: BigInt(180 * 24 * 60 * 60),
+    cliffDuration: 30 * 24 * 60 * 60,
+  };
+  const longTailSchedule = {
+    duration: BigInt(365 * 24 * 60 * 60),
+    cliffDuration: 90 * 24 * 60 * 60,
+  };
+
+  const params = sdk
+    .buildMulticurveAuction()
+    .tokenConfig({
+      name: 'Per Schedule Vesting Token',
+      symbol: 'PSVT',
+      tokenURI: 'ipfs://per-schedule-vesting.json',
+    })
+    .saleConfig({
+      initialSupply: 1_000_000n * WAD,
+      numTokensToSell: 900_000n * WAD,
+      numeraire: addresses.weth,
+    })
+    .poolConfig({
+      fee: 0,
+      tickSpacing: 8,
+      curves: [
+        {
+          tickLower: 0,
+          tickUpper: 240000,
+          numPositions: 12,
+          shares: parseEther('0.5'),
+        },
+        {
+          tickLower: 16000,
+          tickUpper: 240000,
+          numPositions: 12,
+          shares: parseEther('0.5'),
+        },
+      ],
+    })
+    .withVesting({
+      recipients,
+      amounts,
+      schedules: [teamSchedule, longTailSchedule],
+      scheduleIds: [0, 1, 1],
+    })
+    .withGovernance({ type: 'default' })
+    .withMigration({ type: 'uniswapV2' })
+    .withUserAddress(account.address)
+    .build();
+
+  console.log('Base Sepolia per-beneficiary vesting example');
+  console.log('RPC:', rpcUrl);
+  console.log('Execute:', shouldExecute);
+  console.log('Beneficiaries:', recipients);
+  console.log(
+    'Schedule mapping:',
+    recipients.map((recipient, index) => ({
+      recipient,
+      amount: amounts[index].toString(),
+      scheduleId: params.vesting?.scheduleIds?.[index] ?? index,
+    })),
+  );
+
+  const simulation = await sdk.factory.simulateCreateMulticurve(params);
+  console.log('Simulation OK');
+  console.log('Predicted token:', simulation.tokenAddress);
+  console.log('Predicted pool id:', simulation.poolId);
+  console.log('Estimated gas:', simulation.gasEstimate?.toString() ?? 'n/a');
+
+  if (!shouldExecute) {
+    console.log('Skipping broadcast. Set EXECUTE=1 to create the launch.');
+    return;
+  }
+
+  const result = await simulation.execute();
+  console.log('✅ Multicurve created');
+  console.log('Token address:', result.tokenAddress);
+  console.log('Pool ID:', result.poolId);
+  console.log('Transaction:', result.transactionHash);
+
+  const token = sdk.getDerc20V2(result.tokenAddress);
+  const scheduleCount = await token.getVestingScheduleCount();
+  console.log('Vesting schedule count:', scheduleCount.toString());
+
+  for (const recipient of recipients) {
+    const scheduleIds = await token.getScheduleIdsOf(recipient);
+    console.log('Recipient schedules:', {
+      recipient,
+      scheduleIds: scheduleIds.map((id) => id.toString()),
+    });
+
+    for (const scheduleId of scheduleIds) {
+      const schedule = await token.getVestingSchedule(scheduleId);
+      const vestingData = await token.getVestingDataForSchedule(
+        recipient,
+        scheduleId,
+      );
+      console.log('Schedule details:', {
+        recipient,
+        scheduleId: scheduleId.toString(),
+        cliffDuration: schedule.cliffDuration.toString(),
+        duration: schedule.duration.toString(),
+        totalAmount: vestingData.totalAmount.toString(),
+        releasedAmount: vestingData.releasedAmount.toString(),
+      });
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/src/evm/builders/DynamicAuctionBuilder.ts
+++ b/src/evm/builders/DynamicAuctionBuilder.ts
@@ -26,7 +26,12 @@ import {
   type ModuleAddressOverrides,
 } from '../types';
 import { type SupportedChainId } from '../addresses';
-import { computeTicks, type BaseAuctionBuilder } from './shared';
+import {
+  computeTicks,
+  normalizeBuilderScheduleId,
+  normalizeBuilderVestingScheduleDuration,
+  type BaseAuctionBuilder,
+} from './shared';
 
 export class DynamicAuctionBuilder<
   C extends SupportedChainId,
@@ -332,10 +337,15 @@ export class DynamicAuctionBuilder<
       recipients: params.recipients,
       amounts: params.amounts,
       schedules: params.schedules?.map((schedule) => ({
-        duration: Number(schedule.duration ?? 0n),
+        duration: normalizeBuilderVestingScheduleDuration(
+          schedule.duration,
+          'Vesting schedule duration',
+        ),
         cliffDuration: schedule.cliffDuration ?? 0,
       })),
-      scheduleIds: params.scheduleIds?.map((scheduleId) => Number(scheduleId)),
+      scheduleIds: params.scheduleIds?.map((scheduleId, index) =>
+        normalizeBuilderScheduleId(scheduleId, `Vesting scheduleIds[${index}]`),
+      ),
     };
     return this;
   }

--- a/src/evm/builders/DynamicAuctionBuilder.ts
+++ b/src/evm/builders/DynamicAuctionBuilder.ts
@@ -316,6 +316,11 @@ export class DynamicAuctionBuilder<
     cliffDuration?: number;
     recipients?: Address[];
     amounts?: bigint[];
+    schedules?: {
+      duration?: bigint;
+      cliffDuration?: number;
+    }[];
+    scheduleIds?: Array<number | bigint>;
   }): this {
     if (!params) {
       this.vesting = undefined;
@@ -326,6 +331,11 @@ export class DynamicAuctionBuilder<
       cliffDuration: params.cliffDuration ?? 0,
       recipients: params.recipients,
       amounts: params.amounts,
+      schedules: params.schedules?.map((schedule) => ({
+        duration: Number(schedule.duration ?? 0n),
+        cliffDuration: schedule.cliffDuration ?? 0,
+      })),
+      scheduleIds: params.scheduleIds?.map((scheduleId) => Number(scheduleId)),
     };
     return this;
   }

--- a/src/evm/builders/MulticurveBuilder.ts
+++ b/src/evm/builders/MulticurveBuilder.ts
@@ -34,6 +34,8 @@ import {
   type BaseAuctionBuilder,
   type MarketCapPresetOverrides,
   buildCurvesFromPresets,
+  normalizeBuilderScheduleId,
+  normalizeBuilderVestingScheduleDuration,
 } from './shared';
 
 export class MulticurveBuilder<
@@ -658,10 +660,15 @@ export class MulticurveBuilder<
       recipients: params.recipients,
       amounts: params.amounts,
       schedules: params.schedules?.map((schedule) => ({
-        duration: Number(schedule.duration ?? 0n),
+        duration: normalizeBuilderVestingScheduleDuration(
+          schedule.duration,
+          'Vesting schedule duration',
+        ),
         cliffDuration: schedule.cliffDuration ?? 0,
       })),
-      scheduleIds: params.scheduleIds?.map((scheduleId) => Number(scheduleId)),
+      scheduleIds: params.scheduleIds?.map((scheduleId, index) =>
+        normalizeBuilderScheduleId(scheduleId, `Vesting scheduleIds[${index}]`),
+      ),
     };
     return this;
   }

--- a/src/evm/builders/MulticurveBuilder.ts
+++ b/src/evm/builders/MulticurveBuilder.ts
@@ -642,6 +642,11 @@ export class MulticurveBuilder<
     cliffDuration?: number;
     recipients?: Address[];
     amounts?: bigint[];
+    schedules?: {
+      duration?: bigint;
+      cliffDuration?: number;
+    }[];
+    scheduleIds?: Array<number | bigint>;
   }): this {
     if (!params) {
       this.vesting = undefined;
@@ -652,6 +657,11 @@ export class MulticurveBuilder<
       cliffDuration: params.cliffDuration ?? 0,
       recipients: params.recipients,
       amounts: params.amounts,
+      schedules: params.schedules?.map((schedule) => ({
+        duration: Number(schedule.duration ?? 0n),
+        cliffDuration: schedule.cliffDuration ?? 0,
+      })),
+      scheduleIds: params.scheduleIds?.map((scheduleId) => Number(scheduleId)),
     };
     return this;
   }

--- a/src/evm/builders/OpeningAuctionBuilder.ts
+++ b/src/evm/builders/OpeningAuctionBuilder.ts
@@ -23,7 +23,11 @@ import {
   type VestingConfig,
 } from '../types';
 import { type SupportedChainId } from '../addresses';
-import { type BaseAuctionBuilder } from './shared';
+import {
+  normalizeBuilderScheduleId,
+  normalizeBuilderVestingScheduleDuration,
+  type BaseAuctionBuilder,
+} from './shared';
 
 export interface OpeningAuctionConfig {
   auctionDuration: number;
@@ -200,10 +204,15 @@ export class OpeningAuctionBuilder<
       recipients: params.recipients,
       amounts: params.amounts,
       schedules: params.schedules?.map((schedule) => ({
-        duration: Number(schedule.duration ?? 0n),
+        duration: normalizeBuilderVestingScheduleDuration(
+          schedule.duration,
+          'Vesting schedule duration',
+        ),
         cliffDuration: schedule.cliffDuration ?? 0,
       })),
-      scheduleIds: params.scheduleIds?.map((scheduleId) => Number(scheduleId)),
+      scheduleIds: params.scheduleIds?.map((scheduleId, index) =>
+        normalizeBuilderScheduleId(scheduleId, `Vesting scheduleIds[${index}]`),
+      ),
     };
     return this;
   }

--- a/src/evm/builders/OpeningAuctionBuilder.ts
+++ b/src/evm/builders/OpeningAuctionBuilder.ts
@@ -184,6 +184,11 @@ export class OpeningAuctionBuilder<
     cliffDuration?: number;
     recipients?: Address[];
     amounts?: bigint[];
+    schedules?: {
+      duration?: bigint;
+      cliffDuration?: number;
+    }[];
+    scheduleIds?: Array<number | bigint>;
   }): this {
     if (!params) {
       this.vesting = undefined;
@@ -194,6 +199,11 @@ export class OpeningAuctionBuilder<
       cliffDuration: params.cliffDuration ?? 0,
       recipients: params.recipients,
       amounts: params.amounts,
+      schedules: params.schedules?.map((schedule) => ({
+        duration: Number(schedule.duration ?? 0n),
+        cliffDuration: schedule.cliffDuration ?? 0,
+      })),
+      scheduleIds: params.scheduleIds?.map((scheduleId) => Number(scheduleId)),
     };
     return this;
   }

--- a/src/evm/builders/StaticAuctionBuilder.ts
+++ b/src/evm/builders/StaticAuctionBuilder.ts
@@ -303,16 +303,32 @@ export class StaticAuctionBuilder<
     cliffDuration?: number;
     recipients?: Address[];
     amounts?: bigint[];
+    schedules?: {
+      duration?: bigint;
+      cliffDuration?: number;
+    }[];
+    scheduleIds?: Array<number | bigint>;
   }): this {
     if (!params) {
       this.vesting = undefined;
       return this;
     }
+    const hasCustomSchedules =
+      (params.schedules?.length ?? 0) > 0 ||
+      (params.scheduleIds?.length ?? 0) > 0;
     this.vesting = {
-      duration: Number(params.duration ?? DEFAULT_V3_VESTING_DURATION),
+      duration: Number(
+        params.duration ??
+          (hasCustomSchedules ? 0n : DEFAULT_V3_VESTING_DURATION),
+      ),
       cliffDuration: params.cliffDuration ?? 0,
       recipients: params.recipients,
       amounts: params.amounts,
+      schedules: params.schedules?.map((schedule) => ({
+        duration: Number(schedule.duration ?? 0n),
+        cliffDuration: schedule.cliffDuration ?? 0,
+      })),
+      scheduleIds: params.scheduleIds?.map((scheduleId) => Number(scheduleId)),
     };
     return this;
   }

--- a/src/evm/builders/StaticAuctionBuilder.ts
+++ b/src/evm/builders/StaticAuctionBuilder.ts
@@ -28,7 +28,12 @@ import {
   type ModuleAddressOverrides,
 } from '../types';
 import { type SupportedChainId } from '../addresses';
-import { computeTicks, type BaseAuctionBuilder } from './shared';
+import {
+  computeTicks,
+  normalizeBuilderScheduleId,
+  normalizeBuilderVestingScheduleDuration,
+  type BaseAuctionBuilder,
+} from './shared';
 
 export class StaticAuctionBuilder<
   C extends SupportedChainId,
@@ -325,10 +330,15 @@ export class StaticAuctionBuilder<
       recipients: params.recipients,
       amounts: params.amounts,
       schedules: params.schedules?.map((schedule) => ({
-        duration: Number(schedule.duration ?? 0n),
+        duration: normalizeBuilderVestingScheduleDuration(
+          schedule.duration,
+          'Vesting schedule duration',
+        ),
         cliffDuration: schedule.cliffDuration ?? 0,
       })),
-      scheduleIds: params.scheduleIds?.map((scheduleId) => Number(scheduleId)),
+      scheduleIds: params.scheduleIds?.map((scheduleId, index) =>
+        normalizeBuilderScheduleId(scheduleId, `Vesting scheduleIds[${index}]`),
+      ),
     };
     return this;
   }

--- a/src/evm/builders/shared.ts
+++ b/src/evm/builders/shared.ts
@@ -77,6 +77,11 @@ export interface BaseAuctionBuilder<C extends SupportedChainId> {
     cliffDuration?: number;
     recipients?: Address[];
     amounts?: bigint[];
+    schedules?: {
+      duration?: bigint;
+      cliffDuration?: number;
+    }[];
+    scheduleIds?: Array<number | bigint>;
   }): this;
 
   /**

--- a/src/evm/builders/shared.ts
+++ b/src/evm/builders/shared.ts
@@ -122,6 +122,45 @@ export interface BaseAuctionBuilder<C extends SupportedChainId> {
   withNoOpMigrator(address: Address): this;
 }
 
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+
+export function normalizeBuilderVestingScheduleDuration(
+  value: bigint | undefined,
+  fieldPath: string,
+): number {
+  const duration = value ?? 0n;
+  if (duration < 0n) {
+    throw new RangeError(`${fieldPath} cannot be negative`);
+  }
+  if (duration > MAX_SAFE_INTEGER_BIGINT) {
+    throw new RangeError(`${fieldPath} must be a safe integer`);
+  }
+  return Number(duration);
+}
+
+export function normalizeBuilderScheduleId(
+  scheduleId: number | bigint,
+  fieldPath: string,
+): number {
+  if (typeof scheduleId === 'bigint') {
+    if (scheduleId < 0n) {
+      throw new RangeError(`${fieldPath} cannot be negative`);
+    }
+    if (scheduleId > MAX_SAFE_INTEGER_BIGINT) {
+      throw new RangeError(`${fieldPath} must be a safe integer`);
+    }
+    return Number(scheduleId);
+  }
+
+  if (!Number.isSafeInteger(scheduleId)) {
+    throw new RangeError(`${fieldPath} must be a safe integer`);
+  }
+  if (scheduleId < 0) {
+    throw new RangeError(`${fieldPath} cannot be negative`);
+  }
+  return scheduleId;
+}
+
 export function computeTicks(
   priceRange: PriceRange,
   tickSpacing: number,

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -175,6 +175,7 @@ type StandardTokenFactoryData =
   | V2StandardTokenFactoryData;
 
 const DERC20_V2_MIN_VESTING_DURATION = 24 * 60 * 60;
+const MAX_UINT64 = (1n << 64n) - 1n;
 
 export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
   private publicClient: SupportedPublicClient;
@@ -237,10 +238,36 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     if (!Number.isFinite(scheduleId) || !Number.isInteger(scheduleId)) {
       throw new Error(`${label} must be an integer`);
     }
+    if (!Number.isSafeInteger(scheduleId)) {
+      throw new Error(`${label} must be a safe integer`);
+    }
     if (scheduleId < 0) {
       throw new Error(`${label} cannot be negative`);
     }
     return BigInt(scheduleId);
+  }
+
+  private validateUint64LikeNumber(
+    value: number,
+    fieldPath: string,
+    options: { allowZero?: boolean } = {},
+  ): void {
+    const { allowZero = true } = options;
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      throw new Error(`${fieldPath} must be a finite integer`);
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`${fieldPath} must be a safe integer`);
+    }
+    if (value < 0) {
+      throw new Error(`${fieldPath} cannot be negative`);
+    }
+    if (!allowZero && value === 0) {
+      throw new Error(`${fieldPath} must be greater than zero`);
+    }
+    if (BigInt(value) > MAX_UINT64) {
+      throw new Error(`${fieldPath} must fit in uint64`);
+    }
   }
 
   private resolveV2VestingSchedules(args: {
@@ -4206,12 +4233,10 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         }
 
         for (const [index, scheduleId] of vesting.scheduleIds.entries()) {
-          if (!Number.isFinite(scheduleId) || !Number.isInteger(scheduleId)) {
-            throw new Error(`Vesting scheduleIds[${index}] must be an integer`);
-          }
-          if (scheduleId < 0) {
-            throw new Error(`Vesting scheduleIds[${index}] cannot be negative`);
-          }
+          this.validateUint64LikeNumber(
+            scheduleId,
+            `Vesting scheduleIds[${index}]`,
+          );
           if (scheduleId >= schedules.length) {
             throw new Error(
               `Vesting scheduleIds[${index}] references missing schedule ${scheduleId}`,
@@ -4231,16 +4256,14 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         const scheduleCliff = schedule.cliffDuration ?? 0;
         const scheduleDuration = schedule.duration ?? 0;
 
-        if (scheduleCliff < 0) {
-          throw new Error(
-            `Vesting schedules[${index}].cliffDuration cannot be negative`,
-          );
-        }
-        if (scheduleDuration < 0) {
-          throw new Error(
-            `Vesting schedules[${index}].duration cannot be negative`,
-          );
-        }
+        this.validateUint64LikeNumber(
+          scheduleCliff,
+          `Vesting schedules[${index}].cliffDuration`,
+        );
+        this.validateUint64LikeNumber(
+          scheduleDuration,
+          `Vesting schedules[${index}].duration`,
+        );
         if (scheduleCliff > scheduleDuration) {
           throw new Error(
             `Vesting schedules[${index}].cliffDuration cannot exceed duration`,

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -194,8 +194,21 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     this.chainId = chainId;
   }
 
+  private hasCustomV2Schedules(vesting?: VestingConfig): boolean {
+    return (
+      (vesting?.schedules?.length ?? 0) > 0 ||
+      (vesting?.scheduleIds?.length ?? 0) > 0
+    );
+  }
+
   private usesDerc20V2Vesting(vesting?: VestingConfig): boolean {
-    return (vesting?.cliffDuration ?? 0) > 0;
+    if (!vesting) {
+      return false;
+    }
+
+    return (
+      this.hasCustomV2Schedules(vesting) || (vesting.cliffDuration ?? 0) > 0
+    );
   }
 
   private resolveVestingAllocations(args: {
@@ -218,6 +231,77 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       recipients: [args.userAddress],
       amounts: [args.sale.initialSupply - args.sale.numTokensToSell],
     };
+  }
+
+  private normalizeV2ScheduleId(scheduleId: number, label: string): bigint {
+    if (!Number.isFinite(scheduleId) || !Number.isInteger(scheduleId)) {
+      throw new Error(`${label} must be an integer`);
+    }
+    if (scheduleId < 0) {
+      throw new Error(`${label} cannot be negative`);
+    }
+    return BigInt(scheduleId);
+  }
+
+  private resolveV2VestingSchedules(args: {
+    vesting?: VestingConfig;
+    recipientCount: number;
+  }): {
+    schedules: V2VestingSchedule[];
+    scheduleIds: bigint[];
+  } {
+    if (!args.vesting) {
+      return { schedules: [], scheduleIds: [] };
+    }
+
+    if (!this.hasCustomV2Schedules(args.vesting)) {
+      return {
+        schedules: [
+          {
+            cliff: BigInt(args.vesting.cliffDuration ?? 0),
+            duration: BigInt(args.vesting.duration ?? 0),
+          },
+        ],
+        scheduleIds: Array.from({ length: args.recipientCount }, () => 0n),
+      };
+    }
+
+    const schedules =
+      args.vesting.schedules?.map((schedule) => ({
+        cliff: BigInt(schedule.cliffDuration ?? 0),
+        duration: BigInt(schedule.duration ?? 0),
+      })) ?? [];
+
+    const explicitScheduleIds = args.vesting.scheduleIds;
+    if (explicitScheduleIds && explicitScheduleIds.length > 0) {
+      return {
+        schedules,
+        scheduleIds: explicitScheduleIds.map((scheduleId, index) =>
+          this.normalizeV2ScheduleId(
+            scheduleId,
+            `Vesting scheduleIds[${index}]`,
+          ),
+        ),
+      };
+    }
+
+    if (schedules.length === 1) {
+      return {
+        schedules,
+        scheduleIds: Array.from({ length: args.recipientCount }, () => 0n),
+      };
+    }
+
+    if (schedules.length === args.recipientCount) {
+      return {
+        schedules,
+        scheduleIds: schedules.map((_, index) => BigInt(index)),
+      };
+    }
+
+    throw new Error(
+      'Vesting schedules must either contain exactly one shared schedule or one schedule per recipient when scheduleIds are omitted',
+    );
   }
 
   private resolveStandardTokenFactoryMode(args: {
@@ -293,15 +377,10 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         );
       }
 
-      const schedules =
-        args.vesting === undefined
-          ? []
-          : [
-              {
-                cliff: BigInt(args.vesting.cliffDuration ?? 0),
-                duration: BigInt(args.vesting.duration ?? 0),
-              },
-            ];
+      const { schedules, scheduleIds } = this.resolveV2VestingSchedules({
+        vesting: args.vesting,
+        recipientCount: recipients.length,
+      });
 
       return {
         kind: 'v2',
@@ -312,7 +391,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         yearlyMintRate,
         schedules,
         beneficiaries: recipients,
-        scheduleIds: recipients.map(() => 0n),
+        scheduleIds,
         amounts,
         tokenURI: args.token.tokenURI,
         implementation,
@@ -4076,23 +4155,11 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
 
     const cliffDuration = vesting.cliffDuration ?? 0;
     const duration = vesting.duration ?? 0;
+    const hasCustomSchedules = this.hasCustomV2Schedules(vesting);
 
-    if (cliffDuration < 0) {
-      throw new Error('Vesting cliff duration cannot be negative');
-    }
-    if (duration < 0) {
-      throw new Error('Vesting duration cannot be negative');
-    }
-    if (cliffDuration > duration) {
-      throw new Error('Vesting cliff duration cannot exceed vesting duration');
-    }
-    if (
-      cliffDuration > 0 &&
-      duration > 0 &&
-      duration < DERC20_V2_MIN_VESTING_DURATION
-    ) {
+    if (hasCustomSchedules && (cliffDuration > 0 || duration > 0)) {
       throw new Error(
-        `Vesting duration must be 0 or at least ${DERC20_V2_MIN_VESTING_DURATION} seconds when using cliffs`,
+        'Use vesting.schedules instead of top-level duration/cliffDuration when configuring multiple vesting schedules',
       );
     }
 
@@ -4113,12 +4180,103 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           `Total vesting amount (${totalVested}) exceeds available tokens (${availableForVesting})`,
         );
       }
+    } else {
+      const vestedAmount = sale.initialSupply - sale.numTokensToSell;
+      if (vestedAmount <= 0n) {
+        throw new Error('No tokens available for vesting');
+      }
+    }
+
+    if (hasCustomSchedules) {
+      const schedules = vesting.schedules;
+      if (!schedules || schedules.length === 0) {
+        throw new Error(
+          'Vesting schedules are required when using scheduleIds or multiple vesting schedules',
+        );
+      }
+
+      const recipientCount =
+        vesting.recipients && vesting.amounts ? vesting.recipients.length : 1;
+
+      if (vesting.scheduleIds) {
+        if (vesting.scheduleIds.length !== recipientCount) {
+          throw new Error(
+            'Vesting scheduleIds array must have the same length as vesting recipients',
+          );
+        }
+
+        for (const [index, scheduleId] of vesting.scheduleIds.entries()) {
+          if (!Number.isFinite(scheduleId) || !Number.isInteger(scheduleId)) {
+            throw new Error(`Vesting scheduleIds[${index}] must be an integer`);
+          }
+          if (scheduleId < 0) {
+            throw new Error(`Vesting scheduleIds[${index}] cannot be negative`);
+          }
+          if (scheduleId >= schedules.length) {
+            throw new Error(
+              `Vesting scheduleIds[${index}] references missing schedule ${scheduleId}`,
+            );
+          }
+        }
+      } else if (
+        schedules.length !== 1 &&
+        schedules.length !== recipientCount
+      ) {
+        throw new Error(
+          'Vesting schedules must either contain exactly one shared schedule or one schedule per recipient when scheduleIds are omitted',
+        );
+      }
+
+      for (const [index, schedule] of schedules.entries()) {
+        const scheduleCliff = schedule.cliffDuration ?? 0;
+        const scheduleDuration = schedule.duration ?? 0;
+
+        if (scheduleCliff < 0) {
+          throw new Error(
+            `Vesting schedules[${index}].cliffDuration cannot be negative`,
+          );
+        }
+        if (scheduleDuration < 0) {
+          throw new Error(
+            `Vesting schedules[${index}].duration cannot be negative`,
+          );
+        }
+        if (scheduleCliff > scheduleDuration) {
+          throw new Error(
+            `Vesting schedules[${index}].cliffDuration cannot exceed duration`,
+          );
+        }
+        if (
+          scheduleCliff > 0 &&
+          scheduleDuration > 0 &&
+          scheduleDuration < DERC20_V2_MIN_VESTING_DURATION
+        ) {
+          throw new Error(
+            `Vesting schedules[${index}].duration must be 0 or at least ${DERC20_V2_MIN_VESTING_DURATION} seconds when using cliffs`,
+          );
+        }
+      }
+
       return;
     }
 
-    const vestedAmount = sale.initialSupply - sale.numTokensToSell;
-    if (vestedAmount <= 0n) {
-      throw new Error('No tokens available for vesting');
+    if (cliffDuration < 0) {
+      throw new Error('Vesting cliff duration cannot be negative');
+    }
+    if (duration < 0) {
+      throw new Error('Vesting duration cannot be negative');
+    }
+    if (cliffDuration > duration) {
+      throw new Error('Vesting cliff duration cannot exceed vesting duration');
+    }
+    if (
+      cliffDuration > 0 &&
+      duration > 0 &&
+      duration < DERC20_V2_MIN_VESTING_DURATION
+    ) {
+      throw new Error(
+        `Vesting duration must be 0 or at least ${DERC20_V2_MIN_VESTING_DURATION} seconds when using cliffs`,
+      );
     }
   }
 
@@ -4169,8 +4327,6 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     if (params.sale.numTokensToSell > params.sale.initialSupply) {
       throw new Error('Cannot sell more tokens than initial supply');
     }
-
-    this.validateVestingConfig(params.sale, params.vesting);
 
     this.validateVestingConfig(params.sale, params.vesting);
 

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -101,11 +101,18 @@ export interface OpeningAuctionDopplerConfig {
 }
 
 // Vesting configuration
+export interface VestingScheduleConfig {
+  duration: number; // in seconds
+  cliffDuration: number; // in seconds
+}
+
 export interface VestingConfig {
   duration: number; // in seconds
   cliffDuration: number; // in seconds
   recipients?: Address[]; // Optional array of recipient addresses (defaults to [userAddress] if not specified)
   amounts?: bigint[]; // Optional array of vesting amounts per recipient (must match recipients length if provided)
+  schedules?: VestingScheduleConfig[]; // Optional V2 vesting schedule definitions
+  scheduleIds?: number[]; // Optional mapping from recipients to schedule indexes
 }
 
 // Chains where no-op governance is enabled

--- a/test/evm/fork/base-sepolia/multicurve-cliff-vesting.base-sepolia.test.ts
+++ b/test/evm/fork/base-sepolia/multicurve-cliff-vesting.base-sepolia.test.ts
@@ -34,6 +34,8 @@ describe('Multicurve cliff vesting (Base Sepolia fork)', () => {
   const anvilManager = getAnvilManager()
   const cliffDuration = 90n * BigInt(DAY_SECONDS)
   const vestingDuration = 180n * BigInt(DAY_SECONDS)
+  const secondaryRecipient =
+    '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address
 
   let publicClient: ReturnType<typeof getForkClients>['publicClient']
   let walletClient: ReturnType<typeof getForkClients>['walletClient']
@@ -217,5 +219,133 @@ describe('Multicurve cliff vesting (Base Sepolia fork)', () => {
     })
     expect(await token.getBalanceOf(account.address)).toBe(expectedReleased)
     expect(await token.getAvailableVestedAmount(account.address)).toBe(0n)
+  }, 120_000)
+
+  it('creates per-beneficiary schedules and releases them independently', async () => {
+    expect(moduleStates.tokenFactory).toBe(1)
+    expect(moduleStates.governanceFactory).toBe(2)
+    expect(moduleStates.initializer).toBe(3)
+    expect(moduleStates.migrator).toBe(4)
+    expect(modulesWhitelisted).toBe(true)
+
+    const primaryAmount = 60_000n * WAD
+    const secondaryAmount = 40_000n * WAD
+    const primarySchedule = {
+      cliffDuration: 30n * BigInt(DAY_SECONDS),
+      duration: 180n * BigInt(DAY_SECONDS),
+    }
+    const secondarySchedule = {
+      cliffDuration: 120n * BigInt(DAY_SECONDS),
+      duration: 365n * BigInt(DAY_SECONDS),
+    }
+
+    const params = sdk
+      .buildMulticurveAuction()
+      .tokenConfig({
+        type: 'standard',
+        name: 'Fork Multi Cliff Vest',
+        symbol: 'FMCV',
+        tokenURI: 'ipfs://fork-multi-cliff-vest',
+      })
+      .saleConfig({
+        initialSupply: 900_000n * WAD + primaryAmount + secondaryAmount,
+        numTokensToSell: 900_000n * WAD,
+        numeraire: addresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: Array.from({ length: 5 }, (_, index) => ({
+          tickLower: index * 16_000,
+          tickUpper: 240_000,
+          numPositions: 10,
+          shares: WAD / 5n,
+        })),
+      })
+      .withVesting({
+        recipients: [account.address, secondaryRecipient],
+        amounts: [primaryAmount, secondaryAmount],
+        schedules: [
+          {
+            duration: primarySchedule.duration,
+            cliffDuration: Number(primarySchedule.cliffDuration),
+          },
+          {
+            duration: secondarySchedule.duration,
+            cliffDuration: Number(secondarySchedule.cliffDuration),
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(account.address)
+      .withV4MulticurveInitializer(addresses.v4MulticurveInitializer!)
+      .build()
+
+    let mining = true
+    const miner = (async () => {
+      while (mining) {
+        try {
+          await testClient.mine({ blocks: 1 })
+        } catch {}
+        await delay(150)
+      }
+    })()
+
+    let result: Awaited<ReturnType<typeof sdk.factory.createMulticurve>>
+    try {
+      result = await sdk.factory.createMulticurve(params)
+    } finally {
+      mining = false
+      await miner
+    }
+
+    const token = sdk.getDerc20V2(result.tokenAddress as Address)
+    expect(await token.getVestingScheduleCount()).toBe(2n)
+    expect(await token.getVestingSchedule(0n)).toEqual(primarySchedule)
+    expect(await token.getVestingSchedule(1n)).toEqual(secondarySchedule)
+    expect(await token.getScheduleIdsOf(account.address)).toEqual([0n])
+    expect(await token.getScheduleIdsOf(secondaryRecipient)).toEqual([1n])
+    expect(await token.getTotalAllocatedOf(account.address)).toBe(primaryAmount)
+    expect(await token.getTotalAllocatedOf(secondaryRecipient)).toBe(
+      secondaryAmount
+    )
+
+    const vestingStart = await token.getVestingStart()
+    await mineToTimestamp(testClient, vestingStart + primarySchedule.cliffDuration + 1n)
+
+    const primaryReleased =
+      (primaryAmount * (primarySchedule.cliffDuration + 1n)) /
+      primarySchedule.duration
+
+    expect(
+      await token.getAvailableVestedAmountForSchedule(account.address, 0n)
+    ).toBe(primaryReleased)
+    expect(
+      await token.getAvailableVestedAmountForSchedule(secondaryRecipient, 1n)
+    ).toBe(0n)
+
+    await mineToTimestamp(
+      testClient,
+      vestingStart + secondarySchedule.cliffDuration + 1n
+    )
+
+    const secondaryReleased =
+      (secondaryAmount * (secondarySchedule.cliffDuration + 1n)) /
+      secondarySchedule.duration
+
+    expect(
+      await token.getAvailableVestedAmountForSchedule(secondaryRecipient, 1n)
+    ).toBe(secondaryReleased)
+
+    const releaseTx = await token.releaseFor(secondaryRecipient, 1n)
+    await testClient.mine({ blocks: 1 })
+    await publicClient.waitForTransactionReceipt({ hash: releaseTx })
+
+    expect(await token.getVestingDataForSchedule(secondaryRecipient, 1n)).toEqual({
+      totalAmount: secondaryAmount,
+      releasedAmount: secondaryReleased,
+    })
+    expect(await token.getBalanceOf(secondaryRecipient)).toBe(secondaryReleased)
   }, 120_000)
 })

--- a/test/evm/unit/builders/MulticurveVesting.test.ts
+++ b/test/evm/unit/builders/MulticurveVesting.test.ts
@@ -295,4 +295,43 @@ describe('MulticurveBuilder - Vesting with multiple beneficiaries', () => {
     ]);
     expect(params.vesting?.scheduleIds).toEqual([0, 1, 1]);
   });
+
+  it('rejects unsafe schedule ids before building params', () => {
+    const builder = new MulticurveBuilder(chainId);
+
+    expect(() =>
+      builder.withVesting({
+        recipients: [
+          '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as `0x${string}`,
+        ],
+        amounts: [parseEther('100000')],
+        schedules: [
+          {
+            duration: BigInt(365 * 24 * 60 * 60),
+            cliffDuration: 30 * 24 * 60 * 60,
+          },
+        ],
+        scheduleIds: [BigInt(Number.MAX_SAFE_INTEGER) + 1n],
+      }),
+    ).toThrow('Vesting scheduleIds[0] must be a safe integer');
+  });
+
+  it('rejects custom schedule durations that exceed safe integer range', () => {
+    const builder = new MulticurveBuilder(chainId);
+
+    expect(() =>
+      builder.withVesting({
+        recipients: [
+          '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as `0x${string}`,
+        ],
+        amounts: [parseEther('100000')],
+        schedules: [
+          {
+            duration: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
+            cliffDuration: 30 * 24 * 60 * 60,
+          },
+        ],
+      }),
+    ).toThrow('Vesting schedule duration must be a safe integer');
+  });
 });

--- a/test/evm/unit/builders/MulticurveVesting.test.ts
+++ b/test/evm/unit/builders/MulticurveVesting.test.ts
@@ -221,4 +221,78 @@ describe('MulticurveBuilder - Vesting with multiple beneficiaries', () => {
     expect(params.vesting?.recipients).toEqual(recipients);
     expect(params.vesting?.amounts).toEqual(amounts);
   });
+
+  it('preserves custom schedules and schedule ids for V2 vesting', () => {
+    const recipients = [
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as `0x${string}`,
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as `0x${string}`,
+      '0xcccccccccccccccccccccccccccccccccccccccc' as `0x${string}`,
+    ];
+    const amounts = [
+      parseEther('100000'),
+      parseEther('50000'),
+      parseEther('150000'),
+    ];
+
+    const builder = new MulticurveBuilder(chainId);
+    const params = builder
+      .tokenConfig({
+        type: 'standard',
+        name: 'Test Token',
+        symbol: 'TEST',
+        tokenURI: 'ipfs://test',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('700000'),
+        numeraire:
+          '0x4200000000000000000000000000000000000006' as `0x${string}`,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 240_000,
+            numPositions: 10,
+            shares: parseEther('1'),
+          },
+        ],
+      })
+      .withVesting({
+        recipients,
+        amounts,
+        schedules: [
+          {
+            duration: BigInt(365 * 24 * 60 * 60),
+            cliffDuration: 30 * 24 * 60 * 60,
+          },
+          {
+            duration: BigInt(2 * 365 * 24 * 60 * 60),
+            cliffDuration: 180 * 24 * 60 * 60,
+          },
+        ],
+        scheduleIds: [0, 1, 1],
+      })
+      .withGovernance({ type: 'default' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(
+        '0x1234567890123456789012345678901234567890' as `0x${string}`,
+      )
+      .build();
+
+    expect(params.vesting).toBeDefined();
+    expect(params.vesting?.schedules).toEqual([
+      {
+        duration: 365 * 24 * 60 * 60,
+        cliffDuration: 30 * 24 * 60 * 60,
+      },
+      {
+        duration: 2 * 365 * 24 * 60 * 60,
+        cliffDuration: 180 * 24 * 60 * 60,
+      },
+    ]);
+    expect(params.vesting?.scheduleIds).toEqual([0, 1, 1]);
+  });
 });

--- a/test/evm/unit/entities/DopplerFactory.vestingV2.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.vestingV2.test.ts
@@ -553,6 +553,145 @@ describe('DopplerFactory V2 cliff vesting', () => {
     );
   });
 
+  it('rejects unsafe schedule ids for direct factory callers', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Unsafe Schedule Id',
+        symbol: 'USID',
+        tokenURI: 'ipfs://unsafe-schedule-id',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        recipients: [userAddress],
+        amounts: [parseEther('100000')],
+        schedules: [
+          {
+            duration: 180n * BigInt(DAY_SECONDS),
+            cliffDuration: 30 * DAY_SECONDS,
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    (params.vesting as any).scheduleIds = [Number.MAX_SAFE_INTEGER + 1];
+
+    expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+      'Vesting scheduleIds[0] must be a safe integer',
+    );
+  });
+
+  it('rejects non-integer custom schedule values for direct factory callers', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Fractional Schedule',
+        symbol: 'FRACT',
+        tokenURI: 'ipfs://fractional-schedule',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        recipients: [userAddress],
+        amounts: [parseEther('100000')],
+        schedules: [
+          {
+            duration: 180n * BigInt(DAY_SECONDS),
+            cliffDuration: 30 * DAY_SECONDS,
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    (params.vesting!.schedules as any)[0].duration = Number.NaN;
+
+    expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+      'Vesting schedules[0].duration must be a finite integer',
+    );
+  });
+
+  it('rejects non-safe custom schedule values for direct factory callers', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Unsafe Schedule',
+        symbol: 'UNSAFE',
+        tokenURI: 'ipfs://unsafe-schedule',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        recipients: [userAddress],
+        amounts: [parseEther('100000')],
+        schedules: [
+          {
+            duration: 180n * BigInt(DAY_SECONDS),
+            cliffDuration: 30 * DAY_SECONDS,
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    (params.vesting!.schedules as any)[0].duration =
+      Number.MAX_SAFE_INTEGER + 1;
+
+    expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+      'Vesting schedules[0].duration must be a safe integer',
+    );
+  });
+
   it('rejects legacy tokenFactory overrides when cliffs are requested', async () => {
     const params = StaticAuctionBuilder.forChain(1)
       .tokenConfig({

--- a/test/evm/unit/entities/DopplerFactory.vestingV2.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.vestingV2.test.ts
@@ -26,6 +26,8 @@ vi.mock('../../../../src/evm/addresses', async (importOriginal) => {
 const userAddress = '0x1234567890123456789012345678901234567890' as Address;
 const secondaryRecipient =
   '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address;
+const tertiaryRecipient =
+  '0xfedcfedcfedcfedcfedcfedcfedcfedcfedcfedc' as Address;
 
 const STANDARD_TOKEN_V2_DATA_ABI = [
   { type: 'string' },
@@ -158,6 +160,124 @@ describe('DopplerFactory V2 cliff vesting', () => {
     expect(decoded[4]).toEqual([userAddress]);
     expect(decoded[5]).toEqual([0n]);
     expect(decoded[6]).toEqual([parseEther('100000')]);
+  });
+
+  it('assigns one custom schedule per recipient when scheduleIds are omitted', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Scheduled Cliff',
+        symbol: 'SCFL',
+        tokenURI: 'ipfs://scheduled-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({
+        startTick: -120000,
+        endTick: -60000,
+        fee: 3000,
+      })
+      .withVesting({
+        recipients: [userAddress, secondaryRecipient],
+        amounts: [parseEther('55000'), parseEther('45000')],
+        schedules: [
+          {
+            duration: 180n * BigInt(DAY_SECONDS),
+            cliffDuration: 30 * DAY_SECONDS,
+          },
+          {
+            duration: 365n * BigInt(DAY_SECONDS),
+            cliffDuration: 90 * DAY_SECONDS,
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
+    expect(decoded[3]).toEqual([
+      { cliff: 30n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+      { cliff: 90n * BigInt(DAY_SECONDS), duration: 365n * BigInt(DAY_SECONDS) },
+    ]);
+    expect(decoded[4]).toEqual([
+      getAddress(userAddress),
+      getAddress(secondaryRecipient),
+    ]);
+    expect(decoded[5]).toEqual([0n, 1n]);
+    expect(decoded[6]).toEqual([parseEther('55000'), parseEther('45000')]);
+  });
+
+  it('reuses explicit schedule ids across recipients', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Mapped Schedules',
+        symbol: 'MAP',
+        tokenURI: 'ipfs://mapped-schedules',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('700000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        recipients: [userAddress, secondaryRecipient, tertiaryRecipient],
+        amounts: [
+          parseEther('120000'),
+          parseEther('80000'),
+          parseEther('100000'),
+        ],
+        schedules: [
+          {
+            duration: 180n * BigInt(DAY_SECONDS),
+            cliffDuration: 30 * DAY_SECONDS,
+          },
+          {
+            duration: 365n * BigInt(DAY_SECONDS),
+            cliffDuration: 120 * DAY_SECONDS,
+          },
+        ],
+        scheduleIds: [0, 1, 1],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = factory.encodeCreateMulticurveParams(params);
+    const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(decoded[3]).toEqual([
+      { cliff: 30n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+      {
+        cliff: 120n * BigInt(DAY_SECONDS),
+        duration: 365n * BigInt(DAY_SECONDS),
+      },
+    ]);
+    expect(decoded[5]).toEqual([0n, 1n, 1n]);
+    expect(decoded[6]).toEqual([
+      parseEther('120000'),
+      parseEther('80000'),
+      parseEther('100000'),
+    ]);
   });
 
   it('uses the V2 factory for opening auctions with cliffs', async () => {
@@ -340,6 +460,96 @@ describe('DopplerFactory V2 cliff vesting', () => {
 
     expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
       `Vesting duration must be 0 or at least ${DAY_SECONDS} seconds when using cliffs`,
+    );
+  });
+
+  it('rejects explicit schedules mixed with top-level duration settings', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Mixed Schedules',
+        symbol: 'MIX',
+        tokenURI: 'ipfs://mixed-schedules',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        duration: 180n * BigInt(DAY_SECONDS),
+        recipients: [userAddress],
+        amounts: [parseEther('100000')],
+        schedules: [
+          {
+            duration: 365n * BigInt(DAY_SECONDS),
+            cliffDuration: 90 * DAY_SECONDS,
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+      'Use vesting.schedules instead of top-level duration/cliffDuration when configuring multiple vesting schedules',
+    );
+  });
+
+  it('rejects schedule ids that reference missing schedules', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Missing Schedule',
+        symbol: 'MISS',
+        tokenURI: 'ipfs://missing-schedule',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          {
+            tickLower: 0,
+            tickUpper: 80000,
+            numPositions: 8,
+            shares: WAD,
+          },
+        ],
+      })
+      .withVesting({
+        recipients: [userAddress, secondaryRecipient],
+        amounts: [parseEther('50000'), parseEther('50000')],
+        schedules: [
+          {
+            duration: 180n * BigInt(DAY_SECONDS),
+            cliffDuration: 30 * DAY_SECONDS,
+          },
+        ],
+        scheduleIds: [0, 1],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+      'Vesting scheduleIds[1] references missing schedule 1',
     );
   });
 


### PR DESCRIPTION
## Summary
- add a multi-schedule vesting path to the EVM builders and public vesting types via `schedules` and optional `scheduleIds`
- teach `DopplerFactory` to validate and encode per-beneficiary DERC20 V2 schedule mappings while preserving the existing shared `duration` / `cliffDuration` flow
- extend unit and Base Sepolia fork coverage to prove different beneficiaries can receive different cliffs and vesting durations, and document the new API

## Why
PR #105 added DERC20 V2 cliff vesting support, but the creation API still built exactly one schedule and assigned every beneficiary to `scheduleId = 0`. That meant different addresses could receive different amounts, but not different cliffs or vesting durations.

## Impact
Callers can now create standard-token launches where beneficiaries either:
- share a single vesting schedule
- get one schedule per recipient in order by passing `schedules` only
- reuse schedules across recipients by passing `scheduleIds`

This keeps the existing API working for the common case while exposing the underlying V2 schedule model when a launch needs per-address cliffs or vesting durations.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:unit`
- `pnpm test:solana`
- `TEST_CHAIN=base-sepolia pnpm vitest run --config vitest.fork.config.ts test/evm/fork/base-sepolia/multicurve-cliff-vesting.base-sepolia.test.ts`

## Notes
- `pnpm typecheck:test` still fails on unrelated pre-existing repository-wide test typing issues outside this change, so it was not used as a gating signal for this PR.
- The Base Sepolia fork test now covers both the original shared-cliff path and the new per-beneficiary schedule path.