### PR TITLE
feat: overhaul whitelist auditing and improve contract coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1558,7 +1558,7 @@ pnpm build
 pnpm test
 
 # Run specific test suite
-pnpm test airlock-whitelisting
+pnpm test:whitelisting
 
 # Run tests in watch mode
 pnpm test:watch
@@ -1571,7 +1571,7 @@ pnpm dev
 
 The SDK includes comprehensive tests covering:
 
-- **Airlock Whitelisting**: Verifies that all modules are properly whitelisted on deployed Airlock contracts across all chains
+- **Airlock Whitelisting**: Verifies that all modules are properly whitelisted on Ethereum Mainnet, Monad Mainnet, Base Mainnet, and Base Sepolia
 - **Multicurve Functionality**: Tests multicurve auction creation and quoting
 - **Token Address Mining**: Tests for generating optimized token addresses
 
@@ -1580,12 +1580,23 @@ See [`test/README.md`](./test/README.md) for detailed testing documentation.
 To run whitelisting tests:
 
 ```bash
-# Uses default public RPCs
-pnpm test airlock-whitelisting
+# Canonical whitelist audit
+pnpm test:whitelisting
 
-# Or with Alchemy (faster and more reliable)
-ALCHEMY_API_KEY=your_key_here pnpm test airlock-whitelisting
+# With Alchemy fallback (faster and more reliable)
+ALCHEMY_API_KEY=your_key_here pnpm test:whitelisting
+
+# Limit to specific whitelist-audit chains when needed
+TEST_CHAINS=mainnet,base,base-sepolia,monad-mainnet pnpm test:whitelisting
 ```
+
+The whitelisting suite is scoped to Ethereum Mainnet, Monad Mainnet, Base Mainnet, and Base Sepolia.
+
+Whitelisting test RPC priority is:
+
+1. Chain-specific RPC URL env var (`ETH_MAINNET_RPC_URL`, `BASE_RPC_URL`, `BASE_SEPOLIA_RPC_URL`, `MONAD_MAINNET_RPC_URL`)
+2. `ALCHEMY_API_KEY` fallback for supported Alchemy networks, including Monad Mainnet
+3. Public/default RPC URL
 
 To run fork tests (Anvil):
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:unit": "vitest run --config vitest.unit.config.ts",
     "test:fork": "ANVIL_FORK_ENABLED=true vitest run --config vitest.fork.config.ts",
     "test:live": "LIVE_TEST_ENABLED=true vitest run --config vitest.live.config.ts",
+    "test:whitelisting": "LIVE_TEST_ENABLED=true vitest run --config vitest.live.config.ts test/evm/e2e/whitelisting.test.ts",
     "test:solana": "vitest run --config vitest.solana.config.ts",
     "test:watch": "vitest watch --config vitest.unit.config.ts",
     "test:coverage": "vitest run --coverage --config vitest.unit.config.ts",

--- a/scripts/generate-test-summary.ts
+++ b/scripts/generate-test-summary.ts
@@ -22,18 +22,42 @@ const CHAIN_NAMES: Record<number, string> = {
 // Module name extraction from test titles
 // Order matters: more specific patterns must come before less specific ones
 const MODULE_PATTERNS: [RegExp, string][] = [
+  [
+    /RehypeDopplerHookInitializer.*not whitelisted on Airlock/,
+    'RehypeDopplerHookInitializer on Airlock',
+  ],
+  [
+    /RehypeDopplerHookInitializer.*enabled on DopplerHookInitializer/,
+    'RehypeDopplerHookInitializer on DopplerHookInitializer',
+  ],
+  [
+    /RehypeDopplerHookMigrator.*not whitelisted on Airlock/,
+    'RehypeDopplerHookMigrator on Airlock',
+  ],
+  [
+    /RehypeDopplerHookMigrator.*enabled on DopplerHookMigrator/,
+    'RehypeDopplerHookMigrator on DopplerHookMigrator',
+  ],
   [/TokenFactory/, 'TokenFactory'],
   [/NoOpGovernanceFactory/, 'NoOpGovernanceFactory'],
   [/LaunchpadGovernanceFactory/, 'LaunchpadGovernanceFactory'],
   [/GovernanceFactory/, 'GovernanceFactory'],
-  [/LockableV3Initializer/, 'LockableV3Initializer'],
+  [/DopplerHookInitializer/, 'DopplerHookInitializer'],
+  [
+    /Lockable(?:Uniswap)?V3Initializer/,
+    'LockableUniswapV3Initializer',
+  ],
   [/V4ScheduledMulticurveInitializer/, 'V4ScheduledMulticurveInitializer'],
   [/V4MulticurveInitializer/, 'V4MulticurveInitializer'],
-  [/V3Initializer/, 'V3Initializer'],
-  [/V4Initializer/, 'V4Initializer'],
+  [/V4DecayMulticurveInitializer/, 'V4DecayMulticurveInitializer'],
+  [/(?:Uniswap)?V3Initializer/, 'UniswapV3Initializer'],
+  [/(?:Uniswap)?V4Initializer/, 'UniswapV4Initializer'],
   [/NoOpMigrator/, 'NoOpMigrator'],
-  [/V2Migrator/, 'V2Migrator'],
-  [/V4Migrator/, 'V4Migrator'],
+  [/(?:Uniswap)?V2MigratorSplit/, 'UniswapV2MigratorSplit'],
+  [/(?:Uniswap)?V2Migrator/, 'UniswapV2Migrator'],
+  [/DopplerHookMigrator/, 'DopplerHookMigrator'],
+  [/(?:Uniswap)?V4MigratorSplit/, 'UniswapV4MigratorSplit'],
+  [/(?:Uniswap)?V4Migrator/, 'UniswapV4Migrator'],
 ];
 
 interface VitestJsonResult {

--- a/src/evm/addresses.ts
+++ b/src/evm/addresses.ts
@@ -1,5 +1,6 @@
 import { Address } from 'viem';
 import { GENERATED_DOPPLER_DEPLOYMENTS } from './deployments.generated';
+import { ZERO_ADDRESS } from './constants';
 
 // Chain IDs
 export const CHAIN_IDS = {
@@ -57,7 +58,9 @@ export interface ChainAddresses {
 
   // Migration contracts
   v2Migrator: Address;
+  v2MigratorSplit?: Address;
   v4Migrator: Address;
+  v4MigratorSplit?: Address;
   dopplerHookMigrator?: Address;
   rehypeDopplerHookMigrator?: Address;
   v4MigratorHook?: Address;
@@ -83,9 +86,6 @@ export interface ChainAddresses {
   uniswapV3Factory?: Address;
   uniswapV4Quoter: Address;
 }
-
-// Not yet deployed placeholder
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
 
 function getGeneratedAddress(
   chainId: SupportedChainId,
@@ -122,6 +122,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     ),
     v3Initializer: ZERO_ADDRESS,
     v3Quoter: ZERO_ADDRESS,
+    lockableV3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
+      .LockableUniswapV3Initializer as Address,
     v4Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .UniswapV4Initializer as Address,
     v4ScheduledMulticurveInitializer: GENERATED_DOPPLER_DEPLOYMENTS[
@@ -141,15 +143,20 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     poolManager: '0x000000000004444c5dc75cB358380D2e3dE08A90' as Address,
     v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .UniswapV2Migrator as Address,
+    v2MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
+      .UniswapV2MigratorSplit as Address,
     v4Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .UniswapV4Migrator as Address,
+    v4MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
+      .UniswapV4MigratorSplit as Address,
     dopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .DopplerHookMigrator as Address,
     rehypeDopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .RehypeDopplerHookMigrator as Address,
     noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .NoOpMigrator as Address,
-    governanceFactory: ZERO_ADDRESS,
+    governanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
+      .GovernanceFactory as Address,
     noOpGovernanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .NoOpGovernanceFactory as Address,
     launchpadGovernanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
@@ -257,15 +264,20 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       '0xBDF938149ac6a781F94FAa0ed45E6A0e984c6544' as Address,
     v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .UniswapV2Migrator as Address,
+    v2MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
+      .UniswapV2MigratorSplit as Address,
     v4Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .UniswapV4Migrator as Address,
+    v4MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
+      .UniswapV4MigratorSplit as Address,
     dopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .DopplerHookMigrator as Address,
     rehypeDopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .RehypeDopplerHookMigrator as Address,
     noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .NoOpMigrator as Address,
-    governanceFactory: '0xb4deE32EB70A5E55f3D2d861F49Fb3D79f7a14d9' as Address,
+    governanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
+      .GovernanceFactory as Address,
     noOpGovernanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .NoOpGovernanceFactory as Address,
     launchpadGovernanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
@@ -330,8 +342,12 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     poolManager: '0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408' as Address,
     v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
       .UniswapV2Migrator as Address,
+    v2MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
+      .UniswapV2MigratorSplit as Address,
     v4Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
       .UniswapV4Migrator as Address,
+    v4MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
+      .UniswapV4MigratorSplit as Address,
     dopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
       .DopplerHookMigrator as Address,
     rehypeDopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[
@@ -524,13 +540,22 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     ),
     v3Initializer: ZERO_ADDRESS,
     v3Quoter: '0x66266174564170519409d8853898f065c719536b' as Address,
-    v4Initializer: ZERO_ADDRESS,
+    lockableV3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[
+      CHAIN_IDS.MONAD_MAINNET
+    ].LockableUniswapV3Initializer as Address,
+    v4Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
+      .UniswapV4Initializer as Address,
     dopplerLens: ZERO_ADDRESS,
     dopplerDeployer: ZERO_ADDRESS,
     poolManager: '0x188d586ddcf52439676ca21a244753fa19f9ea8e' as Address,
     v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
       .UniswapV2Migrator as Address,
-    v4Migrator: ZERO_ADDRESS,
+    v2MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
+      .UniswapV2MigratorSplit as Address,
+    v4Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
+      .UniswapV4Migrator as Address,
+    v4MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
+      .UniswapV4MigratorSplit as Address,
     noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
       .NoOpMigrator as Address,
     governanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -1079,7 +1079,9 @@ export interface ModuleAddressOverrides {
 
   // Migrators
   v2Migrator?: Address;
+  v2MigratorSplit?: Address;
   v4Migrator?: Address;
+  v4MigratorSplit?: Address;
   dopplerHookMigrator?: Address;
   rehypeDopplerHookMigrator?: Address;
   noOpMigrator?: Address;

--- a/test/evm/e2e/whitelisting.test.ts
+++ b/test/evm/e2e/whitelisting.test.ts
@@ -1,41 +1,42 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, it, vi } from 'vitest';
 
-// Set shorter timeout for individual tests (10s instead of default 60s)
-vi.setConfig({ testTimeout: 10_000 });
-import { type Address, type Chain } from 'viem';
-import {
-  base,
-  baseSepolia,
-  sepolia,
-  mainnet,
-  ink,
-  unichain,
-  unichainSepolia,
-} from 'viem/chains';
+// Keep unit/local runs snappy, but allow slower live RPC reads.
+vi.setConfig({
+  testTimeout: process.env.LIVE_TEST_ENABLED === 'true' ? 60_000 : 10_000,
+});
+import { type Address } from 'viem';
 import {
   CHAIN_IDS,
   getAddresses,
   airlockAbi,
   type SupportedChainId,
 } from '../../../src/evm';
-import { createRateLimitedClient, delay } from '../utils/rpc';
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
+import { delay } from '../utils/rpc';
+import { getRpcEnvVar, getTestClient, hasRpcUrl } from '../utils/clients';
+import {
+  dopplerHookWhitelistAbi,
+  isConfiguredAddress,
+  MODULE_STATE_NAMES,
+  ModuleState,
+  ZERO_ADDRESS,
+} from '../utils/whitelisting';
 
 // Use more conservative delay for this test file (many sequential RPC calls)
 // Can be overridden via RPC_DELAY_MS env var for workflow_dispatch
 const RPC_DELAY_MS = Number(process.env.RPC_DELAY_MS) || 500;
+
+const WHITELIST_TEST_CHAIN_IDS = [
+  CHAIN_IDS.MAINNET,
+  CHAIN_IDS.MONAD_MAINNET,
+  CHAIN_IDS.BASE,
+  CHAIN_IDS.BASE_SEPOLIA,
+] as const satisfies readonly SupportedChainId[];
 
 // Chain name mapping for TEST_CHAINS env var filtering
 const CHAIN_NAME_TO_ID: Record<string, SupportedChainId> = {
   base: CHAIN_IDS.BASE,
   'base-sepolia': CHAIN_IDS.BASE_SEPOLIA,
   mainnet: CHAIN_IDS.MAINNET,
-  'eth-sepolia': CHAIN_IDS.ETH_SEPOLIA,
-  ink: CHAIN_IDS.INK,
-  unichain: CHAIN_IDS.UNICHAIN,
-  'unichain-sepolia': CHAIN_IDS.UNICHAIN_SEPOLIA,
-  'monad-testnet': CHAIN_IDS.MONAD_TESTNET,
   'monad-mainnet': CHAIN_IDS.MONAD_MAINNET,
 };
 
@@ -43,7 +44,7 @@ const CHAIN_NAME_TO_ID: Record<string, SupportedChainId> = {
 function getTestChainIds(): SupportedChainId[] {
   const testChains = process.env.TEST_CHAINS?.toLowerCase().trim();
   if (!testChains || testChains === 'all') {
-    return Object.values(CHAIN_IDS) as SupportedChainId[];
+    return [...WHITELIST_TEST_CHAIN_IDS];
   }
   const chainNames = testChains.split(',').map((s) => s.trim());
   const chainIds: SupportedChainId[] = [];
@@ -58,22 +59,6 @@ function getTestChainIds(): SupportedChainId[] {
   return chainIds;
 }
 
-enum ModuleState {
-  NotWhitelisted = 0,
-  TokenFactory = 1,
-  GovernanceFactory = 2,
-  PoolInitializer = 3,
-  LiquidityMigrator = 4,
-}
-
-const MODULE_STATE_NAMES: Record<number, string> = {
-  0: 'NotWhitelisted',
-  1: 'TokenFactory',
-  2: 'GovernanceFactory',
-  3: 'PoolInitializer',
-  4: 'LiquidityMigrator',
-};
-
 // Track results for summary
 interface TestResult {
   chain: string;
@@ -81,93 +66,51 @@ interface TestResult {
   module: string;
   address: string;
   status: 'PASS' | 'FAIL' | 'SKIP' | 'RPC_ERROR';
-  expected?: number;
-  actual?: number;
+  expected?: number | string;
+  actual?: number | string;
   error?: string;
 }
 
-const testResults: TestResult[] = [];
+const testResults = new Map<string, TestResult>();
+
+function getTestResultKey(result: Pick<TestResult, 'chainId' | 'module' | 'address'>) {
+  return `${result.chainId}:${result.module}:${result.address}`;
+}
+
+function recordTestResult(result: TestResult) {
+  testResults.set(getTestResultKey(result), { ...result });
+}
 
 // Chain ID to name mapping
 const CHAIN_ID_NAMES: Record<number, string> = {
   1: 'Mainnet',
-  11155111: 'Ethereum Sepolia',
   8453: 'Base',
   84532: 'Base Sepolia',
-  57073: 'Ink',
-  130: 'Unichain',
-  1301: 'Unichain Sepolia',
-  10143: 'Monad Testnet',
   143: 'Monad Mainnet',
 };
 
-const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY;
-const isCi = Boolean(process.env.CI);
-
-const getAlchemyRpc = (network: string) =>
-  ALCHEMY_API_KEY
-    ? `https://${network}.g.alchemy.com/v2/${ALCHEMY_API_KEY}`
-    : undefined;
-
-// Custom chain definition for Monad Testnet
-const monadTestnet: Chain = {
-  id: CHAIN_IDS.MONAD_TESTNET,
-  name: 'Monad Testnet',
-  nativeCurrency: { name: 'MON', symbol: 'MON', decimals: 18 },
-  rpcUrls: {
-    default: { http: ['https://testnet-rpc.monad.xyz'] },
-  },
+type AirlockModuleCase = {
+  title: string;
+  module: string;
+  address?: Address;
+  expectedState: ModuleState;
 };
 
-// Custom chain definition for Monad Mainnet
-const monadMainnet: Chain = {
-  id: CHAIN_IDS.MONAD_MAINNET,
-  name: 'Monad',
-  nativeCurrency: { name: 'MON', symbol: 'MON', decimals: 18 },
-  rpcUrls: {
-    default: { http: ['https://rpc.monad.xyz'] },
-  },
+type DopplerHookCase = {
+  title: string;
+  module: string;
+  hookAddress?: Address;
+  parentAddress?: Address;
 };
 
-const CHAINS: Partial<Record<SupportedChainId, { chain: Chain; rpc?: string }>> =
-  {
-    [CHAIN_IDS.MAINNET]: {
-      chain: mainnet,
-      rpc: getAlchemyRpc('eth-mainnet'),
-    },
-    [CHAIN_IDS.ETH_SEPOLIA]: {
-      chain: sepolia,
-      rpc: getAlchemyRpc('eth-sepolia'),
-    },
-    [CHAIN_IDS.BASE]: {
-      chain: base,
-      rpc: getAlchemyRpc('base-mainnet'),
-    },
-    [CHAIN_IDS.BASE_SEPOLIA]: {
-      chain: baseSepolia,
-      rpc: getAlchemyRpc('base-sepolia'),
-    },
-    [CHAIN_IDS.INK]: {
-      chain: ink,
-      rpc: getAlchemyRpc('ink-mainnet'),
-    },
-    [CHAIN_IDS.UNICHAIN]: {
-      chain: unichain,
-      rpc: getAlchemyRpc('unichain-mainnet'),
-    },
-    [CHAIN_IDS.UNICHAIN_SEPOLIA]: {
-      chain: unichainSepolia,
-      rpc: getAlchemyRpc('unichain-sepolia'),
-    },
-    [CHAIN_IDS.MONAD_TESTNET]: {
-      chain: monadTestnet,
-      rpc: getAlchemyRpc('monad-testnet'),
-    },
-    [CHAIN_IDS.MONAD_MAINNET]: {
-      chain: monadMainnet,
-      rpc: getAlchemyRpc('monad-mainnet'),
-    },
-  };
+function formatExpectation(value: number | string | undefined): string {
+  if (value === undefined) return 'n/a';
+  if (typeof value === 'number') {
+    return `${MODULE_STATE_NAMES[value] || value} (${value})`;
+  }
+  return value;
+}
+
 
 describe('Airlock Module Whitelisting', () => {
   // Use filtered chain IDs from env var (defaults to all)
@@ -175,15 +118,16 @@ describe('Airlock Module Whitelisting', () => {
 
   // Print summary after all tests
   afterAll(() => {
-    const failed = testResults.filter(r => r.status === 'FAIL' || r.status === 'RPC_ERROR');
-    if (failed.length > 0 || testResults.length > 0) {
+    const finalResults = Array.from(testResults.values());
+    const failed = finalResults.filter(r => r.status === 'FAIL' || r.status === 'RPC_ERROR');
+    if (failed.length > 0 || finalResults.length > 0) {
       console.log('\n' + '='.repeat(80));
       console.log('  TEST RESULTS SUMMARY');
       console.log('='.repeat(80));
 
       // Group by chain
       const byChain = new Map<number, TestResult[]>();
-      for (const r of testResults) {
+      for (const r of finalResults) {
         if (!byChain.has(r.chainId)) byChain.set(r.chainId, []);
         byChain.get(r.chainId)!.push(r);
       }
@@ -198,8 +142,8 @@ describe('Airlock Module Whitelisting', () => {
           const icon = r.status === 'PASS' ? '[PASS]' : r.status === 'SKIP' ? '[SKIP]' : '[FAIL]';
           console.log(`    ${icon} ${r.module}: ${r.address}`);
           if (r.status === 'FAIL') {
-            console.log(`           Expected: ${MODULE_STATE_NAMES[r.expected!] || r.expected} (${r.expected})`);
-            console.log(`           Actual:   ${MODULE_STATE_NAMES[r.actual!] || r.actual} (${r.actual})`);
+            console.log(`           Expected: ${formatExpectation(r.expected)}`);
+            console.log(`           Actual:   ${formatExpectation(r.actual)}`);
           } else if (r.status === 'RPC_ERROR') {
             console.log(`           Error: ${r.error}`);
           }
@@ -212,23 +156,21 @@ describe('Airlock Module Whitelisting', () => {
   for (const chainId of supportedChainIds) {
     describe(`Chain ${chainId}`, () => {
       const addresses = getAddresses(chainId);
-      const config = CHAINS[chainId];
-
-      if (!config) {
-        it.skip(`Chain config not defined for chain ${chainId}`);
-        return;
-      }
 
       if (addresses.airlock === ZERO_ADDRESS) {
         it.skip(`Airlock not deployed on chain ${chainId}`);
         return;
       }
 
-      const publicClient = createRateLimitedClient(
-        config.chain,
-        config.rpc,
-        { retryCount: 3, retryDelay: 1000 }
-      );
+      if (!hasRpcUrl(chainId)) {
+        it.skip(`requires ${getRpcEnvVar(chainId)} or ALCHEMY_API_KEY`);
+        return;
+      }
+
+      const publicClient = getTestClient(chainId, {
+        retryCount: 3,
+        retryDelay: 1000,
+      });
 
       // Add delay before each test to avoid rate limiting
       beforeEach(async () => {
@@ -264,140 +206,222 @@ describe('Airlock Module Whitelisting', () => {
 
           if (result.actual !== expectedState) {
             result.status = 'FAIL';
-            testResults.push(result);
+            recordTestResult(result);
             throw new Error(
-              `State=${MODULE_STATE_NAMES[result.actual]}(${result.actual}), expected ${MODULE_STATE_NAMES[expectedState]}(${expectedState}) | ${moduleAddress}`
+              `State=${formatExpectation(result.actual)}, expected ${formatExpectation(expectedState)} | ${moduleAddress}`
             );
           }
 
-          testResults.push(result);
+          recordTestResult(result);
         } catch (err) {
           if (result.status !== 'FAIL') {
             result.status = 'RPC_ERROR';
             result.error = err instanceof Error ? err.message : String(err);
-            testResults.push(result);
+            recordTestResult(result);
           }
           throw err;
         }
       }
 
-      (addresses.tokenFactory === ZERO_ADDRESS ? it.skip : it)(
-        `TokenFactory (${addresses.tokenFactory}) whitelisted`,
-        () => testModule('TokenFactory', addresses.tokenFactory, ModuleState.TokenFactory)
-      );
-
-      (addresses.governanceFactory === ZERO_ADDRESS ? it.skip : it)(
-        `GovernanceFactory (${addresses.governanceFactory}) whitelisted`,
-        () => testModule('GovernanceFactory', addresses.governanceFactory, ModuleState.GovernanceFactory)
-      );
-
-      (addresses.v3Initializer === ZERO_ADDRESS ? it.skip : it)(
-        `V3Initializer (${addresses.v3Initializer}) whitelisted`,
-        () => testModule('V3Initializer', addresses.v3Initializer, ModuleState.PoolInitializer)
-      );
-
-      (addresses.v4Initializer === ZERO_ADDRESS ? it.skip : it)(
-        `V4Initializer (${addresses.v4Initializer}) whitelisted`,
-        () => testModule('V4Initializer', addresses.v4Initializer, ModuleState.PoolInitializer)
-      );
-
-      if (
-        addresses.lockableV3Initializer &&
-        addresses.lockableV3Initializer !== ZERO_ADDRESS
+      async function testDopplerHookEnabled(
+        moduleName: string,
+        hookAddress: Address,
+        parentAddress: Address,
       ) {
-        it(`LockableV3Initializer (${addresses.lockableV3Initializer}) whitelisted`,
-          () => testModule('LockableV3Initializer', addresses.lockableV3Initializer!, ModuleState.PoolInitializer)
+        const result: TestResult = {
+          chain: chainName,
+          chainId,
+          module: moduleName,
+          address: hookAddress,
+          status: 'PASS',
+          expected: 'Enabled (> 0)',
+        };
+
+        try {
+          const flag = await publicClient.readContract({
+            address: parentAddress,
+            abi: dopplerHookWhitelistAbi,
+            functionName: 'isDopplerHookEnabled',
+            args: [hookAddress],
+          });
+
+          result.actual =
+            flag > 0n ? `Enabled (${flag.toString()})` : 'Disabled (0)';
+
+          if (flag <= 0n) {
+            result.status = 'FAIL';
+            recordTestResult(result);
+            throw new Error(
+              `Hook flag=${flag.toString()}, expected a non-zero enabled flag | hook=${hookAddress} parent=${parentAddress}`,
+            );
+          }
+
+          recordTestResult(result);
+        } catch (err) {
+          if (result.status !== 'FAIL') {
+            result.status = 'RPC_ERROR';
+            result.error = err instanceof Error ? err.message : String(err);
+            recordTestResult(result);
+          }
+          throw err;
+        }
+      }
+
+      const airlockModuleCases: AirlockModuleCase[] = [
+        {
+          title: `TokenFactory (${addresses.tokenFactory}) whitelisted`,
+          module: 'TokenFactory',
+          address: addresses.tokenFactory,
+          expectedState: ModuleState.TokenFactory,
+        },
+        {
+          title: `GovernanceFactory (${addresses.governanceFactory}) whitelisted`,
+          module: 'GovernanceFactory',
+          address: addresses.governanceFactory,
+          expectedState: ModuleState.GovernanceFactory,
+        },
+        {
+          title: `UniswapV3Initializer (${addresses.v3Initializer}) whitelisted`,
+          module: 'UniswapV3Initializer',
+          address: addresses.v3Initializer,
+          expectedState: ModuleState.PoolInitializer,
+        },
+        {
+          title: `UniswapV4Initializer (${addresses.v4Initializer}) whitelisted`,
+          module: 'UniswapV4Initializer',
+          address: addresses.v4Initializer,
+          expectedState: ModuleState.PoolInitializer,
+        },
+        {
+          title: `DopplerHookInitializer (${addresses.dopplerHookInitializer}) whitelisted`,
+          module: 'DopplerHookInitializer',
+          address: addresses.dopplerHookInitializer,
+          expectedState: ModuleState.PoolInitializer,
+        },
+        {
+          title: `LockableUniswapV3Initializer (${addresses.lockableV3Initializer}) whitelisted`,
+          module: 'LockableUniswapV3Initializer',
+          address: addresses.lockableV3Initializer,
+          expectedState: ModuleState.PoolInitializer,
+        },
+        {
+          title: `V4MulticurveInitializer (${addresses.v4MulticurveInitializer}) whitelisted`,
+          module: 'V4MulticurveInitializer',
+          address: addresses.v4MulticurveInitializer,
+          expectedState: ModuleState.PoolInitializer,
+        },
+        {
+          title: `V4ScheduledMulticurveInitializer (${addresses.v4ScheduledMulticurveInitializer}) whitelisted`,
+          module: 'V4ScheduledMulticurveInitializer',
+          address: addresses.v4ScheduledMulticurveInitializer,
+          expectedState: ModuleState.PoolInitializer,
+        },
+        {
+          title: `V4DecayMulticurveInitializer (${addresses.v4DecayMulticurveInitializer}) whitelisted`,
+          module: 'V4DecayMulticurveInitializer',
+          address: addresses.v4DecayMulticurveInitializer,
+          expectedState: ModuleState.PoolInitializer,
+        },
+        {
+          title: `UniswapV2Migrator (${addresses.v2Migrator}) whitelisted`,
+          module: 'UniswapV2Migrator',
+          address: addresses.v2Migrator,
+          expectedState: ModuleState.LiquidityMigrator,
+        },
+        {
+          title: `UniswapV2MigratorSplit (${addresses.v2MigratorSplit}) whitelisted`,
+          module: 'UniswapV2MigratorSplit',
+          address: addresses.v2MigratorSplit,
+          expectedState: ModuleState.LiquidityMigrator,
+        },
+        {
+          title: `UniswapV4Migrator (${addresses.v4Migrator}) whitelisted`,
+          module: 'UniswapV4Migrator',
+          address: addresses.v4Migrator,
+          expectedState: ModuleState.LiquidityMigrator,
+        },
+        {
+          title: `UniswapV4MigratorSplit (${addresses.v4MigratorSplit}) whitelisted`,
+          module: 'UniswapV4MigratorSplit',
+          address: addresses.v4MigratorSplit,
+          expectedState: ModuleState.LiquidityMigrator,
+        },
+        {
+          title: `DopplerHookMigrator (${addresses.dopplerHookMigrator}) whitelisted`,
+          module: 'DopplerHookMigrator',
+          address: addresses.dopplerHookMigrator,
+          expectedState: ModuleState.LiquidityMigrator,
+        },
+        {
+          title: `RehypeDopplerHookInitializer (${addresses.rehypeDopplerHookInitializer}) not whitelisted on Airlock`,
+          module: 'RehypeDopplerHookInitializer on Airlock',
+          address: addresses.rehypeDopplerHookInitializer,
+          expectedState: ModuleState.NotWhitelisted,
+        },
+        {
+          title: `RehypeDopplerHookMigrator (${addresses.rehypeDopplerHookMigrator}) not whitelisted on Airlock`,
+          module: 'RehypeDopplerHookMigrator on Airlock',
+          address: addresses.rehypeDopplerHookMigrator,
+          expectedState: ModuleState.NotWhitelisted,
+        },
+        {
+          title: `NoOpMigrator (${addresses.noOpMigrator}) whitelisted`,
+          module: 'NoOpMigrator',
+          address: addresses.noOpMigrator,
+          expectedState: ModuleState.LiquidityMigrator,
+        },
+        {
+          title: `NoOpGovernanceFactory (${addresses.noOpGovernanceFactory}) whitelisted`,
+          module: 'NoOpGovernanceFactory',
+          address: addresses.noOpGovernanceFactory,
+          expectedState: ModuleState.GovernanceFactory,
+        },
+        {
+          title: `LaunchpadGovernanceFactory (${addresses.launchpadGovernanceFactory}) whitelisted`,
+          module: 'LaunchpadGovernanceFactory',
+          address: addresses.launchpadGovernanceFactory,
+          expectedState: ModuleState.GovernanceFactory,
+        },
+      ];
+
+      const dopplerHookCases: DopplerHookCase[] = [
+        {
+          title: `RehypeDopplerHookInitializer (${addresses.rehypeDopplerHookInitializer}) enabled on DopplerHookInitializer (${addresses.dopplerHookInitializer})`,
+          module: 'RehypeDopplerHookInitializer on DopplerHookInitializer',
+          hookAddress: addresses.rehypeDopplerHookInitializer,
+          parentAddress: addresses.dopplerHookInitializer,
+        },
+        {
+          title: `RehypeDopplerHookMigrator (${addresses.rehypeDopplerHookMigrator}) enabled on DopplerHookMigrator (${addresses.dopplerHookMigrator})`,
+          module: 'RehypeDopplerHookMigrator on DopplerHookMigrator',
+          hookAddress: addresses.rehypeDopplerHookMigrator,
+          parentAddress: addresses.dopplerHookMigrator,
+        },
+      ];
+
+      for (const moduleCase of airlockModuleCases) {
+        const shouldRun = isConfiguredAddress(moduleCase.address);
+        const testFn = shouldRun ? it : it.skip;
+        testFn(moduleCase.title, () =>
+          testModule(
+            moduleCase.module,
+            moduleCase.address as Address,
+            moduleCase.expectedState,
+          ),
         );
       }
 
-      if (
-        addresses.v4MulticurveInitializer &&
-        addresses.v4MulticurveInitializer !== ZERO_ADDRESS
-      ) {
-        it(`V4MulticurveInitializer (${addresses.v4MulticurveInitializer}) whitelisted`,
-          () => testModule('V4MulticurveInitializer', addresses.v4MulticurveInitializer!, ModuleState.PoolInitializer)
-        );
-      }
-
-      if (
-        addresses.v4ScheduledMulticurveInitializer &&
-        addresses.v4ScheduledMulticurveInitializer !== ZERO_ADDRESS
-      ) {
-        it(`V4ScheduledMulticurveInitializer (${addresses.v4ScheduledMulticurveInitializer}) whitelisted`,
-          () => testModule('V4ScheduledMulticurveInitializer', addresses.v4ScheduledMulticurveInitializer!, ModuleState.PoolInitializer)
-        );
-      }
-
-      if (
-        addresses.v4DecayMulticurveInitializer &&
-        addresses.v4DecayMulticurveInitializer !== ZERO_ADDRESS
-      ) {
-        it(`V4DecayMulticurveInitializer (${addresses.v4DecayMulticurveInitializer}) whitelisted`,
-          () => testModule('V4DecayMulticurveInitializer', addresses.v4DecayMulticurveInitializer!, ModuleState.PoolInitializer)
-        );
-      }
-
-      (addresses.v2Migrator === ZERO_ADDRESS ? it.skip : it)(
-        `V2Migrator (${addresses.v2Migrator}) whitelisted`,
-        () => testModule('V2Migrator', addresses.v2Migrator, ModuleState.LiquidityMigrator)
-      );
-
-      (addresses.v4Migrator === ZERO_ADDRESS ? it.skip : it)(
-        `V4Migrator (${addresses.v4Migrator}) whitelisted`,
-        () => testModule('V4Migrator', addresses.v4Migrator, ModuleState.LiquidityMigrator)
-      );
-
-      if (
-        addresses.dopplerHookMigrator &&
-        addresses.dopplerHookMigrator !== ZERO_ADDRESS
-      ) {
-        (isCi ? it.skip : it)(
-          `DopplerHookMigrator (${addresses.dopplerHookMigrator}) whitelisted`,
-          () =>
-            testModule(
-              'DopplerHookMigrator',
-              addresses.dopplerHookMigrator!,
-              ModuleState.LiquidityMigrator
-            )
-        );
-      }
-
-      if (
-        addresses.rehypeDopplerHookMigrator &&
-        addresses.rehypeDopplerHookMigrator !== ZERO_ADDRESS
-      ) {
-        (isCi ? it.skip : it)(
-          `RehypeDopplerHookMigrator (${addresses.rehypeDopplerHookMigrator}) whitelisted`,
-          () =>
-            testModule(
-              'RehypeDopplerHookMigrator',
-              addresses.rehypeDopplerHookMigrator!,
-              ModuleState.LiquidityMigrator
-            )
-        );
-      }
-
-      if (addresses.noOpMigrator && addresses.noOpMigrator !== ZERO_ADDRESS) {
-        it(`NoOpMigrator (${addresses.noOpMigrator}) whitelisted`,
-          () => testModule('NoOpMigrator', addresses.noOpMigrator!, ModuleState.LiquidityMigrator)
-        );
-      }
-
-      if (
-        addresses.noOpGovernanceFactory &&
-        addresses.noOpGovernanceFactory !== ZERO_ADDRESS
-      ) {
-        it(`NoOpGovernanceFactory (${addresses.noOpGovernanceFactory}) whitelisted`,
-          () => testModule('NoOpGovernanceFactory', addresses.noOpGovernanceFactory!, ModuleState.GovernanceFactory)
-        );
-      }
-
-      if (
-        addresses.launchpadGovernanceFactory &&
-        addresses.launchpadGovernanceFactory !== ZERO_ADDRESS
-      ) {
-        it(`LaunchpadGovernanceFactory (${addresses.launchpadGovernanceFactory}) whitelisted`,
-          () => testModule('LaunchpadGovernanceFactory', addresses.launchpadGovernanceFactory!, ModuleState.GovernanceFactory)
+      for (const hookCase of dopplerHookCases) {
+        const shouldRun =
+          isConfiguredAddress(hookCase.hookAddress) &&
+          isConfiguredAddress(hookCase.parentAddress);
+        const testFn = shouldRun ? it : it.skip;
+        testFn(hookCase.title, () =>
+          testDopplerHookEnabled(
+            hookCase.module,
+            hookCase.hookAddress as Address,
+            hookCase.parentAddress as Address,
+          ),
         );
       }
     });

--- a/test/evm/fork/base-sepolia/dynamic-auction-rehype-migrator.base-sepolia.test.ts
+++ b/test/evm/fork/base-sepolia/dynamic-auction-rehype-migrator.base-sepolia.test.ts
@@ -14,6 +14,7 @@ import {
   hasRpcUrl,
   isAnvilForkEnabled,
 } from '../../utils';
+import { dopplerHookWhitelistAbi, ModuleState } from '../../utils/whitelisting';
 
 describe('Dynamic auction with RehypeDopplerHookMigrator (Base Sepolia fork)', () => {
   if (!isAnvilForkEnabled()) {
@@ -47,7 +48,8 @@ describe('Dynamic auction with RehypeDopplerHookMigrator (Base Sepolia fork)', (
       const [
         initializerState,
         dopplerHookMigratorState,
-        rehypeHookMigratorState,
+        rehypeHookMigratorAirlockState,
+        rehypeHookMigratorEnabledFlag,
         tokenFactoryState,
         governanceFactoryState,
       ] = await Promise.all([
@@ -70,6 +72,12 @@ describe('Dynamic auction with RehypeDopplerHookMigrator (Base Sepolia fork)', (
           args: [addresses.rehypeDopplerHookMigrator!],
         }),
         publicClient.readContract({
+          address: addresses.dopplerHookMigrator!,
+          abi: dopplerHookWhitelistAbi,
+          functionName: 'isDopplerHookEnabled',
+          args: [addresses.rehypeDopplerHookMigrator!],
+        }),
+        publicClient.readContract({
           address: addresses.airlock,
           abi: airlockAbi,
           functionName: 'getModuleState',
@@ -84,11 +92,12 @@ describe('Dynamic auction with RehypeDopplerHookMigrator (Base Sepolia fork)', (
       ]);
 
       modulesWhitelisted =
-        Number(initializerState) === 3 &&
-        Number(dopplerHookMigratorState) === 4 &&
-        Number(rehypeHookMigratorState) === 4 &&
-        Number(tokenFactoryState) === 1 &&
-        Number(governanceFactoryState) === 2;
+        Number(initializerState) === ModuleState.PoolInitializer &&
+        Number(dopplerHookMigratorState) === ModuleState.LiquidityMigrator &&
+        Number(rehypeHookMigratorAirlockState) === ModuleState.NotWhitelisted &&
+        rehypeHookMigratorEnabledFlag > 0n &&
+        Number(tokenFactoryState) === ModuleState.TokenFactory &&
+        Number(governanceFactoryState) === ModuleState.GovernanceFactory;
     } catch (error) {
       console.error('Failed to check module states:', error);
     }

--- a/test/evm/fork/base-sepolia/multicurve-rehype.base-sepolia.test.ts
+++ b/test/evm/fork/base-sepolia/multicurve-rehype.base-sepolia.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest'
 import { parseEther } from 'viem'
 import { DopplerSDK, getAddresses, CHAIN_IDS, airlockAbi, WAD } from '../../../../src/evm'
 import { getTestClient, hasRpcUrl, getRpcEnvVar } from '../../utils'
+import { dopplerHookWhitelistAbi, ModuleState } from '../../utils/whitelisting'
 
 describe('Multicurve with RehypeDopplerHook (Base Sepolia) test', () => {
   if (!hasRpcUrl(CHAIN_IDS.BASE_SEPOLIA)) {
@@ -17,7 +18,13 @@ describe('Multicurve with RehypeDopplerHook (Base Sepolia) test', () => {
   const REHYPE_DOPPLER_HOOK_ADDRESS =
     addresses.rehypeDopplerHookInitializer as `0x${string}`
 
-  let states: { tokenFactory?: number; governanceFactory?: number; initializer?: number; migrator?: number } = {}
+  let states: {
+    tokenFactory?: number
+    governanceFactory?: number
+    initializer?: number
+    migrator?: number
+    rehypeInitializerAirlock?: number
+  } = {}
   let airlockOwner: `0x${string}` | undefined
   let isRehypeHookEnabled = false
 
@@ -36,14 +43,10 @@ describe('Multicurve with RehypeDopplerHook (Base Sepolia) test', () => {
     } catch (e) {
       console.log('Failed to get airlock owner:', e)
     }
-    const dopplerHookInitializerAbi = [
-      { name: 'isDopplerHookEnabled', type: 'function', stateMutability: 'view', inputs: [{ name: 'dopplerHook', type: 'address' }], outputs: [{ name: '', type: 'uint256' }] }
-    ] as const
-    
     try {
       const hookFlag = await publicClient.readContract({
         address: addresses.dopplerHookInitializer!,
-        abi: dopplerHookInitializerAbi,
+        abi: dopplerHookWhitelistAbi,
         functionName: 'isDopplerHookEnabled',
         args: [REHYPE_DOPPLER_HOOK_ADDRESS],
       })
@@ -61,6 +64,16 @@ describe('Multicurve with RehypeDopplerHook (Base Sepolia) test', () => {
         args: [addresses.dopplerHookInitializer!],
       }) as unknown as number
       states.initializer = Number(initState)
+    } catch {}
+
+    try {
+      const rehypeInitializerAirlockState = await publicClient.readContract({
+        address: addresses.airlock,
+        abi: airlockAbi,
+        functionName: 'getModuleState',
+        args: [REHYPE_DOPPLER_HOOK_ADDRESS],
+      }) as unknown as number
+      states.rehypeInitializerAirlock = Number(rehypeInitializerAirlockState)
     } catch {}
 
     try {
@@ -99,6 +112,8 @@ describe('Multicurve with RehypeDopplerHook (Base Sepolia) test', () => {
     expect(states.governanceFactory).toBe(2)
     expect(states.initializer).toBe(3)
     expect(states.migrator).toBe(4)
+    expect(states.rehypeInitializerAirlock).toBe(ModuleState.NotWhitelisted)
+    expect(isRehypeHookEnabled).toBe(true)
     expect(airlockOwner).toBeDefined()
 
     const builder = sdk
@@ -154,6 +169,8 @@ describe('Multicurve with RehypeDopplerHook (Base Sepolia) test', () => {
     expect(states.governanceFactory).toBe(2)
     expect(states.initializer).toBe(3)
     expect(states.migrator).toBe(4)
+    expect(states.rehypeInitializerAirlock).toBe(ModuleState.NotWhitelisted)
+    expect(isRehypeHookEnabled).toBe(true)
     expect(airlockOwner).toBeDefined()
 
     const BUYBACK_DST = '0x0000000000000000000000000000000000000007' as `0x${string}`

--- a/test/evm/fork/mainnet/multicurve.mainnet.test.ts
+++ b/test/evm/fork/mainnet/multicurve.mainnet.test.ts
@@ -14,7 +14,10 @@ describe('Multicurve (Ethereum Mainnet fork) smoke test', () => {
 
   const chainId = CHAIN_IDS.MAINNET
   const addresses = getAddresses(chainId)
-  const publicClient = getTestClient(chainId)
+  const publicClient = getTestClient(chainId, {
+    retryCount: 1,
+    retryDelay: 250,
+  })
   const sdk = new DopplerSDK({ publicClient, chainId })
 
   const configuredModules: Array<{
@@ -38,8 +41,28 @@ describe('Multicurve (Ethereum Mainnet fork) smoke test', () => {
       expectedState: 3,
     },
     {
+      label: 'DopplerHookInitializer',
+      address: addresses.dopplerHookInitializer,
+      expectedState: 3,
+    },
+    {
+      label: 'LockableUniswapV3Initializer',
+      address: addresses.lockableV3Initializer,
+      expectedState: 3,
+    },
+    {
+      label: 'GovernanceFactory',
+      address: addresses.governanceFactory,
+      expectedState: 2,
+    },
+    {
       label: 'NoOpGovernanceFactory',
       address: addresses.noOpGovernanceFactory,
+      expectedState: 2,
+    },
+    {
+      label: 'LaunchpadGovernanceFactory',
+      address: addresses.launchpadGovernanceFactory,
       expectedState: 2,
     },
     {
@@ -48,8 +71,23 @@ describe('Multicurve (Ethereum Mainnet fork) smoke test', () => {
       expectedState: 4,
     },
     {
+      label: 'UniswapV2MigratorSplit',
+      address: addresses.v2MigratorSplit,
+      expectedState: 4,
+    },
+    {
       label: 'V4Migrator',
       address: addresses.v4Migrator,
+      expectedState: 4,
+    },
+    {
+      label: 'UniswapV4MigratorSplit',
+      address: addresses.v4MigratorSplit,
+      expectedState: 4,
+    },
+    {
+      label: 'DopplerHookMigrator',
+      address: addresses.dopplerHookMigrator,
       expectedState: 4,
     },
     {
@@ -69,24 +107,35 @@ describe('Multicurve (Ethereum Mainnet fork) smoke test', () => {
     expect(addresses.uniswapV4Quoter).not.toBe(ZERO_ADDRESS)
   })
 
-  it('verifies whitelisted module states for configured Ethereum mainnet modules', async () => {
-    for (const module of configuredModules) {
-      if (!module.address || module.address === ZERO_ADDRESS) continue
+  it(
+    'verifies whitelisted module states for configured Ethereum mainnet modules',
+    { timeout: 180_000 },
+    async () => {
+      const activeModules = configuredModules.filter(
+        (module): module is typeof module & { address: Address } =>
+          Boolean(module.address) && module.address !== ZERO_ADDRESS,
+      )
 
-      const state = await publicClient.readContract({
-        address: addresses.airlock,
-        abi: airlockAbi,
-        functionName: 'getModuleState',
-        args: [module.address],
-      })
+      const moduleStates = await Promise.all(
+        activeModules.map(async (module) => ({
+          module,
+          state: await publicClient.readContract({
+            address: addresses.airlock,
+            abi: airlockAbi,
+            functionName: 'getModuleState',
+            args: [module.address],
+          }),
+        })),
+      )
 
-      expect(
-        Number(state),
-        `${module.label} expected state ${module.expectedState}`,
-      ).toBe(module.expectedState)
-      await delay(250)
-    }
-  })
+      for (const { module, state } of moduleStates) {
+        expect(
+          Number(state),
+          `${module.label} expected state ${module.expectedState}`,
+        ).toBe(module.expectedState)
+      }
+    },
+  )
 
   it('defaults multicurve governance to noOp on Ethereum mainnet', () => {
     const params = sdk

--- a/test/evm/setup/fixtures/addresses.ts
+++ b/test/evm/setup/fixtures/addresses.ts
@@ -23,6 +23,9 @@ export const mockAddresses: ChainAddresses = {
   v2Migrator: getAddress(
     '0x5000000000000000000000000000000000000005',
   ) as Address,
+  v2MigratorSplit: getAddress(
+    '0x5000000000000000000000000000000000000027',
+  ) as Address,
   v4Initializer: getAddress(
     '0x7000000000000000000000000000000000000007',
   ) as Address,
@@ -40,6 +43,9 @@ export const mockAddresses: ChainAddresses = {
   ) as Address,
   v4Migrator: getAddress(
     '0x8000000000000000000000000000000000000008',
+  ) as Address,
+  v4MigratorSplit: getAddress(
+    '0x8000000000000000000000000000000000000028',
   ) as Address,
   dopplerHookMigrator: getAddress(
     '0x8100000000000000000000000000000000000008',

--- a/test/evm/setup/vitest.setup.ts
+++ b/test/evm/setup/vitest.setup.ts
@@ -5,22 +5,11 @@
  * This runs before each test file.
  */
 
-import * as dotenv from 'dotenv'
-import { resolve } from 'path'
-import { existsSync } from 'fs'
 import { expect } from 'vitest'
 import { isAddress, isHash } from 'viem'
+import { loadTestEnv } from '../utils/env'
 
-// Load .env files from project root (check multiple common names)
-const projectRoot = resolve(__dirname, '../../..')
-const envFiles = ['.env.local', '.env', '.env.development']
-for (const file of envFiles) {
-  const envPath = resolve(projectRoot, file)
-  if (existsSync(envPath)) {
-    dotenv.config({ path: envPath })
-    break
-  }
-}
+loadTestEnv()
 
 /**
  * Custom matcher: toBeValidAddress

--- a/test/evm/utils/anvil.ts
+++ b/test/evm/utils/anvil.ts
@@ -13,6 +13,9 @@
 
 import { type ChildProcess, spawn } from 'child_process'
 import { CHAIN_IDS } from '../../../src/evm'
+import { loadTestEnv } from './env'
+
+loadTestEnv()
 
 /** Default Anvil mnemonic - generates the same accounts every time */
 export const ANVIL_MNEMONIC =

--- a/test/evm/utils/clients.ts
+++ b/test/evm/utils/clients.ts
@@ -21,7 +21,6 @@ import {
   type WalletClient,
   type TestClient,
   type Account,
-  type Transport,
   defineChain,
   createPublicClient,
   createWalletClient,
@@ -32,13 +31,15 @@ import { base, baseSepolia, mainnet, sepolia } from 'viem/chains'
 import { privateKeyToAccount } from 'viem/accounts'
 import { createRateLimitedClient } from './rpc'
 import { CHAIN_IDS } from '../../../src/evm'
+import { loadTestEnv } from './env'
 import {
   ANVIL_ACCOUNTS,
   getAnvilManager,
   getAnvilPort,
-  isAnvilForkEnabled,
 } from './anvil'
 import { getTestMode, type TestMode } from './testHelpers'
+
+loadTestEnv()
 
 /** Default retry configuration for test clients */
 const DEFAULT_TEST_CLIENT_CONFIG = {
@@ -94,6 +95,7 @@ const CHAIN_CONFIG: Record<number, ChainTestConfig> = {
   [CHAIN_IDS.MONAD_MAINNET]: {
     chain: monadMainnet,
     envVar: 'MONAD_MAINNET_RPC_URL',
+    alchemyNetwork: 'monad-mainnet',
   },
 }
 

--- a/test/evm/utils/env.ts
+++ b/test/evm/utils/env.ts
@@ -1,0 +1,22 @@
+import * as dotenv from 'dotenv'
+import { existsSync } from 'fs'
+import { resolve } from 'path'
+
+let loaded = false
+
+export function loadTestEnv(): void {
+  if (loaded) return
+
+  const projectRoot = resolve(__dirname, '../../..')
+  const envFiles = ['.env.local', '.env', '.env.development']
+
+  for (const file of envFiles) {
+    const envPath = resolve(projectRoot, file)
+    if (existsSync(envPath)) {
+      dotenv.config({ path: envPath })
+      break
+    }
+  }
+
+  loaded = true
+}

--- a/test/evm/utils/whitelisting.ts
+++ b/test/evm/utils/whitelisting.ts
@@ -1,0 +1,34 @@
+import type { Address } from 'viem';
+
+export const ZERO_ADDRESS =
+  '0x0000000000000000000000000000000000000000' as Address;
+
+export enum ModuleState {
+  NotWhitelisted = 0,
+  TokenFactory = 1,
+  GovernanceFactory = 2,
+  PoolInitializer = 3,
+  LiquidityMigrator = 4,
+}
+
+export const MODULE_STATE_NAMES: Record<number, string> = {
+  [ModuleState.NotWhitelisted]: 'NotWhitelisted',
+  [ModuleState.TokenFactory]: 'TokenFactory',
+  [ModuleState.GovernanceFactory]: 'GovernanceFactory',
+  [ModuleState.PoolInitializer]: 'PoolInitializer',
+  [ModuleState.LiquidityMigrator]: 'LiquidityMigrator',
+};
+
+export const dopplerHookWhitelistAbi = [
+  {
+    name: 'isDopplerHookEnabled',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'dopplerHook', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const;
+
+export function isConfiguredAddress(address?: Address): address is Address {
+  return Boolean(address) && address !== ZERO_ADDRESS;
+}


### PR DESCRIPTION
This PR overhauls whitelist auditing so the SDK, live whitelist test, and related fork/unit coverage all reflect the current canonical set of contracts on our target V1 chains (Ethereum, Monad, Base, Base Sepolia). We need the SDK to expose the right canonical addresses and audit whitelist state reliably. It also addresses that `Rehype` doppler hooks are enabled on their respective initializer and migrator contracts, not against `Airlock`. The test path also needed to prefer configured RPCs/Alchemy over public fallbacks so failures reflect real config gaps instead of timeout/rate-limit noise.

- `README.md`
  - documented the new `pnpm test:whitelisting` flow, four-chain whitelist scope, and RPC priority
- `package.json`
  - added `test:whitelisting` so the live whitelist suite has a dedicated entrypoint
- `scripts/generate-test-summary.ts`
  - adjusted the summary parser for the expanded module set and rehype-specific assertions so CI output stays readable
- `src/evm/addresses.ts`
  - filled in canonical module addresses on the target chains, including missing initializer and split-migrator entries
- `src/evm/types.ts`
  - added split migrator override fields
- `test/evm/e2e/whitelisting.test.ts`
  - refactored the whitelist audit into a reusable matrix, scoped it to Ethereum Mainnet/Monad Mainnet/Base Mainnet/Base Sepolia, added parent-hook rehype checks, and improved result reporting
- `test/evm/fork/base-sepolia/dynamic-auction-rehype-migrator.base-sepolia.test.ts`
  - aligned the rehype migrator fork test with the new whitelist model (Airlock negative check plus parent migrator enablement check)
- `test/evm/fork/base-sepolia/multicurve-rehype.base-sepolia.test.ts`
  - aligned the rehype initializer fork test with the same model (not whitelisted on Airlock, but enabled on the parent initializer)
- `test/evm/fork/mainnet/multicurve.mainnet.test.ts`
  - expanded mainnet module coverage and made the live module-state audit complete quickly enough to fail on real state mismatches instead of timing out
- `test/evm/setup/fixtures/addresses.ts`
  - added mock addresses for new governance/split-migrator fields so test fixtures stay in sync with the SDK surface
- `test/evm/setup/vitest.setup.ts`
  - switched setup env loading to the shared helper so test env resolution stays consistent
- `test/evm/utils/anvil.ts`
  - loads shared test env so fork RPC resolution sees configured env vars consistently
- `test/evm/utils/clients.ts`
  - loads shared test env before RPC resolution, adds Monad Mainnet Alchemy fallback, and preserves env RPC -> Alchemy -> public fallback behavior
- `test/evm/utils/env.ts`
  - new shared env loader so plain `pnpm test ...` and mode-specific test runs resolve RPC credentials the same way
- `test/evm/utils/whitelisting.ts`
  - new shared whitelist helpers for module states, zero-address checks, and doppler-hook enablement ABI reuse.