### PR TITLE
feat: add DopplerERC20V1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,67 @@ import { Derc20 } from '@whetstone-research/doppler-sdk/evm';
 const tokenDirect = new Derc20(publicClient, walletClient, tokenAddress);
 ```
 
+### DopplerERC20V1 Tokens
+
+Use the newer DopplerERC20V1 token template by either setting `type: 'dopplerERC20V1'` explicitly or by passing fields such as `maxBalanceLimit` with `balanceLimitEnd`, `controller`, or `excludedFromBalanceLimit`. When selected, the SDK uses the configured `dopplerERC20V1Factory` by default. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. `controller` is optional and defaults to the zero address, set it only if early balance-limit disable should be possible. Standard configs without the specific fields still use the legacy `standard` path, where cliff/allocation vesting routes to legacy DERC20 V2. Keep explicit `type: 'dopplerERC20V1'` when you want its behavior but have no specific fields to infer from.
+
+When balance limiting is enabled on the default DopplerERC20V1 integration, the SDK encodes user exclusions plus determinable protocol recipients for the selected auction path into deployment-time `excludedFromBalanceLimit`, including initializers, hooks, PoolManager, migrators, known migration pools, no-op governance, and launchpad governance multisigs. Custom `withTokenFactory(address)` paths receive only the `excludedFromBalanceLimit` entries supplied in `tokenConfig`, so custom factory users must provide any required deployment-time exclusions themselves. Exclusions cannot be added later through the controller or governance. Default and custom governance timelocks are not precomputed before create, so account for them before deployment or disable strict limits early via the controller when needed.
+
+DopplerERC20V1 supports vesting through `withVesting` while staying on the DopplerERC20V1 factory path: use `duration` with optional `cliffDuration` for a shared schedule, or `allocations` for per-beneficiary schedules.
+
+```typescript
+const params = new StaticAuctionBuilder(base.id)
+  .tokenConfig({
+    name: 'My Doppler Token',
+    symbol: 'MDT',
+    tokenURI: 'ipfs://doppler-token.json',
+    maxBalanceLimit: parseEther('10000'),
+    balanceLimitEnd: Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS,
+    controller: userAddress, // optional; defaults to zero address when omitted
+    excludedFromBalanceLimit: [userAddress], // default DopplerERC20V1 path also adds protocol modules
+  })
+  .saleConfig({
+    initialSupply: parseEther('1000000'),
+    numTokensToSell: parseEther('900000'),
+    numeraire: wethAddress,
+  })
+  .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+  .withVesting({
+    duration: 365n * BigInt(DAY_SECONDS),
+    cliffDuration: 30 * DAY_SECONDS,
+    recipients: [userAddress],
+    amounts: [parseEther('100000')],
+  })
+  .withMigration({ type: 'uniswapV2' })
+  .withUserAddress(userAddress)
+  .build();
+```
+
+DopplerERC20V1 token data includes schedule vesting and balance-limit controls, but it intentionally omits `yearlyMintRate`; DopplerERC20V1 tokens do not expose `mintInflation` or mint-rate update helpers.
+
+```typescript
+const token = sdk.getDopplerERC20V1(tokenAddress);
+const scheduleCount = await token.getVestingScheduleCount();
+
+for (let scheduleId = 0n; scheduleId < scheduleCount; scheduleId++) {
+  const schedule = await token.getVestingSchedule(scheduleId);
+  const available = await token.getAvailableVestedAmountForSchedule(
+    userAddress,
+    scheduleId,
+  );
+  console.log(schedule, available);
+
+  // Release half of the available vested amount for one schedule.
+  if (available > 0n) await token.releaseSchedule(scheduleId, available / 2n);
+}
+
+console.log(await token.getMaxBalanceLimit());
+console.log(await token.getBalanceLimitEnd());
+console.log(await token.isBalanceLimitActive());
+```
+
+For a runnable example, see [examples/doppler-erc20-v1.ts](./examples/doppler-erc20-v1.ts).
+
 ### Governance Delegation (ERC20Votes)
 
 DERC20 extends OpenZeppelin's ERC20Votes. Voting power is tracked via checkpoints and only updates once an address delegates voting power (typically to itself). The SDK exposes simple read/write helpers for delegation.

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -11,7 +11,8 @@ All types referenced are exported from `src/types.ts`.
 ## Common Concepts
 
 - Token specification:
-  - `standard` (default): DERC20 with optional vesting and yearly mint rate
+  - `standard` (default): legacy DERC20 factory path with optional vesting and yearly mint rate
+  - `dopplerERC20V1`: newer DopplerERC20V1 template with schedule vesting and balance-limit settings; selected explicitly with `type: 'dopplerERC20V1'` or automatically when template-specific fields are present
 - Governance is required:
   - Call `withGovernance(...)` in all cases.
   - `withGovernance()` with no arguments applies standard governance defaults.
@@ -36,6 +37,9 @@ Methods (chainable):
 - tokenConfig(params)
   - Standard: `{ name, symbol, tokenURI, yearlyMintRate? }`
     - Defaults: `yearlyMintRate = DEFAULT_V3_YEARLY_MINT_RATE (0.02e18)`
+  - DopplerERC20V1: `{ type?: 'dopplerERC20V1', name, symbol, tokenURI, maxBalanceLimit?, balanceLimitEnd?, controller?, excludedFromBalanceLimit? }`
+    - Uses `dopplerERC20V1Factory` by default when `type: 'dopplerERC20V1'` is explicit or when specific fields (`maxBalanceLimit`, `balanceLimitEnd`, `controller`, `excludedFromBalanceLimit`) are present. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address, so set it only if early balance-limit disable should be possible. Keep explicit `type: 'dopplerERC20V1'` when there are no template-specific fields.
+    - `excludedFromBalanceLimit` is encoded only at deployment. The default DopplerERC20V1 integration adds user-controlled entries plus determinable protocol recipients for the selected auction path, including initializers, hooks, PoolManager, migrators, known migration pools, no-op governance, and launchpad governance multisigs. Custom `withTokenFactory(address)` paths receive only explicitly supplied entries, so custom factory users must provide any required deployment-time exclusions themselves. Exclusions cannot be added later through the controller or governance; default and custom governance timelocks are not precomputed before create.
 - saleConfig({ initialSupply, numTokensToSell, numeraire })
 - Price specification methods (use one, not multiple):
   - **withMarketCapRange({ marketCap, numerairePrice, ... })** ⭐ Recommended
@@ -52,11 +56,11 @@ Methods (chainable):
     - @deprecated: Use `withMarketCapRange()` instead for more intuitive configuration
 - withVesting({ duration?, cliffDuration?, recipients?, amounts?, allocations? } | undefined)
   - Omit to disable vesting. Default duration if provided but undefined is `DEFAULT_V3_VESTING_DURATION`.
-  - `cliffDuration > 0` or `allocations` automatically routes standard tokens through the DERC20 V2 factory (`CloneDERC20VotesV2Factory`).
+  - `cliffDuration > 0` or `allocations` automatically routes standard tokens through the legacy DERC20 V2 factory (`CloneDERC20VotesV2Factory`). With explicit `type: 'dopplerERC20V1'` or template-specific fields, shared schedules using `duration` plus `cliffDuration` and per-beneficiary `allocations` stay on the DopplerERC20V1 factory path.
   - Cliff vesting requires `duration >= 1 day` and `cliffDuration <= duration`.
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
-  - `allocations`: Optional array of `{ recipient, amount, schedule }` entries for per-beneficiary DERC20 V2 vesting. Identical schedules are deduped internally.
+  - `allocations`: Optional array of `{ recipient, amount, schedule }` entries for per-beneficiary schedule vesting. Identical schedules are deduped internally.
 - withGovernance(GovernanceConfig | { useDefaults: true } | { noOp: true } | undefined)
 - withMigration(MigrationConfig)
 - withUserAddress(address)
@@ -171,6 +175,9 @@ Methods (chainable):
 - tokenConfig(params)
   - Standard: `{ name, symbol, tokenURI, yearlyMintRate? }`
     - Defaults: `yearlyMintRate = DEFAULT_V4_YEARLY_MINT_RATE (0.02e18)`
+  - DopplerERC20V1: `{ type?: 'dopplerERC20V1', name, symbol, tokenURI, maxBalanceLimit?, balanceLimitEnd?, controller?, excludedFromBalanceLimit? }`
+    - Uses `dopplerERC20V1Factory` by default when `type: 'dopplerERC20V1'` is explicit or when specific fields (`maxBalanceLimit`, `balanceLimitEnd`, `controller`, `excludedFromBalanceLimit`) are present. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address, so set it only if early balance-limit disable should be possible. Keep explicit `type: 'dopplerERC20V1'` when there are no template-specific fields.
+    - `excludedFromBalanceLimit` is encoded only at deployment. The default DopplerERC20V1 integration adds user-controlled entries plus determinable protocol recipients for the selected auction path, including initializers, hooks, PoolManager, migrators, known migration pools, no-op governance, and launchpad governance multisigs. Custom `withTokenFactory(address)` paths receive only explicitly supplied entries, so custom factory users must provide any required deployment-time exclusions themselves. Exclusions cannot be added later through the controller or governance; default and custom governance timelocks are not precomputed before create.
 - saleConfig({ initialSupply, numTokensToSell, numeraire? })
   - Defaults: `numeraire = ZERO_ADDRESS` (token is paired against ETH)
 - poolConfig({ fee, tickSpacing })
@@ -192,6 +199,7 @@ Methods (chainable):
     - @deprecated: Use `withMarketCapRange()` instead for more intuitive configuration
 - withVesting({ duration?, cliffDuration?, recipients?, amounts?, allocations? } | undefined)
   - Omit to disable vesting. Default duration if provided but undefined is `0` for dynamic auctions.
+  - Standard tokens with `cliffDuration > 0` or `allocations` route through legacy DERC20 V2. With explicit `type: 'dopplerERC20V1'` or template-specific fields, shared schedules using `duration` plus `cliffDuration` and per-beneficiary `allocations` stay on the DopplerERC20V1 factory path.
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
 - withGovernance(GovernanceConfig | { useDefaults: true } | { noOp: true } | undefined)
@@ -265,6 +273,9 @@ Methods (chainable):
 - tokenConfig(params)
   - Standard: `{ name, symbol, tokenURI, yearlyMintRate? }`
     - Defaults: `yearlyMintRate = DEFAULT_V4_YEARLY_MINT_RATE (0.02e18)`
+  - DopplerERC20V1: `{ type?: 'dopplerERC20V1', name, symbol, tokenURI, maxBalanceLimit?, balanceLimitEnd?, controller?, excludedFromBalanceLimit? }`
+    - Uses `dopplerERC20V1Factory` by default when `type: 'dopplerERC20V1'` is explicit or when specific fields (`maxBalanceLimit`, `balanceLimitEnd`, `controller`, `excludedFromBalanceLimit`) are present. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address, so set it only if early balance-limit disable should be possible. Keep explicit `type: 'dopplerERC20V1'` when there are no template-specific fields.
+    - `excludedFromBalanceLimit` is encoded only at deployment. The default DopplerERC20V1 integration adds user-controlled entries plus determinable protocol recipients for the selected auction path, including initializers, hooks, PoolManager, migrators, known migration pools, no-op governance, and launchpad governance multisigs. Custom `withTokenFactory(address)` paths receive only explicitly supplied entries, so custom factory users must provide any required deployment-time exclusions themselves. Exclusions cannot be added later through the controller or governance; default and custom governance timelocks are not precomputed before create.
 - saleConfig({ initialSupply, numTokensToSell, numeraire })
 - Curve configuration methods (use one, not multiple):
   - **withCurves({ numerairePrice, curves, ... })** ⭐ Recommended
@@ -390,6 +401,9 @@ Methods (chainable):
 
 - tokenConfig(params)
   - Standard: `{ name, symbol, tokenURI, yearlyMintRate? }`
+  - DopplerERC20V1: `{ type?: 'dopplerERC20V1', name, symbol, tokenURI, maxBalanceLimit?, balanceLimitEnd?, controller?, excludedFromBalanceLimit? }`
+    - Uses `dopplerERC20V1Factory` by default when `type: 'dopplerERC20V1'` is explicit or when specific fields (`maxBalanceLimit`, `balanceLimitEnd`, `controller`, `excludedFromBalanceLimit`) are present. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address, so set it only if early balance-limit disable should be possible. Keep explicit `type: 'dopplerERC20V1'` when there are no template-specific fields.
+    - `excludedFromBalanceLimit` is encoded only at deployment. The default DopplerERC20V1 integration adds user-controlled entries plus determinable protocol recipients for the selected auction path, including initializers, hooks, PoolManager, migrators, known migration pools, no-op governance, and launchpad governance multisigs. Custom `withTokenFactory(address)` paths receive only explicitly supplied entries, so custom factory users must provide any required deployment-time exclusions themselves. Exclusions cannot be added later through the controller or governance; default and custom governance timelocks are not precomputed before create.
   - Doppler404: `{ type: 'doppler404', name, symbol, baseURI, unit? }`
 - saleConfig({ initialSupply, numTokensToSell, numeraire })
 - openingAuctionConfig({ auctionDuration, minAcceptableTickToken0, minAcceptableTickToken1, incentiveShareBps, tickSpacing, fee, minLiquidity, shareToAuctionBps })

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,6 +60,10 @@ Create a multicurve auction that queues until a future start time using the sche
 
 Create a multicurve auction whose vesting beneficiaries use different cliff and vesting schedules on the DERC20 V2 path. Demonstrates the `allocations` API and reading the assigned schedule data back from `sdk.getDerc20V2(...)`.
 
+### 12b. [DopplerERC20V1 Token Configuration](./doppler-erc20-v1.ts)
+
+Create a `dopplerERC20V1` token selected automatically from template-specific balance-limit fields, enumerate vesting schedules, release a partial vested amount by schedule or across schedules, and read max-balance-limit state. The default DopplerERC20V1 integration adds protocol balance-limit exclusions; custom `withTokenFactory(address)` paths must provide any required exclusions explicitly. This implementation does not configure or expose yearly mint inflation.
+
 ### 13. [Multicurve Vanity Launch (Market Cap)](./multicurve-vanity-by-marketcap.ts)
 
 Create a multicurve pool and mine a salt so the deployed token address ends with a chosen hex suffix (identifier). Launches on-chain (requires RPC + PRIVATE_KEY).

--- a/examples/doppler-erc20-v1.ts
+++ b/examples/doppler-erc20-v1.ts
@@ -1,0 +1,135 @@
+import './env';
+import {
+  DopplerSDK,
+  StaticAuctionBuilder,
+  DAY_SECONDS,
+  getAddresses,
+} from '../src/evm';
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  parseEther,
+  type Address,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { baseSepolia } from 'viem/chains';
+
+const rpcUrl = process.env.BASE_SEPOLIA_RPC_URL ?? process.env.RPC_URL;
+if (!rpcUrl) {
+  throw new Error('Set BASE_SEPOLIA_RPC_URL or RPC_URL');
+}
+
+const privateKey = process.env.PRIVATE_KEY as `0x${string}` | undefined;
+const account = privateKey ? privateKeyToAccount(privateKey) : undefined;
+const publicClient = createPublicClient({
+  chain: baseSepolia,
+  transport: http(rpcUrl),
+});
+const walletClient = account
+  ? createWalletClient({
+      chain: baseSepolia,
+      transport: http(rpcUrl),
+      account,
+    })
+  : undefined;
+
+const sdk = new DopplerSDK({
+  publicClient,
+  walletClient,
+  chainId: baseSepolia.id,
+});
+
+const userAddress = (account?.address ?? process.env.USER_ADDRESS) as
+  | Address
+  | undefined;
+if (!userAddress) {
+  throw new Error('Set PRIVATE_KEY or USER_ADDRESS');
+}
+const resolvedUserAddress: Address = userAddress;
+
+const addresses = getAddresses(baseSepolia.id);
+const params = StaticAuctionBuilder.forChain(baseSepolia.id)
+  .tokenConfig({
+    name: 'Doppler ERC20 V1 Example',
+    symbol: 'DERV1',
+    tokenURI: 'ipfs://example-v1-token',
+    maxBalanceLimit: parseEther('10000'),
+    balanceLimitEnd: Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS,
+    controller: resolvedUserAddress,
+    // User-controlled exclusions; the default DopplerERC20V1 path also adds required protocol modules.
+    excludedFromBalanceLimit: [resolvedUserAddress],
+  })
+  .saleConfig({
+    initialSupply: parseEther('1000000'),
+    numTokensToSell: parseEther('900000'),
+    numeraire: addresses.weth,
+  })
+  .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+  .withVesting({
+    duration: 365n * BigInt(DAY_SECONDS),
+    recipients: [resolvedUserAddress],
+    amounts: [parseEther('100000')],
+  })
+  .withGovernance({ type: 'noOp' })
+  .withMigration({ type: 'uniswapV2' })
+  .withUserAddress(resolvedUserAddress)
+  .build();
+
+const simulation = await sdk.factory.simulateCreateStaticAuction(params);
+console.log('Predicted token:', simulation.asset);
+console.log('Predicted pool:', simulation.pool);
+console.log('Template-specific fields selected dopplerERC20V1 automatically.');
+
+if (process.env.EXECUTE === '1') {
+  if (!walletClient) {
+    throw new Error('Set PRIVATE_KEY to broadcast');
+  }
+  const created = await simulation.execute();
+  console.log('Created token:', created.tokenAddress);
+  console.log('Create tx:', created.transactionHash);
+}
+
+const tokenAddress = (process.env.TOKEN_ADDRESS ?? simulation.asset) as Address;
+const token = sdk.getDopplerERC20V1(tokenAddress);
+const scheduleCount = await token.getVestingScheduleCount();
+console.log('Vesting schedules:', scheduleCount.toString());
+
+for (let scheduleId = 0n; scheduleId < scheduleCount; scheduleId++) {
+  const schedule = await token.getVestingSchedule(scheduleId);
+  const vesting = await token.getVestingDataForSchedule(
+    resolvedUserAddress,
+    scheduleId,
+  );
+  const available = await token.getAvailableVestedAmountForSchedule(
+    resolvedUserAddress,
+    scheduleId,
+  );
+  console.log('Schedule', scheduleId.toString(), {
+    cliffDuration: schedule.cliffDuration.toString(),
+    duration: schedule.duration.toString(),
+    totalAmount: vesting.totalAmount.toString(),
+    releasedAmount: vesting.releasedAmount.toString(),
+    available: available.toString(),
+  });
+
+  if (process.env.RELEASE_SCHEDULE_ID === scheduleId.toString()) {
+    await token.releaseSchedule(scheduleId, available / 2n);
+  }
+}
+
+const totalAvailable =
+  await token.getAvailableVestedAmount(resolvedUserAddress);
+console.log('Total releasable across schedules:', totalAvailable.toString());
+
+console.log(
+  'Max balance limit:',
+  (await token.getMaxBalanceLimit()).toString(),
+);
+console.log('Balance limit end:', await token.getBalanceLimitEnd());
+console.log('Balance limit active:', await token.isBalanceLimitActive());
+console.log('Controller:', await token.getController());
+console.log(
+  'User excluded from balance limit:',
+  await token.isExcludedFromBalanceLimit(resolvedUserAddress),
+);

--- a/src/evm/DopplerSDK.ts
+++ b/src/evm/DopplerSDK.ts
@@ -21,7 +21,7 @@ import {
   OpeningAuctionPositionManager,
 } from './entities/auction';
 import { Quoter } from './entities/quoter';
-import { Derc20, Derc20V2 } from './entities/token';
+import { Derc20, Derc20V2, DopplerERC20V1 } from './entities/token';
 import {
   StaticAuctionBuilder,
   DynamicAuctionBuilder,
@@ -228,6 +228,18 @@ export class DopplerSDK<C extends SupportedChainId = SupportedChainId> {
    */
   getDerc20V2(tokenAddress: Address): Derc20V2 {
     return new Derc20V2(this.publicClient, this.walletClient, tokenAddress);
+  }
+
+  /**
+   * Get a DopplerERC20V1 token instance for schedule vesting and balance-limit controls.
+   * @param tokenAddress The address of the DopplerERC20V1 token
+   */
+  getDopplerERC20V1(tokenAddress: Address): DopplerERC20V1 {
+    return new DopplerERC20V1(
+      this.publicClient,
+      this.walletClient,
+      tokenAddress,
+    );
   }
 
   /**

--- a/src/evm/abis/index.ts
+++ b/src/evm/abis/index.ts
@@ -737,6 +737,13 @@ export const derc20V2Abi = [
   {
     type: 'function',
     name: 'computeAvailableVestedAmount',
+    inputs: [{ name: 'beneficiary', type: 'address', internalType: 'address' }],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'computeAvailableVestedAmount',
     inputs: [
       { name: 'beneficiary', type: 'address', internalType: 'address' },
       { name: 'scheduleId', type: 'uint256', internalType: 'uint256' },
@@ -811,6 +818,1586 @@ export const derc20V2Abi = [
       { name: 'duration', type: 'uint64', internalType: 'uint64' },
     ],
     stateMutability: 'view',
+  },
+] as const;
+
+export const dopplerERC20V1Abi = [
+  {
+    type: 'constructor',
+    inputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'CLOCK_MODE',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'DOMAIN_SEPARATOR',
+    inputs: [],
+    outputs: [
+      {
+        name: 'result',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'allowance',
+    inputs: [
+      {
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'spender',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'result',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'approve',
+    inputs: [
+      {
+        name: 'spender',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'balanceLimitEnd',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint48',
+        internalType: 'uint48',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'balanceOf',
+    inputs: [
+      {
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'result',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'burn',
+    inputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'cancelOwnershipHandover',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'checkpointAt',
+    inputs: [
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'i',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: 'checkpointClock',
+        type: 'uint48',
+        internalType: 'uint48',
+      },
+      {
+        name: 'checkpointValue',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'checkpointCount',
+    inputs: [
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'result',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'clock',
+    inputs: [],
+    outputs: [
+      {
+        name: 'result',
+        type: 'uint48',
+        internalType: 'uint48',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'completeOwnershipHandover',
+    inputs: [
+      {
+        name: 'pendingOwner',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'computeAvailableVestedAmount',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'computeAvailableVestedAmount',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'total',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'controller',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'decimals',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'delegate',
+    inputs: [
+      {
+        name: 'delegatee',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'delegateBySig',
+    inputs: [
+      {
+        name: 'delegatee',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'nonce',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'expiry',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'v',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
+      {
+        name: 'r',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 's',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'delegates',
+    inputs: [
+      {
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'result',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'disableBalanceLimit',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'getPastVotes',
+    inputs: [
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'timepoint',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getPastVotesTotalSupply',
+    inputs: [
+      {
+        name: 'timepoint',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getScheduleIdsOf',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getVotes',
+    inputs: [
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getVotesTotalSupply',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'initialize',
+    inputs: [
+      {
+        name: 'name_',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'symbol_',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'initialSupply',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'recipient',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'owner_',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'schedules',
+        type: 'tuple[]',
+        internalType: 'struct VestingSchedule[]',
+        components: [
+          {
+            name: 'cliff',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+          {
+            name: 'duration',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+        ],
+      },
+      {
+        name: 'beneficiaries',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
+      {
+        name: 'scheduleIds',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      {
+        name: 'amounts',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      {
+        name: 'tokenURI_',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'maxBalanceLimit_',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'balanceLimitEnd_',
+        type: 'uint48',
+        internalType: 'uint48',
+      },
+      {
+        name: 'controller_',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'excludedFromBalanceLimit',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'isBalanceLimitActive',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'isExcludedFromBalanceLimit',
+    inputs: [
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'excluded',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'isPoolLocked',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'lockPool',
+    inputs: [
+      {
+        name: 'pool_',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'maxBalanceLimit',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'name',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'nonces',
+    inputs: [
+      {
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'result',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'owner',
+    inputs: [],
+    outputs: [
+      {
+        name: 'result',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'ownershipHandoverExpiresAt',
+    inputs: [
+      {
+        name: 'pendingOwner',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'result',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'permit',
+    inputs: [
+      {
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'spender',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'deadline',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'v',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
+      {
+        name: 'r',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 's',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'pool',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'release',
+    inputs: [
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'release',
+    inputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'releaseFor',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'releaseFor',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'renounceOwnership',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'requestOwnershipHandover',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'symbol',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'tokenURI',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'totalAllocatedOf',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'totalSupply',
+    inputs: [],
+    outputs: [
+      {
+        name: 'result',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'transfer',
+    inputs: [
+      {
+        name: 'to',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'transferFrom',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'transferOwnership',
+    inputs: [
+      {
+        name: 'newOwner',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'unlockPool',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'updateTokenURI',
+    inputs: [
+      {
+        name: 'tokenURI_',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'vestedTotalAmount',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'vestingOf',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: 'totalAmount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'releasedAmount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'vestingScheduleCount',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'vestingSchedules',
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: 'cliff',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'duration',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'vestingStart',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'event',
+    name: 'Approval',
+    inputs: [
+      {
+        name: 'owner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'spender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'BalanceLimitDisabled',
+    inputs: [
+      {
+        name: 'expired',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'DelegateChanged',
+    inputs: [
+      {
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'DelegateVotesChanged',
+    inputs: [
+      {
+        name: 'delegate',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'oldValue',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'newValue',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'Initialized',
+    inputs: [
+      {
+        name: 'version',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'OwnershipHandoverCanceled',
+    inputs: [
+      {
+        name: 'pendingOwner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'OwnershipHandoverRequested',
+    inputs: [
+      {
+        name: 'pendingOwner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'OwnershipTransferred',
+    inputs: [
+      {
+        name: 'oldOwner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'newOwner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'TokensReleased',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'Transfer',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'UpdateTokenURI',
+    inputs: [
+      {
+        name: 'tokenURI',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'VestingAllocated',
+    inputs: [
+      {
+        name: 'beneficiary',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'VestingScheduleCreated',
+    inputs: [
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
+        name: 'cliff',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
+      {
+        name: 'duration',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'error',
+    name: 'AllowanceOverflow',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AllowanceUnderflow',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AlreadyInitialized',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ArrayLengthsMismatch',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'BalanceLimitExceeded',
+    inputs: [
+      {
+        name: 'balance',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'limit',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'BalanceLimitNotActive',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ERC5805CheckpointIndexOutOfBounds',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ERC5805CheckpointValueOverflow',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ERC5805CheckpointValueUnderflow',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ERC5805DelegateInvalidSignature',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ERC5805DelegateSignatureExpired',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ERC5805FutureLookup',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InsufficientAllowance',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InsufficientBalance',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InsufficientReleasableAmount',
+    inputs: [
+      {
+        name: 'available',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'requested',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'InvalidAllocation',
+    inputs: [
+      {
+        name: 'index',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'InvalidBalanceLimit',
+    inputs: [
+      {
+        name: 'limit',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'InvalidBalanceLimitTimestamp',
+    inputs: [
+      {
+        name: 'specified',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'current',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'InvalidInitialization',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InvalidPermit',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InvalidSchedule',
+    inputs: [
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'MaxPreMintPerAddressExceeded',
+    inputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'limit',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'MaxTotalPreMintExceeded',
+    inputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'limit',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'MaxTotalVestedExceeded',
+    inputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'limit',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'NewOwnerIsZeroAddress',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'NoHandoverRequest',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'NoReleasableAmount',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'NotInitializing',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Permit2AllowanceIsFixedAtInfinity',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'PermitExpired',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'PoolAlreadyLocked',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'PoolAlreadyUnlocked',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'PoolLocked',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'TotalSupplyOverflow',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Unauthorized',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'UnknownScheduleId',
+    inputs: [
+      {
+        name: 'scheduleId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
   },
 ] as const;
 

--- a/src/evm/addresses.ts
+++ b/src/evm/addresses.ts
@@ -27,6 +27,8 @@ export interface ChainAddresses {
   tokenFactory: Address;
   derc20V2Factory?: Address;
   derc20V2Implementation?: Address;
+  dopplerERC20V1Factory?: Address;
+  dopplerERC20V1Implementation?: Address;
 
   // Static auction contracts (V3)
   v3Initializer: Address;
@@ -119,6 +121,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     derc20V2Implementation: getGeneratedAddress(
       CHAIN_IDS.MAINNET,
       'CloneDERC20VotesV2',
+    ),
+    dopplerERC20V1Factory: getGeneratedAddress(
+      CHAIN_IDS.MAINNET,
+      'DopplerERC20V1Factory',
+    ),
+    dopplerERC20V1Implementation: getGeneratedAddress(
+      CHAIN_IDS.MAINNET,
+      'DopplerERC20V1',
     ),
     v3Initializer: ZERO_ADDRESS,
     v3Quoter: ZERO_ADDRESS,
@@ -235,6 +245,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       CHAIN_IDS.BASE,
       'CloneDERC20VotesV2',
     ),
+    dopplerERC20V1Factory: getGeneratedAddress(
+      CHAIN_IDS.BASE,
+      'DopplerERC20V1Factory',
+    ),
+    dopplerERC20V1Implementation: getGeneratedAddress(
+      CHAIN_IDS.BASE,
+      'DopplerERC20V1',
+    ),
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .UniswapV3Initializer as Address,
     v3Quoter: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a' as Address,
@@ -286,9 +304,11 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .StreamableFeesLocker as Address,
     universalRouter: '0x6ff5693b99212da76ad316178a184ab56d299b43' as Address,
     univ2Router02: '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24' as Address,
+    uniswapV2Factory: '0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6' as Address,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address,
     bundler: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE].Bundler as Address,
     weth: '0x4200000000000000000000000000000000000006' as Address,
+    uniswapV3Factory: '0x33128a8fC17869897dcE68Ed026d694621f6FDfD' as Address,
     uniswapV4Quoter: '0x0d5e0f971ed27fbff6c2837bf31316121532048d' as Address,
   },
   [CHAIN_IDS.BASE_SEPOLIA]: {
@@ -303,6 +323,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     derc20V2Implementation: getGeneratedAddress(
       CHAIN_IDS.BASE_SEPOLIA,
       'CloneDERC20VotesV2',
+    ),
+    dopplerERC20V1Factory: getGeneratedAddress(
+      CHAIN_IDS.BASE_SEPOLIA,
+      'DopplerERC20V1Factory',
+    ),
+    dopplerERC20V1Implementation: getGeneratedAddress(
+      CHAIN_IDS.BASE_SEPOLIA,
+      'DopplerERC20V1',
     ),
     doppler404Factory: '0xdd8cea2890f1b3498436f19ec8da8fecc2cb7af7' as Address,
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
@@ -368,9 +396,11 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .StreamableFeesLocker as Address,
     universalRouter: '0x492E6456D9528771018DeB9E87ef7750EF184104' as Address,
     univ2Router02: '0x1689E7B1F10000AE47eBfE339a4f69dECd19F602' as Address,
+    uniswapV2Factory: '0x7Ae58f10f7849cA6F5fB71b7f45CB416c9204b1e' as Address,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address,
     bundler: '0x69DB7c20cDdA49Bed2bFb21e16Fa218330C50661' as Address,
     weth: '0x4200000000000000000000000000000000000006' as Address,
+    uniswapV3Factory: '0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24' as Address,
     uniswapV4Quoter: '0x4A6513c898fe1B2d0E78d3b0e0A4a151589B1cBa' as Address,
   },
   [CHAIN_IDS.INK]: {
@@ -440,6 +470,7 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     streamableFeesLocker: ZERO_ADDRESS, // Not yet deployed
     universalRouter: '0xef740bf23acae26f6492b10de645d6b98dc8eaf3' as Address,
     univ2Router02: '0x284f11109359a7e1306c3e447ef14d38400063ff' as Address,
+    uniswapV2Factory: '0x1f98400000000000000000000000000000000002' as Address,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address,
     bundler: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.UNICHAIN]
       .Bundler as Address,
@@ -538,6 +569,14 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       CHAIN_IDS.MONAD_MAINNET,
       'CloneDERC20VotesV2',
     ),
+    dopplerERC20V1Factory: getGeneratedAddress(
+      CHAIN_IDS.MONAD_MAINNET,
+      'DopplerERC20V1Factory',
+    ),
+    dopplerERC20V1Implementation: getGeneratedAddress(
+      CHAIN_IDS.MONAD_MAINNET,
+      'DopplerERC20V1',
+    ),
     v3Initializer: ZERO_ADDRESS,
     v3Quoter: '0x66266174564170519409d8853898f065c719536b' as Address,
     lockableV3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[
@@ -581,6 +620,7 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     streamableFeesLocker: ZERO_ADDRESS, // Not yet deployed
     universalRouter: '0x0d97dc33264bfc1c226207428a79b26757fb9dc3' as Address,
     univ2Router02: ZERO_ADDRESS,
+    uniswapV2Factory: '0x182a927119d56008d921126764bf884221b10f59' as Address,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address,
     bundler: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
       .Bundler as Address,

--- a/src/evm/builders/DynamicAuctionBuilder.ts
+++ b/src/evm/builders/DynamicAuctionBuilder.ts
@@ -28,6 +28,7 @@ import {
 import { type SupportedChainId } from '../addresses';
 import {
   computeTicks,
+  normalizeBuilderTokenConfig,
   normalizeBuilderVestingSchedule,
   type BaseAuctionBuilder,
   type BuilderVestingInput,
@@ -77,40 +78,11 @@ export class DynamicAuctionBuilder<
     return new DynamicAuctionBuilder(chainId);
   }
 
-  tokenConfig(
-    params:
-      | {
-          type?: 'standard';
-          name: string;
-          symbol: string;
-          tokenURI: string;
-          yearlyMintRate?: bigint;
-        }
-      | {
-          type: 'doppler404';
-          name: string;
-          symbol: string;
-          baseURI: string;
-          unit?: bigint;
-        },
-  ): this {
-    if (params && 'type' in params && params.type === 'doppler404') {
-      this.token = {
-        type: 'doppler404',
-        name: params.name,
-        symbol: params.symbol,
-        baseURI: params.baseURI,
-        unit: params.unit,
-      };
-    } else {
-      this.token = {
-        type: 'standard',
-        name: params.name,
-        symbol: params.symbol,
-        tokenURI: params.tokenURI,
-        yearlyMintRate: params.yearlyMintRate ?? DEFAULT_V4_YEARLY_MINT_RATE,
-      };
-    }
+  tokenConfig(params: TokenConfig): this {
+    this.token = normalizeBuilderTokenConfig(
+      params,
+      DEFAULT_V4_YEARLY_MINT_RATE,
+    );
     return this;
   }
 

--- a/src/evm/builders/MulticurveBuilder.ts
+++ b/src/evm/builders/MulticurveBuilder.ts
@@ -35,6 +35,7 @@ import {
   type BuilderVestingInput,
   type MarketCapPresetOverrides,
   buildCurvesFromPresets,
+  normalizeBuilderTokenConfig,
   normalizeBuilderVestingSchedule,
 } from './shared';
 
@@ -85,40 +86,11 @@ export class MulticurveBuilder<
     return new MulticurveBuilder(chainId);
   }
 
-  tokenConfig(
-    params:
-      | {
-          type?: 'standard';
-          name: string;
-          symbol: string;
-          tokenURI: string;
-          yearlyMintRate?: bigint;
-        }
-      | {
-          type: 'doppler404';
-          name: string;
-          symbol: string;
-          baseURI: string;
-          unit?: bigint;
-        },
-  ): this {
-    if (params && 'type' in params && params.type === 'doppler404') {
-      this.token = {
-        type: 'doppler404',
-        name: params.name,
-        symbol: params.symbol,
-        baseURI: params.baseURI,
-        unit: params.unit,
-      };
-    } else {
-      this.token = {
-        type: 'standard',
-        name: params.name,
-        symbol: params.symbol,
-        tokenURI: params.tokenURI,
-        yearlyMintRate: params.yearlyMintRate ?? DEFAULT_V3_YEARLY_MINT_RATE,
-      };
-    }
+  tokenConfig(params: TokenConfig): this {
+    this.token = normalizeBuilderTokenConfig(
+      params,
+      DEFAULT_V3_YEARLY_MINT_RATE,
+    );
     return this;
   }
 

--- a/src/evm/builders/OpeningAuctionBuilder.ts
+++ b/src/evm/builders/OpeningAuctionBuilder.ts
@@ -24,6 +24,7 @@ import {
 } from '../types';
 import { type SupportedChainId } from '../addresses';
 import {
+  normalizeBuilderTokenConfig,
   normalizeBuilderVestingSchedule,
   type BaseAuctionBuilder,
   type BuilderVestingInput,
@@ -123,40 +124,11 @@ export class OpeningAuctionBuilder<
     return new OpeningAuctionBuilder(chainId);
   }
 
-  tokenConfig(
-    params:
-      | {
-          type?: 'standard';
-          name: string;
-          symbol: string;
-          tokenURI: string;
-          yearlyMintRate?: bigint;
-        }
-      | {
-          type: 'doppler404';
-          name: string;
-          symbol: string;
-          baseURI: string;
-          unit?: bigint;
-        },
-  ): this {
-    if (params && 'type' in params && params.type === 'doppler404') {
-      this.token = {
-        type: 'doppler404',
-        name: params.name,
-        symbol: params.symbol,
-        baseURI: params.baseURI,
-        unit: params.unit,
-      };
-    } else {
-      this.token = {
-        type: 'standard',
-        name: params.name,
-        symbol: params.symbol,
-        tokenURI: params.tokenURI,
-        yearlyMintRate: params.yearlyMintRate ?? DEFAULT_V4_YEARLY_MINT_RATE,
-      };
-    }
+  tokenConfig(params: TokenConfig): this {
+    this.token = normalizeBuilderTokenConfig(
+      params,
+      DEFAULT_V4_YEARLY_MINT_RATE,
+    );
     return this;
   }
 

--- a/src/evm/builders/StaticAuctionBuilder.ts
+++ b/src/evm/builders/StaticAuctionBuilder.ts
@@ -30,6 +30,7 @@ import {
 import { type SupportedChainId } from '../addresses';
 import {
   computeTicks,
+  normalizeBuilderTokenConfig,
   normalizeBuilderVestingSchedule,
   type BaseAuctionBuilder,
   type BuilderVestingInput,
@@ -72,40 +73,11 @@ export class StaticAuctionBuilder<
     return new StaticAuctionBuilder(chainId);
   }
 
-  tokenConfig(
-    params:
-      | {
-          type?: 'standard';
-          name: string;
-          symbol: string;
-          tokenURI: string;
-          yearlyMintRate?: bigint;
-        }
-      | {
-          type: 'doppler404';
-          name: string;
-          symbol: string;
-          baseURI: string;
-          unit?: bigint;
-        },
-  ): this {
-    if (params && 'type' in params && params.type === 'doppler404') {
-      this.token = {
-        type: 'doppler404',
-        name: params.name,
-        symbol: params.symbol,
-        baseURI: params.baseURI,
-        unit: params.unit,
-      };
-    } else {
-      this.token = {
-        type: 'standard',
-        name: params.name,
-        symbol: params.symbol,
-        tokenURI: params.tokenURI,
-        yearlyMintRate: params.yearlyMintRate ?? DEFAULT_V3_YEARLY_MINT_RATE,
-      };
-    }
+  tokenConfig(params: TokenConfig): this {
+    this.token = normalizeBuilderTokenConfig(
+      params,
+      DEFAULT_V3_YEARLY_MINT_RATE,
+    );
     return this;
   }
 

--- a/src/evm/builders/shared.ts
+++ b/src/evm/builders/shared.ts
@@ -10,11 +10,15 @@ import {
 } from '../constants';
 import { MAX_TICK, MIN_TICK } from '../utils';
 import type {
+  Doppler404TokenConfig,
+  DopplerERC20V1TokenConfig,
   PriceRange,
   TickRange,
   MulticurveMarketCapPreset,
   GovernanceOption,
   MigrationConfig,
+  StandardTokenConfig,
+  TokenConfig,
 } from '../types';
 import type { SupportedChainId } from '../addresses';
 
@@ -45,6 +49,64 @@ export type BuilderVestingInput =
       allocations: BuilderVestingAllocationInput[];
     };
 
+export function hasDopplerERC20V1OnlyTokenConfigFields(
+  params: object,
+): boolean {
+  return (
+    'maxBalanceLimit' in params ||
+    'balanceLimitEnd' in params ||
+    'controller' in params ||
+    'excludedFromBalanceLimit' in params
+  );
+}
+
+export function isDopplerERC20V1TokenConfig(
+  params: TokenConfig,
+): params is DopplerERC20V1TokenConfig {
+  return (
+    params.type === 'dopplerERC20V1' ||
+    hasDopplerERC20V1OnlyTokenConfigFields(params)
+  );
+}
+
+export function normalizeBuilderTokenConfig(
+  params: TokenConfig,
+  defaultYearlyMintRate: bigint,
+): TokenConfig {
+  if (isDopplerERC20V1TokenConfig(params)) {
+    return {
+      type: 'dopplerERC20V1',
+      name: params.name,
+      symbol: params.symbol,
+      tokenURI: params.tokenURI,
+      maxBalanceLimit: params.maxBalanceLimit,
+      balanceLimitEnd: params.balanceLimitEnd,
+      controller: params.controller,
+      excludedFromBalanceLimit: params.excludedFromBalanceLimit,
+    };
+  }
+
+  if (params.type === 'doppler404') {
+    const token = params as Doppler404TokenConfig;
+    return {
+      type: 'doppler404',
+      name: token.name,
+      symbol: token.symbol,
+      baseURI: token.baseURI,
+      unit: token.unit,
+    };
+  }
+
+  const token = params as StandardTokenConfig;
+  return {
+    type: 'standard',
+    name: token.name,
+    symbol: token.symbol,
+    tokenURI: token.tokenURI,
+    yearlyMintRate: token.yearlyMintRate ?? defaultYearlyMintRate,
+  };
+}
+
 // ============================================================================
 // Common Builder Interface
 // ============================================================================
@@ -63,25 +125,9 @@ export interface BaseAuctionBuilder<C extends SupportedChainId> {
 
   /**
    * Configure the token to be created.
-   * Supports standard ERC20 or Doppler404 token types.
+   * Supports standard ERC20, DopplerERC20V1, or Doppler404 token types.
    */
-  tokenConfig(
-    params:
-      | {
-          type?: 'standard';
-          name: string;
-          symbol: string;
-          tokenURI: string;
-          yearlyMintRate?: bigint;
-        }
-      | {
-          type: 'doppler404';
-          name: string;
-          symbol: string;
-          baseURI: string;
-          unit?: bigint;
-        },
-  ): this;
+  tokenConfig(params: TokenConfig): this;
 
   /**
    * Configure the token sale parameters.

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -23,6 +23,8 @@ import type {
   SupportedPublicClient,
   TokenConfig,
   Doppler404TokenConfig,
+  DopplerERC20V1TokenConfig,
+  InferredDopplerERC20V1TokenConfig,
   StandardTokenConfig,
   SaleConfig,
   VestingConfig,
@@ -36,12 +38,15 @@ import type {
   OpeningAuctionState,
   OpeningAuctionCreateResult,
   OpeningAuctionCompleteResult,
+  GovernanceOption,
 } from '../types';
+import { hasDopplerERC20V1OnlyTokenConfigFields } from '../builders/shared';
 import { RehypeFeeRoutingMode } from '../types';
 import type { ModuleAddressOverrides } from '../types';
 import { getAddresses } from '../addresses';
 import {
   ZERO_ADDRESS,
+  DEAD_ADDRESS,
   WAD,
   DEFAULT_PD_SLUGS,
   FLAG_MASK,
@@ -93,9 +98,14 @@ export type MigrationEncoder = (config: MigrationConfig) => Hex;
 
 const MAX_UINT128 = (1n << 128n) - 1n;
 const MAX_PROCEEDS_SPLIT_SHARE = WAD / 2n;
+const DERC20_V1_MAX_PREMINT_WAD = (WAD * 8n) / 10n;
 const ONE_MILLION = 1_000_000n;
 // Auto-mined completion can race with on-chain state changes; keep retries bounded.
 const MAX_COMPLETION_ATTEMPTS = 3;
+const UNISWAP_V2_PAIR_INIT_CODE_HASH =
+  '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' as const;
+const UNISWAP_V3_POOL_INIT_CODE_HASH =
+  '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54' as const;
 
 const erc20BalanceOfAbi = [
   {
@@ -136,6 +146,11 @@ type NormalizedRehypeHookConfig = {
 };
 
 type StandardTokenFactoryMode = 'legacy' | 'v2';
+type TokenFactoryVariant =
+  | 'standard'
+  | 'standard-v2'
+  | 'dopplerERC20V1'
+  | 'doppler404';
 
 type LegacyStandardTokenFactoryData = {
   kind: 'legacy';
@@ -174,8 +189,25 @@ type StandardTokenFactoryData =
   | LegacyStandardTokenFactoryData
   | V2StandardTokenFactoryData;
 
+type DopplerERC20V1TokenFactoryData = {
+  kind: 'dopplerERC20V1';
+  name: string;
+  symbol: string;
+  schedules: V2VestingSchedule[];
+  beneficiaries: Address[];
+  scheduleIds: bigint[];
+  amounts: bigint[];
+  tokenURI: string;
+  maxBalanceLimit: bigint;
+  balanceLimitEnd: number;
+  controller: Address;
+  excludedFromBalanceLimit: Address[];
+  implementation: Address;
+};
+
 const DERC20_V2_MIN_VESTING_DURATION = 24 * 60 * 60;
 const MAX_UINT64 = (1n << 64n) - 1n;
+const MAX_UINT48 = (1n << 48n) - 1n;
 
 export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
   private publicClient: SupportedPublicClient;
@@ -242,6 +274,91 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     };
   }
 
+  private validateDopplerERC20V1TokenFactoryData(args: {
+    sale: SaleConfig;
+    recipients: Address[];
+    amounts: bigint[];
+    schedules: V2VestingSchedule[];
+    scheduleIds: bigint[];
+  }): void {
+    if (
+      args.recipients.length !== args.amounts.length ||
+      args.recipients.length !== args.scheduleIds.length
+    ) {
+      throw new Error(
+        'token.vesting allocations, amounts, and scheduleIds arrays must ' +
+          'have the same length',
+      );
+    }
+
+    for (const [index, schedule] of args.schedules.entries()) {
+      if (
+        (schedule.duration !== 0n &&
+          schedule.duration < BigInt(DERC20_V2_MIN_VESTING_DURATION)) ||
+        schedule.cliff > schedule.duration
+      ) {
+        throw new Error(
+          `token.vesting schedules[${index}] must have duration 0 or ` +
+            `at least ${DERC20_V2_MIN_VESTING_DURATION} seconds, with cliff ` +
+            `less than or equal to duration`,
+        );
+      }
+    }
+
+    const premintCap =
+      (args.sale.initialSupply * DERC20_V1_MAX_PREMINT_WAD) / WAD;
+    const allocatedTotals = new Map<string, bigint>();
+    let totalVested = 0n;
+
+    for (const [index, beneficiary] of args.recipients.entries()) {
+      const amount = args.amounts[index];
+      const scheduleId = args.scheduleIds[index];
+
+      if (beneficiary === ZERO_ADDRESS) {
+        throw new Error(
+          `token.vesting allocations[${index}].beneficiary must not be the ` +
+            'zero address',
+        );
+      }
+
+      if (amount <= 0n) {
+        throw new Error(
+          `token.vesting allocations[${index}].amount must be greater than ` +
+            '0',
+        );
+      }
+
+      if (scheduleId >= BigInt(args.schedules.length)) {
+        throw new Error(
+          `token.vesting allocations[${index}].scheduleId must reference ` +
+            'an existing schedule',
+        );
+      }
+
+      const beneficiaryKey = beneficiary.toLowerCase();
+      const totalAllocated =
+        (allocatedTotals.get(beneficiaryKey) ?? 0n) + amount;
+      allocatedTotals.set(beneficiaryKey, totalAllocated);
+
+      if (totalAllocated > premintCap) {
+        throw new Error(
+          `token.vesting allocations[${index}] exceed the per-beneficiary ` +
+            'premint cap',
+        );
+      }
+
+      totalVested += amount;
+    }
+
+    if (totalVested > premintCap) {
+      throw new Error('token.vesting allocations exceed the total premint cap');
+    }
+
+    if (totalVested > args.sale.initialSupply) {
+      throw new Error('token.vesting allocations exceed sale.initialSupply');
+    }
+  }
+
   private validateUint64LikeNumber(
     value: number,
     fieldPath: string,
@@ -263,6 +380,277 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     if (BigInt(value) > MAX_UINT64) {
       throw new Error(`${fieldPath} must fit in uint64`);
     }
+  }
+
+  private validateUint48LikeNumber(value: number, fieldPath: string): void {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      throw new Error(`${fieldPath} must be a finite integer`);
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`${fieldPath} must be a safe integer`);
+    }
+    if (value < 0) {
+      throw new Error(`${fieldPath} cannot be negative`);
+    }
+    if (BigInt(value) > MAX_UINT48) {
+      throw new Error(`${fieldPath} must fit in uint48`);
+    }
+  }
+
+  private resolveDopplerERC20V1TokenFactoryData(args: {
+    token: DopplerERC20V1TokenConfig | InferredDopplerERC20V1TokenConfig;
+    sale: SaleConfig;
+    vesting?: VestingConfig;
+    userAddress: Address;
+    addresses: ReturnType<typeof getAddresses>;
+    modules?: ModuleAddressOverrides;
+    protocolBalanceLimitExclusions?: (Address | undefined)[];
+  }): DopplerERC20V1TokenFactoryData {
+    const implementation = args.addresses.dopplerERC20V1Implementation;
+    if (!implementation || implementation === ZERO_ADDRESS) {
+      throw new Error(
+        'DopplerERC20V1 implementation address not configured for this chain.',
+      );
+    }
+
+    const maxBalanceLimit = args.token.maxBalanceLimit ?? 0n;
+    const balanceLimitEnd = args.token.balanceLimitEnd ?? 0;
+    this.validateUint48LikeNumber(balanceLimitEnd, 'token.balanceLimitEnd');
+
+    const balanceLimitEnabled = maxBalanceLimit > 0n || balanceLimitEnd > 0;
+    if (
+      balanceLimitEnabled &&
+      (maxBalanceLimit === 0n || balanceLimitEnd === 0)
+    ) {
+      throw new Error(
+        'token.maxBalanceLimit and token.balanceLimitEnd must both be set when balance limiting is enabled',
+      );
+    }
+
+    if (balanceLimitEnabled && maxBalanceLimit >= args.sale.initialSupply) {
+      throw new Error(
+        'token.maxBalanceLimit must be below sale.initialSupply when balance limiting is enabled',
+      );
+    }
+
+    if (
+      balanceLimitEnabled &&
+      balanceLimitEnd <= Math.floor(Date.now() / 1000)
+    ) {
+      throw new Error(
+        'token.balanceLimitEnd must be in the future when balance limiting is enabled',
+      );
+    }
+
+    const { recipients, amounts } = this.resolveVestingAllocations(args);
+    const { schedules, scheduleIds } = this.resolveV2VestingSchedules({
+      vesting: args.vesting,
+      recipientCount: recipients.length,
+    });
+
+    this.validateDopplerERC20V1TokenFactoryData({
+      sale: args.sale,
+      recipients,
+      amounts,
+      schedules,
+      scheduleIds,
+    });
+
+    return {
+      kind: 'dopplerERC20V1',
+      name: args.token.name,
+      symbol: args.token.symbol,
+      schedules,
+      beneficiaries: recipients,
+      scheduleIds,
+      amounts,
+      tokenURI: args.token.tokenURI,
+      maxBalanceLimit,
+      balanceLimitEnd,
+      controller: args.token.controller ?? ZERO_ADDRESS,
+      excludedFromBalanceLimit: this.mergeDopplerERC20V1BalanceLimitExclusions(
+        args.token.excludedFromBalanceLimit,
+        balanceLimitEnabled ? args.protocolBalanceLimitExclusions : undefined,
+      ),
+      implementation,
+    };
+  }
+
+  private isDopplerERC20V1BalanceLimitActive(
+    tokenFactoryData: Pick<
+      DopplerERC20V1TokenFactoryData,
+      'maxBalanceLimit' | 'balanceLimitEnd'
+    >,
+  ): boolean {
+    return (
+      tokenFactoryData.maxBalanceLimit > 0n ||
+      tokenFactoryData.balanceLimitEnd > 0
+    );
+  }
+
+  private usesDefaultDopplerERC20V1Integration(
+    modules?: ModuleAddressOverrides,
+  ): boolean {
+    return !modules?.tokenFactory && !modules?.dopplerERC20V1Factory;
+  }
+
+  private resolveGovernanceBalanceLimitExclusions(
+    governance: GovernanceOption<C>,
+  ): Address[] {
+    if (governance.type === 'noOp') {
+      return [DEAD_ADDRESS];
+    }
+    if (governance.type === 'launchpad') {
+      return [governance.multisig];
+    }
+    return [];
+  }
+
+  private withDopplerERC20V1BalanceLimitExclusions(
+    tokenFactoryData: DopplerERC20V1TokenFactoryData,
+    exclusions: readonly (Address | undefined)[],
+  ): DopplerERC20V1TokenFactoryData {
+    if (!this.isDopplerERC20V1BalanceLimitActive(tokenFactoryData)) {
+      return { ...tokenFactoryData };
+    }
+
+    return {
+      ...tokenFactoryData,
+      excludedFromBalanceLimit: this.mergeDopplerERC20V1BalanceLimitExclusions(
+        tokenFactoryData.excludedFromBalanceLimit,
+        exclusions,
+      ),
+    };
+  }
+
+  private deriveCreate2Address(args: {
+    deployer: Address;
+    salt: Hex;
+    initCodeHash: Hash;
+  }): Address {
+    const hash = keccak256(
+      `0xff${args.deployer.slice(2)}${args.salt.slice(2)}${args.initCodeHash.slice(
+        2,
+      )}` as Hex,
+    );
+    return getAddress(`0x${hash.slice(-40)}`) as Address;
+  }
+
+  private predictDopplerERC20V1TokenAddress(args: {
+    tokenFactory: Address;
+    salt: Hex;
+    implementation: Address;
+  }): Address {
+    return this.deriveCreate2Address({
+      deployer: args.tokenFactory,
+      salt: args.salt,
+      initCodeHash: this.computeSoladyCloneInitCodeHash(args.implementation),
+    });
+  }
+
+  private computeUniswapV2PairAddress(args: {
+    factory: Address;
+    tokenA: Address;
+    tokenB: Address;
+  }): Address {
+    const [token0, token1] =
+      BigInt(args.tokenA) < BigInt(args.tokenB)
+        ? [args.tokenA, args.tokenB]
+        : [args.tokenB, args.tokenA];
+    const salt = keccak256(
+      encodePacked(['address', 'address'], [token0, token1]),
+    );
+    return this.deriveCreate2Address({
+      deployer: args.factory,
+      salt,
+      initCodeHash: UNISWAP_V2_PAIR_INIT_CODE_HASH,
+    });
+  }
+
+  private computeUniswapV3PoolAddress(args: {
+    factory: Address;
+    tokenA: Address;
+    tokenB: Address;
+    fee: number;
+  }): Address {
+    const [token0, token1] =
+      BigInt(args.tokenA) < BigInt(args.tokenB)
+        ? [args.tokenA, args.tokenB]
+        : [args.tokenB, args.tokenA];
+    const salt = keccak256(
+      encodeAbiParameters(
+        [{ type: 'address' }, { type: 'address' }, { type: 'uint24' }],
+        [token0, token1, args.fee],
+      ),
+    );
+    return this.deriveCreate2Address({
+      deployer: args.factory,
+      salt,
+      initCodeHash: UNISWAP_V3_POOL_INIT_CODE_HASH,
+    });
+  }
+
+  private resolveStaticV3PoolExclusion(args: {
+    addresses: ReturnType<typeof getAddresses>;
+    tokenAddress: Address;
+    numeraire: Address;
+    fee: number;
+  }): Address | undefined {
+    if (!args.addresses.uniswapV3Factory) {
+      return undefined;
+    }
+
+    return this.computeUniswapV3PoolAddress({
+      factory: args.addresses.uniswapV3Factory,
+      tokenA: args.tokenAddress,
+      tokenB: args.numeraire,
+      fee: args.fee,
+    });
+  }
+
+  private resolveUniswapV2MigrationPairExclusion(args: {
+    migration: MigrationConfig;
+    addresses: ReturnType<typeof getAddresses>;
+    tokenAddress: Address;
+    numeraire: Address;
+  }): Address | undefined {
+    if (
+      args.migration.type !== 'uniswapV2' ||
+      !args.addresses.uniswapV2Factory
+    ) {
+      return undefined;
+    }
+
+    return this.computeUniswapV2PairAddress({
+      factory: args.addresses.uniswapV2Factory,
+      tokenA: args.tokenAddress,
+      tokenB: args.numeraire,
+    });
+  }
+
+  private mergeDopplerERC20V1BalanceLimitExclusions(
+    userExclusions: readonly Address[] | undefined,
+    protocolExclusions: readonly (Address | undefined)[] | undefined,
+  ): Address[] {
+    const exclusions: Address[] = [];
+    const seen = new Set<string>();
+
+    for (const address of [
+      ...(userExclusions ?? []),
+      ...(protocolExclusions ?? []),
+    ]) {
+      if (!address || address === ZERO_ADDRESS) {
+        continue;
+      }
+      const key = address.toLowerCase();
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      exclusions.push(address);
+    }
+
+    return exclusions;
   }
 
   private resolveV2VestingSchedules(args: {
@@ -336,6 +724,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
   }): void {
     if (
       this.isDoppler404Token(args.token) ||
+      this.isDopplerERC20V1Token(args.token) ||
       !this.usesDerc20V2Vesting(args.vesting)
     ) {
       return;
@@ -471,6 +860,48 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         tokenFactoryData.recipients,
         tokenFactoryData.amounts,
         tokenFactoryData.tokenURI,
+      ],
+    );
+  }
+
+  private encodeDopplerERC20V1TokenFactoryData(
+    tokenFactoryData: DopplerERC20V1TokenFactoryData,
+  ): Hex {
+    return encodeAbiParameters(
+      [
+        { type: 'string' },
+        { type: 'string' },
+        {
+          type: 'tuple[]',
+          components: [
+            { type: 'uint64', name: 'cliff' },
+            { type: 'uint64', name: 'duration' },
+          ],
+        },
+        { type: 'address[]' },
+        { type: 'uint256[]' },
+        { type: 'uint256[]' },
+        { type: 'string' },
+        { type: 'uint256' },
+        { type: 'uint48' },
+        { type: 'address' },
+        { type: 'address[]' },
+      ],
+      [
+        tokenFactoryData.name,
+        tokenFactoryData.symbol,
+        tokenFactoryData.schedules.map((schedule) => ({
+          cliff: schedule.cliff,
+          duration: schedule.duration,
+        })),
+        tokenFactoryData.beneficiaries,
+        tokenFactoryData.scheduleIds,
+        tokenFactoryData.amounts,
+        tokenFactoryData.tokenURI,
+        tokenFactoryData.maxBalanceLimit,
+        tokenFactoryData.balanceLimitEnd,
+        tokenFactoryData.controller,
+        tokenFactoryData.excludedFromBalanceLimit,
       ],
     );
   }
@@ -648,9 +1079,12 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       params.modules?.tokenFactory ??
       (this.isDoppler404Token(params.token)
         ? (addresses.doppler404Factory as Address | undefined)
-        : this.usesDerc20V2Vesting(params.vesting)
-          ? addresses.derc20V2Factory
-          : addresses.tokenFactory);
+        : this.isDopplerERC20V1Token(params.token)
+          ? (params.modules?.dopplerERC20V1Factory ??
+            addresses.dopplerERC20V1Factory)
+          : this.usesDerc20V2Vesting(params.vesting)
+            ? addresses.derc20V2Factory
+            : addresses.tokenFactory);
 
     if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
       throw new Error(
@@ -664,8 +1098,30 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       addresses,
     });
 
+    const poolInitializerAddress: Address = (() => {
+      if (hasBeneficiaries) {
+        const lockableInitializer =
+          params.modules?.lockableV3Initializer ??
+          addresses.lockableV3Initializer;
+        if (!lockableInitializer) {
+          throw new Error(
+            'Lockable V3 initializer address not configured on this chain. Required when using beneficiaries.',
+          );
+        }
+        return lockableInitializer;
+      }
+      return params.modules?.v3Initializer ?? addresses.v3Initializer;
+    })();
+    const liquidityMigratorAddress = this.getMigratorAddress(
+      params.migration,
+      params.modules,
+    );
+    const includeProtocolBalanceLimitExclusions =
+      this.usesDefaultDopplerERC20V1Integration(params.modules);
+
     // 3. Encode token parameters (standard vs Doppler404)
-    let tokenFactoryData: Hex;
+    let tokenFactoryData: Hex | undefined = undefined;
+    let v1TokenFactoryData: DopplerERC20V1TokenFactoryData | undefined;
     if (this.isDoppler404Token(params.token)) {
       const token404 = params.token;
       const baseURI = token404.baseURI;
@@ -679,6 +1135,29 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         ],
         [params.token.name, params.token.symbol, baseURI, unit],
       );
+    } else if (this.isDopplerERC20V1Token(params.token)) {
+      v1TokenFactoryData = this.resolveDopplerERC20V1TokenFactoryData({
+        token: params.token,
+        sale: params.sale,
+        vesting: params.vesting,
+        userAddress: params.userAddress,
+        addresses,
+        modules: params.modules,
+        protocolBalanceLimitExclusions: includeProtocolBalanceLimitExclusions
+          ? [
+              poolInitializerAddress,
+              liquidityMigratorAddress,
+              params.migration.type === 'uniswapV4'
+                ? (params.modules?.poolManager ?? addresses.poolManager)
+                : undefined,
+              ...this.resolveGovernanceBalanceLimitExclusions(
+                params.governance,
+              ),
+            ]
+          : undefined,
+      });
+      tokenFactoryData =
+        this.encodeDopplerERC20V1TokenFactoryData(v1TokenFactoryData);
     } else {
       const standardTokenFactoryData = this.buildStandardTokenFactoryData({
         token: params.token as StandardTokenConfig,
@@ -763,6 +1242,10 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       return resolved;
     })();
 
+    if (!tokenFactoryData) {
+      throw new Error('Token factory data could not be resolved.');
+    }
+
     // 5. Generate a unique salt
     // Build the base CreateParams for the V3-style ABI; salt will be mined below
     const baseCreateParams = {
@@ -773,25 +1256,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       tokenFactoryData: tokenFactoryData,
       governanceFactory: governanceFactoryAddress,
       governanceFactoryData: governanceFactoryData,
-      poolInitializer: (() => {
-        if (hasBeneficiaries) {
-          const lockableInitializer =
-            params.modules?.lockableV3Initializer ??
-            addresses.lockableV3Initializer;
-          if (!lockableInitializer) {
-            throw new Error(
-              'Lockable V3 initializer address not configured on this chain. Required when using beneficiaries.',
-            );
-          }
-          return lockableInitializer;
-        }
-        return params.modules?.v3Initializer ?? addresses.v3Initializer;
-      })(),
+      poolInitializer: poolInitializerAddress,
       poolInitializerData: poolInitializerData,
-      liquidityMigrator: this.getMigratorAddress(
-        params.migration,
-        params.modules,
-      ),
+      liquidityMigrator: liquidityMigratorAddress,
       liquidityMigratorData: liquidityMigratorData,
       integrator: params.integrator ?? ZERO_ADDRESS,
     };
@@ -800,6 +1267,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       params,
       baseCreateParams,
       addresses,
+      v1TokenFactoryData,
+      includeProtocolBalanceLimitExclusions,
     });
 
     return minedCreateParams;
@@ -1050,6 +1519,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     params: CreateStaticAuctionParams<C>;
     baseCreateParams: Omit<CreateParams, 'salt'>;
     addresses: ReturnType<typeof getAddresses>;
+    v1TokenFactoryData?: DopplerERC20V1TokenFactoryData;
+    includeProtocolBalanceLimitExclusions?: boolean;
   }): Promise<CreateParams> {
     const { params, baseCreateParams, addresses } = args;
 
@@ -1069,7 +1540,41 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     let salt = this.generateRandomSalt(params.userAddress);
 
     while (attempt < maxAttempts) {
-      const createParams = { ...baseCreateParams, salt } as CreateParams;
+      let createParams = { ...baseCreateParams, salt } as CreateParams;
+
+      if (
+        args.v1TokenFactoryData &&
+        args.includeProtocolBalanceLimitExclusions &&
+        this.isDopplerERC20V1BalanceLimitActive(args.v1TokenFactoryData)
+      ) {
+        const tokenAddress = this.predictDopplerERC20V1TokenAddress({
+          tokenFactory: baseCreateParams.tokenFactory,
+          salt,
+          implementation: args.v1TokenFactoryData.implementation,
+        });
+        const tokenFactoryData = this.withDopplerERC20V1BalanceLimitExclusions(
+          args.v1TokenFactoryData,
+          [
+            this.resolveStaticV3PoolExclusion({
+              addresses,
+              tokenAddress,
+              numeraire: params.sale.numeraire,
+              fee: params.pool.fee,
+            }),
+            this.resolveUniswapV2MigrationPairExclusion({
+              migration: params.migration,
+              addresses,
+              tokenAddress,
+              numeraire: params.sale.numeraire,
+            }),
+          ],
+        );
+        createParams = {
+          ...createParams,
+          tokenFactoryData:
+            this.encodeDopplerERC20V1TokenFactoryData(tokenFactoryData),
+        };
+      }
 
       const { result } = await (
         this.publicClient as PublicClient
@@ -1181,9 +1686,12 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       params.modules?.tokenFactory ??
       (this.isDoppler404Token(params.token)
         ? (addresses.doppler404Factory as Address | undefined)
-        : this.usesDerc20V2Vesting(params.vesting)
-          ? addresses.derc20V2Factory
-          : addresses.tokenFactory);
+        : this.isDopplerERC20V1Token(params.token)
+          ? (params.modules?.dopplerERC20V1Factory ??
+            addresses.dopplerERC20V1Factory)
+          : this.usesDerc20V2Vesting(params.vesting)
+            ? addresses.derc20V2Factory
+            : addresses.tokenFactory);
 
     if (!resolvedTokenFactoryDyn || resolvedTokenFactoryDyn === ZERO_ADDRESS) {
       throw new Error(
@@ -1197,6 +1705,15 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       addresses,
     });
 
+    const poolInitializerAddress =
+      params.modules?.v4Initializer ?? addresses.v4Initializer;
+    const liquidityMigratorAddress = this.getMigratorAddress(
+      params.migration,
+      params.modules,
+    );
+    const includeProtocolBalanceLimitExclusions =
+      this.usesDefaultDopplerERC20V1Integration(params.modules);
+
     const tokenFactoryData = this.isDoppler404Token(params.token)
       ? (() => {
           const t = params.token as Doppler404TokenConfig;
@@ -1207,15 +1724,35 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
             unit: t.unit !== undefined ? BigInt(t.unit) : 1000n,
           };
         })()
-      : this.buildStandardTokenFactoryData({
-          token: params.token as StandardTokenConfig,
-          sale: params.sale,
-          vesting: params.vesting,
-          userAddress: params.userAddress,
-          airlock: params.modules?.airlock ?? addresses.airlock,
-          tokenFactory: resolvedTokenFactoryDyn,
-          addresses,
-        });
+      : this.isDopplerERC20V1Token(params.token)
+        ? this.resolveDopplerERC20V1TokenFactoryData({
+            token: params.token,
+            sale: params.sale,
+            vesting: params.vesting,
+            userAddress: params.userAddress,
+            addresses,
+            modules: params.modules,
+            protocolBalanceLimitExclusions:
+              includeProtocolBalanceLimitExclusions
+                ? [
+                    poolInitializerAddress,
+                    params.modules?.poolManager ?? addresses.poolManager,
+                    liquidityMigratorAddress,
+                    ...this.resolveGovernanceBalanceLimitExclusions(
+                      params.governance,
+                    ),
+                  ]
+                : undefined,
+          })
+        : this.buildStandardTokenFactoryData({
+            token: params.token as StandardTokenConfig,
+            sale: params.sale,
+            vesting: params.vesting,
+            userAddress: params.userAddress,
+            airlock: params.modules?.airlock ?? addresses.airlock,
+            tokenFactory: resolvedTokenFactoryDyn,
+            addresses,
+          });
 
     // 5. Mine hook address with appropriate flags
 
@@ -1234,11 +1771,16 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       numeraire: params.sale.numeraire,
       tokenFactory: resolvedTokenFactoryDyn,
       tokenFactoryData: tokenFactoryData,
-      poolInitializer: params.modules?.v4Initializer ?? addresses.v4Initializer,
+      poolInitializer: poolInitializerAddress,
       poolInitializerData: dopplerData,
       tokenVariant: this.isDoppler404Token(params.token)
         ? 'doppler404'
-        : 'standard',
+        : this.isDopplerERC20V1Token(params.token)
+          ? 'dopplerERC20V1'
+          : 'standard',
+      migration: params.migration,
+      addresses,
+      includeProtocolBalanceLimitExclusions,
     });
 
     // 6. Encode migration data
@@ -1325,12 +1867,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       tokenFactoryData: encodedTokenFactoryData,
       governanceFactory: governanceFactoryAddress,
       governanceFactoryData: governanceFactoryData,
-      poolInitializer: params.modules?.v4Initializer ?? addresses.v4Initializer,
+      poolInitializer: poolInitializerAddress,
       poolInitializerData: poolInitializerData,
-      liquidityMigrator: this.getMigratorAddress(
-        params.migration,
-        params.modules,
-      ),
+      liquidityMigrator: liquidityMigratorAddress,
       liquidityMigratorData: liquidityMigratorData,
       integrator: params.integrator ?? ZERO_ADDRESS,
       salt: salt,
@@ -1672,9 +2211,12 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       params.modules?.tokenFactory ??
       (this.isDoppler404Token(params.token)
         ? (addresses.doppler404Factory as Address | undefined)
-        : this.usesDerc20V2Vesting(params.vesting)
-          ? addresses.derc20V2Factory
-          : addresses.tokenFactory);
+        : this.isDopplerERC20V1Token(params.token)
+          ? (params.modules?.dopplerERC20V1Factory ??
+            addresses.dopplerERC20V1Factory)
+          : this.usesDerc20V2Vesting(params.vesting)
+            ? addresses.derc20V2Factory
+            : addresses.tokenFactory);
 
     if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
       throw new Error(
@@ -1688,6 +2230,13 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       addresses,
     });
 
+    const liquidityMigratorAddress = this.getMigratorAddress(
+      params.migration,
+      params.modules,
+    );
+    const includeProtocolBalanceLimitExclusions =
+      this.usesDefaultDopplerERC20V1Integration(params.modules);
+
     const tokenFactoryData = this.isDoppler404Token(params.token)
       ? (() => {
           const t = params.token as Doppler404TokenConfig;
@@ -1698,15 +2247,36 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
             unit: t.unit !== undefined ? BigInt(t.unit) : 1000n,
           };
         })()
-      : this.buildStandardTokenFactoryData({
-          token: params.token as StandardTokenConfig,
-          sale: params.sale,
-          vesting: params.vesting,
-          userAddress: params.userAddress,
-          airlock: params.modules?.airlock ?? addresses.airlock,
-          tokenFactory: resolvedTokenFactory,
-          addresses,
-        });
+      : this.isDopplerERC20V1Token(params.token)
+        ? this.resolveDopplerERC20V1TokenFactoryData({
+            token: params.token,
+            sale: params.sale,
+            vesting: params.vesting,
+            userAddress: params.userAddress,
+            addresses,
+            modules: params.modules,
+            protocolBalanceLimitExclusions:
+              includeProtocolBalanceLimitExclusions
+                ? [
+                    openingAuctionInitializer,
+                    poolManagerForAuction,
+                    auctionDeployer,
+                    liquidityMigratorAddress,
+                    ...this.resolveGovernanceBalanceLimitExclusions(
+                      params.governance,
+                    ),
+                  ]
+                : undefined,
+          })
+        : this.buildStandardTokenFactoryData({
+            token: params.token as StandardTokenConfig,
+            sale: params.sale,
+            vesting: params.vesting,
+            userAddress: params.userAddress,
+            airlock: params.modules?.airlock ?? addresses.airlock,
+            tokenFactory: resolvedTokenFactory,
+            addresses,
+          });
 
     const auctionTokens =
       (params.sale.numTokensToSell *
@@ -1730,7 +2300,12 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         initialSupply: params.sale.initialSupply,
         tokenVariant: this.isDoppler404Token(params.token)
           ? 'doppler404'
-          : 'standard',
+          : this.isDopplerERC20V1Token(params.token)
+            ? 'dopplerERC20V1'
+            : 'standard',
+        migration: params.migration,
+        addresses,
+        includeProtocolBalanceLimitExclusions,
       });
 
     const liquidityMigratorData = this.encodeMigrationData(params.migration, {
@@ -1805,6 +2380,10 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       return resolved;
     })();
 
+    if (!tokenFactoryData) {
+      throw new Error('Token factory data could not be resolved.');
+    }
+
     const createParams: CreateParams = {
       initialSupply: params.sale.initialSupply,
       numTokensToSell: params.sale.numTokensToSell,
@@ -1815,10 +2394,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       governanceFactoryData,
       poolInitializer: openingAuctionInitializer,
       poolInitializerData,
-      liquidityMigrator: this.getMigratorAddress(
-        params.migration,
-        params.modules,
-      ),
+      liquidityMigrator: liquidityMigratorAddress,
       liquidityMigratorData,
       integrator: params.integrator ?? ZERO_ADDRESS,
       salt,
@@ -2743,10 +3319,14 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           baseURI: string;
           unit?: bigint;
         }
+      | DopplerERC20V1TokenFactoryData
       | StandardTokenFactoryData;
     airlock: Address;
     initialSupply: bigint;
-    tokenVariant: 'standard' | 'doppler404';
+    tokenVariant: TokenFactoryVariant;
+    migration?: MigrationConfig;
+    addresses?: ReturnType<typeof getAddresses>;
+    includeProtocolBalanceLimitExclusions?: boolean;
   }): [Hash, Address, Address, Hex] {
     const config = params.openingAuctionConfig;
     const initHashData = encodeAbiParameters(
@@ -2811,9 +3391,13 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
               [t.name, t.symbol, t.baseURI, t.unit ?? 1000n],
             );
           })()
-        : this.encodeStandardTokenFactoryData(
-            params.tokenFactoryData as StandardTokenFactoryData,
-          );
+        : params.tokenVariant === 'dopplerERC20V1'
+          ? this.encodeDopplerERC20V1TokenFactoryData(
+              params.tokenFactoryData as DopplerERC20V1TokenFactoryData,
+            )
+          : this.encodeStandardTokenFactoryData(
+              params.tokenFactoryData as StandardTokenFactoryData,
+            );
 
     let tokenInitHash: Hash;
     if (params.tokenVariant === 'doppler404') {
@@ -2845,6 +3429,12 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           ['bytes', 'bytes'],
           [DopplerDN404Bytecode as Hex, initData],
         ),
+      );
+    } else if (params.tokenVariant === 'dopplerERC20V1') {
+      const tokenFactoryData =
+        params.tokenFactoryData as DopplerERC20V1TokenFactoryData;
+      tokenInitHash = this.computeSoladyCloneInitCodeHash(
+        tokenFactoryData.implementation,
       );
     } else {
       tokenInitHash = this.computeStandardTokenInitHash(
@@ -2878,11 +3468,37 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         (isToken0 && tokenBigInt < numeraireBigInt) ||
         (!isToken0 && tokenBigInt > numeraireBigInt)
       ) {
+        const hook = getAddress(hookRaw) as Address;
+        const v1TokenFactoryData =
+          params.tokenFactoryData as DopplerERC20V1TokenFactoryData;
+        const finalEncodedTokenFactoryData =
+          params.tokenVariant === 'dopplerERC20V1' &&
+          params.includeProtocolBalanceLimitExclusions &&
+          this.isDopplerERC20V1BalanceLimitActive(v1TokenFactoryData)
+            ? this.encodeDopplerERC20V1TokenFactoryData({
+                ...v1TokenFactoryData,
+                excludedFromBalanceLimit:
+                  this.mergeDopplerERC20V1BalanceLimitExclusions(
+                    v1TokenFactoryData.excludedFromBalanceLimit,
+                    [
+                      hook,
+                      params.migration && params.addresses
+                        ? this.resolveUniswapV2MigrationPairExclusion({
+                            migration: params.migration,
+                            addresses: params.addresses,
+                            tokenAddress: getAddress(tokenRaw) as Address,
+                            numeraire: params.numeraire,
+                          })
+                        : undefined,
+                    ],
+                  ),
+              })
+            : encodedTokenFactoryData;
         return [
           `0x${salt.toString(16).padStart(64, '0')}` as Hash,
-          getAddress(hookRaw) as Address,
+          hook,
           getAddress(tokenRaw) as Address,
-          encodedTokenFactoryData,
+          finalEncodedTokenFactoryData,
         ];
       }
     }
@@ -2928,6 +3544,15 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     token: TokenConfig,
   ): token is Doppler404TokenConfig {
     return (token as Doppler404TokenConfig).type === 'doppler404';
+  }
+
+  private isDopplerERC20V1Token(
+    token: TokenConfig,
+  ): token is DopplerERC20V1TokenConfig | InferredDopplerERC20V1TokenConfig {
+    return (
+      token.type === 'dopplerERC20V1' ||
+      hasDopplerERC20V1OnlyTokenConfigFields(token)
+    );
   }
 
   /**
@@ -3710,9 +4335,12 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       params.modules?.tokenFactory ??
       (this.isDoppler404Token(params.token)
         ? (addresses.doppler404Factory as Address | undefined)
-        : this.usesDerc20V2Vesting(params.vesting)
-          ? addresses.derc20V2Factory
-          : addresses.tokenFactory);
+        : this.isDopplerERC20V1Token(params.token)
+          ? (params.modules?.dopplerERC20V1Factory ??
+            addresses.dopplerERC20V1Factory)
+          : this.usesDerc20V2Vesting(params.vesting)
+            ? addresses.derc20V2Factory
+            : addresses.tokenFactory);
     if (!resolvedTokenFactory || resolvedTokenFactory === ZERO_ADDRESS) {
       throw new Error(
         'Token factory address not configured. Provide an explicit address or ensure chain config includes a valid factory.',
@@ -3726,7 +4354,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     });
 
     // Token factory data (standard vs 404)
-    let tokenFactoryData: Hex;
+    let tokenFactoryData: Hex | undefined = undefined;
     if (this.isDoppler404Token(params.token)) {
       const token404 = params.token;
       const unit = token404.unit !== undefined ? BigInt(token404.unit) : 1000n;
@@ -3739,7 +4367,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         ],
         [token404.name, token404.symbol, token404.baseURI, unit],
       );
-    } else {
+    } else if (!this.isDopplerERC20V1Token(params.token)) {
       const standardTokenFactoryData = this.buildStandardTokenFactoryData({
         token: params.token as StandardTokenConfig,
         sale: params.sale,
@@ -3866,6 +4494,51 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       }
     }
 
+    if (this.isDopplerERC20V1Token(params.token)) {
+      const includeProtocolBalanceLimitExclusions =
+        this.usesDefaultDopplerERC20V1Integration(params.modules);
+      const resolvedV1TokenFactoryData =
+        this.resolveDopplerERC20V1TokenFactoryData({
+          token: params.token,
+          sale: params.sale,
+          vesting: params.vesting,
+          userAddress: params.userAddress,
+          addresses,
+          modules: params.modules,
+          protocolBalanceLimitExclusions: includeProtocolBalanceLimitExclusions
+            ? [
+                resolvedInitializer,
+                resolvedMigrator,
+                params.modules?.poolManager ?? addresses.poolManager,
+                ...this.resolveGovernanceBalanceLimitExclusions(
+                  params.governance,
+                ),
+              ]
+            : undefined,
+        });
+      const predictedTokenAddress = this.predictDopplerERC20V1TokenAddress({
+        tokenFactory: resolvedTokenFactory,
+        salt,
+        implementation: resolvedV1TokenFactoryData.implementation,
+      });
+      const finalV1TokenFactoryData = includeProtocolBalanceLimitExclusions
+        ? this.withDopplerERC20V1BalanceLimitExclusions(
+            resolvedV1TokenFactoryData,
+            [
+              this.resolveUniswapV2MigrationPairExclusion({
+                migration: params.migration,
+                addresses,
+                tokenAddress: predictedTokenAddress,
+                numeraire: params.sale.numeraire,
+              }),
+            ],
+          )
+        : resolvedV1TokenFactoryData;
+      tokenFactoryData = this.encodeDopplerERC20V1TokenFactoryData(
+        finalV1TokenFactoryData,
+      );
+    }
+
     const governanceFactoryAddress: Address = (() => {
       if (params.governance.type === 'noOp') {
         const resolved =
@@ -3900,6 +4573,10 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       }
       return resolved;
     })();
+
+    if (!tokenFactoryData) {
+      throw new Error('Token factory data could not be resolved.');
+    }
 
     const createParams: CreateParams = {
       initialSupply: params.sale.initialSupply,
@@ -5124,6 +5801,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           baseURI: string;
           unit?: bigint;
         }
+      | DopplerERC20V1TokenFactoryData
       | StandardTokenFactoryData;
     poolInitializer: Address;
     poolInitializerData: {
@@ -5140,7 +5818,10 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       tickSpacing: number;
     };
     customDerc20Bytecode?: `0x${string}`;
-    tokenVariant?: 'standard' | 'doppler404';
+    tokenVariant?: TokenFactoryVariant;
+    migration?: MigrationConfig;
+    addresses?: ReturnType<typeof getAddresses>;
+    includeProtocolBalanceLimitExclusions?: boolean;
   }): [Hash, Address, Address, Hex, Hex] {
     const isToken0 = isToken0Expected(params.numeraire);
 
@@ -5252,9 +5933,13 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
               [t.name, t.symbol, t.baseURI, t.unit ?? 1000n],
             );
           })()
-        : this.encodeStandardTokenFactoryData(
-            params.tokenFactoryData as StandardTokenFactoryData,
-          );
+        : params.tokenVariant === 'dopplerERC20V1'
+          ? this.encodeDopplerERC20V1TokenFactoryData(
+              params.tokenFactoryData as DopplerERC20V1TokenFactoryData,
+            )
+          : this.encodeStandardTokenFactoryData(
+              params.tokenFactoryData as StandardTokenFactoryData,
+            );
 
     // Compute token init hash; use DN404 bytecode if tokenVariant is doppler404
     let tokenInitHash: Hash | undefined;
@@ -5283,6 +5968,12 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           ['bytes', 'bytes'],
           [DopplerDN404Bytecode as Hex, initHashData],
         ),
+      );
+    } else if (params.tokenVariant === 'dopplerERC20V1') {
+      const tokenFactoryData =
+        params.tokenFactoryData as DopplerERC20V1TokenFactoryData;
+      tokenInitHash = this.computeSoladyCloneInitCodeHash(
+        tokenFactoryData.implementation,
       );
     } else {
       const standardTokenFactoryData =
@@ -5380,12 +6071,37 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           const saltBytes = `0x${salt.toString(16).padStart(64, '0')}` as Hash;
           const hook = getAddress(hookRaw) as Address;
           const token = getAddress(tokenRaw) as Address;
+          const v1TokenFactoryData =
+            params.tokenFactoryData as DopplerERC20V1TokenFactoryData;
+          const encodedTokenFactoryData =
+            params.tokenVariant === 'dopplerERC20V1' &&
+            params.includeProtocolBalanceLimitExclusions &&
+            this.isDopplerERC20V1BalanceLimitActive(v1TokenFactoryData)
+              ? this.encodeDopplerERC20V1TokenFactoryData({
+                  ...v1TokenFactoryData,
+                  excludedFromBalanceLimit:
+                    this.mergeDopplerERC20V1BalanceLimitExclusions(
+                      v1TokenFactoryData.excludedFromBalanceLimit,
+                      [
+                        hook,
+                        params.migration && params.addresses
+                          ? this.resolveUniswapV2MigrationPairExclusion({
+                              migration: params.migration,
+                              addresses: params.addresses,
+                              tokenAddress: token,
+                              numeraire: params.numeraire,
+                            })
+                          : undefined,
+                      ],
+                    ),
+                })
+              : tokenFactoryData;
           return [
             saltBytes,
             hook,
             token,
             poolInitializerData,
-            tokenFactoryData,
+            encodedTokenFactoryData,
           ];
         }
       }

--- a/src/evm/entities/token/derc20/DopplerERC20V1.ts
+++ b/src/evm/entities/token/derc20/DopplerERC20V1.ts
@@ -1,0 +1,666 @@
+import {
+  type Address,
+  type Hex,
+  type WalletClient,
+  type PublicClient,
+} from 'viem';
+import { dopplerERC20V1Abi } from '../../../abis';
+import { SupportedPublicClient } from '../../../types';
+
+const availableVestedAmountAbi = [
+  {
+    type: 'function',
+    name: 'computeAvailableVestedAmount',
+    inputs: [{ name: 'beneficiary', type: 'address', internalType: 'address' }],
+    outputs: [{ name: 'total', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+] as const;
+
+export class DopplerERC20V1 {
+  protected publicClient: SupportedPublicClient;
+  protected walletClient?: WalletClient;
+  protected address: Address;
+  protected get rpc(): PublicClient {
+    return this.publicClient as PublicClient;
+  }
+
+  protected static splitSignature(signature: Hex): {
+    v: number;
+    r: Hex;
+    s: Hex;
+  } {
+    const sig = signature.toLowerCase() as Hex;
+    const r = `0x${sig.slice(2, 66)}` as Hex;
+    const s = `0x${sig.slice(66, 130)}` as Hex;
+    let v = parseInt(sig.slice(130, 132), 16);
+    if (v < 27) v += 27;
+    return { v, r, s };
+  }
+
+  constructor(
+    publicClient: SupportedPublicClient,
+    walletClient: WalletClient | undefined,
+    address: Address,
+  ) {
+    this.publicClient = publicClient;
+    this.walletClient = walletClient;
+    this.address = address;
+  }
+
+  async getName(): Promise<string> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'name',
+    });
+  }
+
+  async getSymbol(): Promise<string> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'symbol',
+    });
+  }
+
+  async getDecimals(): Promise<number> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'decimals',
+    });
+  }
+
+  async getTokenURI(): Promise<string> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'tokenURI',
+    });
+  }
+
+  async getBalanceOf(account: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'balanceOf',
+      args: [account],
+    });
+  }
+
+  async getTotalSupply(): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'totalSupply',
+    });
+  }
+
+  async getAllowance(owner: Address, spender: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'allowance',
+      args: [owner, spender],
+    });
+  }
+
+  async getNonce(owner: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'nonces',
+      args: [owner],
+    });
+  }
+
+  async getDomainSeparator(): Promise<Hex> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'DOMAIN_SEPARATOR',
+    });
+  }
+
+  async getDelegates(account: Address): Promise<Address> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'delegates',
+      args: [account],
+    });
+  }
+
+  async getVotes(account: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'getVotes',
+      args: [account],
+    });
+  }
+
+  async getPastVotes(account: Address, timepoint: bigint): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'getPastVotes',
+      args: [account, timepoint],
+    });
+  }
+
+  async getVotesTotalSupply(): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'getVotesTotalSupply',
+    });
+  }
+
+  async getPastVotesTotalSupply(timepoint: bigint): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'getPastVotesTotalSupply',
+      args: [timepoint],
+    });
+  }
+
+  async getClock(): Promise<number> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'clock',
+    });
+    return Number(result);
+  }
+
+  async getClockMode(): Promise<string> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'CLOCK_MODE',
+    });
+  }
+
+  async getCheckpointCount(account: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'checkpointCount',
+      args: [account],
+    });
+  }
+
+  async getCheckpointAt(
+    account: Address,
+    index: bigint,
+  ): Promise<{ checkpointClock: number; checkpointValue: bigint }> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'checkpointAt',
+      args: [account, index],
+    });
+
+    return {
+      checkpointClock: Number(result[0]),
+      checkpointValue: result[1],
+    };
+  }
+
+  async getOwner(): Promise<Address> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'owner',
+    });
+  }
+
+  async getOwnershipHandoverExpiresAt(pendingOwner: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'ownershipHandoverExpiresAt',
+      args: [pendingOwner],
+    });
+  }
+
+  async getPool(): Promise<Address> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'pool',
+    });
+  }
+
+  async isPoolLocked(): Promise<boolean> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'isPoolLocked',
+    });
+  }
+
+  async getVestingStart(): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'vestingStart',
+    });
+  }
+
+  async getVestedTotalAmount(): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'vestedTotalAmount',
+    });
+  }
+
+  async getVestingScheduleCount(): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'vestingScheduleCount',
+    });
+  }
+
+  async getVestingSchedule(scheduleId: bigint): Promise<{
+    cliffDuration: bigint;
+    duration: bigint;
+  }> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'vestingSchedules',
+      args: [scheduleId],
+    });
+
+    return {
+      cliffDuration: BigInt(result[0]),
+      duration: BigInt(result[1]),
+    };
+  }
+
+  async getScheduleIdsOf(beneficiary: Address): Promise<bigint[]> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'getScheduleIdsOf',
+      args: [beneficiary],
+    });
+    return Array.from(result);
+  }
+
+  async getTotalAllocatedOf(beneficiary: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'totalAllocatedOf',
+      args: [beneficiary],
+    });
+  }
+
+  async getAvailableVestedAmountForSchedule(
+    beneficiary: Address,
+    scheduleId: bigint,
+  ): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'computeAvailableVestedAmount',
+      args: [beneficiary, scheduleId],
+    });
+  }
+
+  async getAvailableVestedAmount(beneficiary: Address): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: availableVestedAmountAbi,
+      functionName: 'computeAvailableVestedAmount',
+      args: [beneficiary],
+    });
+  }
+
+  async getVestingDataForSchedule(
+    beneficiary: Address,
+    scheduleId: bigint,
+  ): Promise<{
+    totalAmount: bigint;
+    releasedAmount: bigint;
+  }> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'vestingOf',
+      args: [beneficiary, scheduleId],
+    });
+
+    return {
+      totalAmount: result[0],
+      releasedAmount: result[1],
+    };
+  }
+
+  async getMaxBalanceLimit(): Promise<bigint> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'maxBalanceLimit',
+    });
+  }
+
+  async getBalanceLimitEnd(): Promise<number> {
+    const result = await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'balanceLimitEnd',
+    });
+    return Number(result);
+  }
+
+  async isBalanceLimitActive(): Promise<boolean> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'isBalanceLimitActive',
+    });
+  }
+
+  async getController(): Promise<Address> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'controller',
+    });
+  }
+
+  async isExcludedFromBalanceLimit(account: Address): Promise<boolean> {
+    return await this.rpc.readContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName: 'isExcludedFromBalanceLimit',
+      args: [account],
+    });
+  }
+
+  async approve(
+    spender: Address,
+    value: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('approve', [spender, value], options);
+  }
+
+  async permit(
+    owner: Address,
+    spender: Address,
+    value: bigint,
+    deadline: bigint,
+    signature: Hex,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`>;
+  async permit(
+    owner: Address,
+    spender: Address,
+    value: bigint,
+    deadline: bigint,
+    v: number,
+    r: Hex,
+    s: Hex,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`>;
+  async permit(
+    owner: Address,
+    spender: Address,
+    value: bigint,
+    deadline: bigint,
+    signatureOrV: Hex | number,
+    rOrOptions?: Hex | { gas?: bigint },
+    s?: Hex,
+    maybeOptions?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    const {
+      v,
+      r,
+      s: signatureS,
+    } = typeof signatureOrV === 'number'
+      ? { v: signatureOrV, r: rOrOptions as Hex, s: s as Hex }
+      : DopplerERC20V1.splitSignature(signatureOrV);
+    const options =
+      typeof signatureOrV === 'number'
+        ? maybeOptions
+        : (rOrOptions as { gas?: bigint } | undefined);
+
+    return await this.write(
+      'permit',
+      [owner, spender, value, deadline, v, r, signatureS],
+      options,
+    );
+  }
+
+  async transfer(
+    to: Address,
+    value: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('transfer', [to, value], options);
+  }
+
+  async transferFrom(
+    from: Address,
+    to: Address,
+    value: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('transferFrom', [from, to, value], options);
+  }
+
+  async delegate(
+    delegatee: Address,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('delegate', [delegatee], options);
+  }
+
+  async delegateBySig(
+    delegatee: Address,
+    expiry: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    if (!this.walletClient) {
+      throw new Error('Wallet client required for write operations');
+    }
+
+    const accountAddress = this.getWalletAccountAddress();
+    const [nonce, name] = await Promise.all([
+      this.getNonce(accountAddress),
+      this.getName(),
+    ]);
+    const chainId =
+      (this.rpc.chain?.id as number | undefined) ??
+      (await this.rpc.getChainId());
+
+    const signature = await this.signTypedData({
+      domain: {
+        name,
+        version: '1',
+        chainId,
+        verifyingContract: this.address,
+      },
+      types: {
+        Delegation: [
+          { name: 'delegatee', type: 'address' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'expiry', type: 'uint256' },
+        ],
+      },
+      primaryType: 'Delegation',
+      message: { delegatee, nonce, expiry },
+      account: accountAddress,
+    });
+
+    const { v, r, s } = DopplerERC20V1.splitSignature(signature);
+    return await this.write(
+      'delegateBySig',
+      [delegatee, nonce, expiry, v, r, s],
+      options,
+    );
+  }
+
+  async transferOwnership(
+    newOwner: Address,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('transferOwnership', [newOwner], options);
+  }
+
+  async renounceOwnership(options?: { gas?: bigint }): Promise<`0x${string}`> {
+    return await this.write('renounceOwnership', [], options);
+  }
+
+  async requestOwnershipHandover(options?: {
+    gas?: bigint;
+  }): Promise<`0x${string}`> {
+    return await this.write('requestOwnershipHandover', [], options);
+  }
+
+  async cancelOwnershipHandover(options?: {
+    gas?: bigint;
+  }): Promise<`0x${string}`> {
+    return await this.write('cancelOwnershipHandover', [], options);
+  }
+
+  async completeOwnershipHandover(
+    pendingOwner: Address,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write(
+      'completeOwnershipHandover',
+      [pendingOwner],
+      options,
+    );
+  }
+
+  async lockPool(
+    pool: Address,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('lockPool', [pool], options);
+  }
+
+  async unlockPool(options?: { gas?: bigint }): Promise<`0x${string}`> {
+    return await this.write('unlockPool', [], options);
+  }
+
+  async burn(
+    amount: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('burn', [amount], options);
+  }
+
+  async release(
+    amount: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('release', [amount], options);
+  }
+
+  async releaseSchedule(
+    scheduleId: bigint,
+    amount: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('release', [scheduleId, amount], options);
+  }
+
+  async releaseFor(
+    beneficiary: Address,
+    amount: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`>;
+  async releaseFor(
+    beneficiary: Address,
+    scheduleId: bigint,
+    amount: bigint,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`>;
+  async releaseFor(
+    beneficiary: Address,
+    amountOrScheduleId: bigint,
+    amountOrOptions?: bigint | { gas?: bigint },
+    maybeOptions?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    const hasSchedule = typeof amountOrOptions === 'bigint';
+    const args = hasSchedule
+      ? [beneficiary, amountOrScheduleId, amountOrOptions]
+      : [beneficiary, amountOrScheduleId];
+    const options = hasSchedule ? maybeOptions : amountOrOptions;
+    return await this.write('releaseFor', args, options);
+  }
+
+  async disableBalanceLimit(options?: {
+    gas?: bigint;
+  }): Promise<`0x${string}`> {
+    return await this.write('disableBalanceLimit', [], options);
+  }
+
+  async updateTokenURI(
+    tokenURI: string,
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    return await this.write('updateTokenURI', [tokenURI], options);
+  }
+
+  private getWalletAccountAddress(): Address {
+    const account = this.walletClient?.account as unknown;
+    if (typeof account === 'string') return account as Address;
+    if (account && typeof account === 'object' && 'address' in account) {
+      return (account as { address: Address }).address;
+    }
+    throw new Error('Invalid wallet account');
+  }
+
+  private async signTypedData(parameters: unknown): Promise<Hex> {
+    if (!this.walletClient) {
+      throw new Error('Wallet client required for write operations');
+    }
+
+    const signTypedData = this.walletClient.signTypedData as unknown as (
+      parameters: unknown,
+    ) => Promise<Hex>;
+    return await signTypedData(parameters);
+  }
+
+  private async write(
+    functionName: string,
+    args: readonly unknown[],
+    options?: { gas?: bigint },
+  ): Promise<`0x${string}`> {
+    if (!this.walletClient) {
+      throw new Error('Wallet client required for write operations');
+    }
+
+    const simulateContract = this.rpc.simulateContract as unknown as (
+      parameters: unknown,
+    ) => Promise<{ request: Record<string, unknown> }>;
+    const writeContract = this.walletClient.writeContract as unknown as (
+      parameters: unknown,
+    ) => Promise<`0x${string}`>;
+
+    const { request } = await simulateContract({
+      address: this.address,
+      abi: dopplerERC20V1Abi,
+      functionName,
+      args,
+      account: this.walletClient.account,
+    });
+
+    return await writeContract(
+      options?.gas ? { ...request, gas: options.gas } : request,
+    );
+  }
+}

--- a/src/evm/entities/token/derc20/index.ts
+++ b/src/evm/entities/token/derc20/index.ts
@@ -1,2 +1,3 @@
 export { Derc20 } from './Derc20';
 export { Derc20V2 } from './Derc20V2';
+export { DopplerERC20V1 } from './DopplerERC20V1';

--- a/src/evm/entities/token/index.ts
+++ b/src/evm/entities/token/index.ts
@@ -1,2 +1,2 @@
-export { Derc20, Derc20V2 } from './derc20';
+export { Derc20, Derc20V2, DopplerERC20V1 } from './derc20';
 export { Eth } from './eth';

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -22,7 +22,7 @@ export {
 export { Quoter } from './entities/quoter';
 
 // Export token entities
-export { Derc20, Derc20V2, Eth } from './entities/token';
+export { Derc20, Derc20V2, DopplerERC20V1, Eth } from './entities/token';
 
 // Export builders and common interface
 export {
@@ -90,6 +90,7 @@ export type {
 export type {
   // Core types
   TokenConfig,
+  DopplerERC20V1TokenConfig,
   SaleConfig,
   StaticPoolConfig,
   DynamicAuctionConfig,

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -22,7 +22,7 @@ export type SupportedChain =
 export type SupportedPublicClient = unknown;
 
 // Core configuration types
-// Token configuration (discriminated union)
+// Token configuration
 export interface StandardTokenConfig {
   type?: 'standard'; // default behavior (backwards compatible)
   name: string;
@@ -30,6 +30,17 @@ export interface StandardTokenConfig {
   tokenURI: string;
   yearlyMintRate?: bigint; // Optional yearly mint rate (in WAD, default: 2% = 0.02e18)
 }
+
+export type DopplerERC20V1OnlyTokenConfigFields = {
+  maxBalanceLimit?: bigint;
+  balanceLimitEnd?: number;
+  controller?: Address;
+  excludedFromBalanceLimit?: Address[];
+};
+
+type RequireAtLeastOne<T> = {
+  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Omit<T, K>>;
+}[keyof T];
 
 export interface Doppler404TokenConfig {
   type: 'doppler404';
@@ -40,7 +51,25 @@ export interface Doppler404TokenConfig {
   unit?: bigint;
 }
 
-export type TokenConfig = StandardTokenConfig | Doppler404TokenConfig;
+export type DopplerERC20V1TokenConfig = {
+  type: 'dopplerERC20V1';
+  name: string;
+  symbol: string;
+  tokenURI: string;
+} & DopplerERC20V1OnlyTokenConfigFields;
+
+export type InferredDopplerERC20V1TokenConfig = {
+  type?: never;
+  name: string;
+  symbol: string;
+  tokenURI: string;
+} & RequireAtLeastOne<DopplerERC20V1OnlyTokenConfigFields>;
+
+export type TokenConfig =
+  | StandardTokenConfig
+  | Doppler404TokenConfig
+  | DopplerERC20V1TokenConfig
+  | InferredDopplerERC20V1TokenConfig;
 
 export interface SaleConfig {
   initialSupply: bigint;
@@ -1051,6 +1080,7 @@ export interface ModuleAddressOverrides {
   // Core deployment & routing
   airlock?: Address;
   tokenFactory?: Address;
+  dopplerERC20V1Factory?: Address;
 
   // Initializers
   v3Initializer?: Address;

--- a/test/evm/setup/fixtures/addresses.ts
+++ b/test/evm/setup/fixtures/addresses.ts
@@ -14,6 +14,12 @@ export const mockAddresses: ChainAddresses = {
   derc20V2Implementation: getAddress(
     '0x2000000000000000000000000000000000000004',
   ) as Address,
+  dopplerERC20V1Factory: getAddress(
+    '0x2000000000000000000000000000000000000005',
+  ) as Address,
+  dopplerERC20V1Implementation: getAddress(
+    '0x2000000000000000000000000000000000000006',
+  ) as Address,
   v3Initializer: getAddress(
     '0x3000000000000000000000000000000000000003',
   ) as Address,
@@ -64,6 +70,12 @@ export const mockAddresses: ChainAddresses = {
   ) as Address,
   weth: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as Address, // Already checksummed
   v3Quoter: getAddress('0xd000000000000000000000000000000000000013') as Address,
+  uniswapV2Factory: getAddress(
+    '0x1900000000000000000000000000000000000026',
+  ) as Address,
+  uniswapV3Factory: getAddress(
+    '0x1900000000000000000000000000000000000027',
+  ) as Address,
   univ2Router02: getAddress(
     '0xf000000000000000000000000000000000000015',
   ) as Address,

--- a/test/evm/unit/addresses.test.ts
+++ b/test/evm/unit/addresses.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isAddress, type Address, zeroAddress } from 'viem';
+import { ADDRESSES, CHAIN_IDS, getAddresses } from '../../../src/evm/addresses';
+import { GENERATED_DOPPLER_DEPLOYMENTS } from '../../../src/evm/deployments.generated';
+
+const dopplerERC20V1TargetChains = [
+  { name: 'mainnet', chainId: CHAIN_IDS.MAINNET },
+  { name: 'base', chainId: CHAIN_IDS.BASE },
+  { name: 'base-sepolia', chainId: CHAIN_IDS.BASE_SEPOLIA },
+  { name: 'monad-mainnet', chainId: CHAIN_IDS.MONAD_MAINNET },
+] as const;
+
+function expectConfiguredAddress(address: Address | undefined): Address {
+  expect(address).toBeDefined();
+  if (!address) {
+    throw new Error('Expected address to be configured');
+  }
+  expect(address).not.toBe(zeroAddress);
+  expect(isAddress(address)).toBe(true);
+  return address;
+}
+
+describe('address configuration', () => {
+  it.each(dopplerERC20V1TargetChains)(
+    'returns generated DopplerERC20V1 addresses for $name',
+    ({ chainId }) => {
+      const addresses = getAddresses(chainId);
+      const generated = GENERATED_DOPPLER_DEPLOYMENTS[chainId];
+
+      const factory = expectConfiguredAddress(
+        addresses.dopplerERC20V1Factory,
+      );
+      const implementation = expectConfiguredAddress(
+        addresses.dopplerERC20V1Implementation,
+      );
+
+      expect(factory).toBe(generated.DopplerERC20V1Factory);
+      expect(implementation).toBe(generated.DopplerERC20V1);
+      expect(ADDRESSES[chainId].dopplerERC20V1Factory).toBe(factory);
+      expect(ADDRESSES[chainId].dopplerERC20V1Implementation).toBe(
+        implementation,
+      );
+    },
+  );
+});

--- a/test/evm/unit/builders/interface.test.ts
+++ b/test/evm/unit/builders/interface.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect } from 'vitest';
+import type { Address } from 'viem';
 import {
   StaticAuctionBuilder,
   DynamicAuctionBuilder,
   MulticurveBuilder,
+  OpeningAuctionBuilder,
   type BaseAuctionBuilder,
 } from '../../../../src/evm/builders';
 import { CHAIN_IDS } from '../../../../src/evm/addresses';
+import { WAD, ZERO_ADDRESS } from '../../../../src/evm/constants';
+
+const USER = '0x00000000000000000000000000000000000000AA' as Address;
+const TOKEN_FACTORY = '0x1111111111111111111111111111111111111111' as Address;
 
 describe('BaseAuctionBuilder interface', () => {
   it('StaticAuctionBuilder implements BaseAuctionBuilder', () => {
@@ -21,6 +27,7 @@ describe('BaseAuctionBuilder interface', () => {
     expect(typeof builder.withUserAddress).toBe('function');
     expect(typeof builder.withIntegrator).toBe('function');
     expect(typeof builder.withGasLimit).toBe('function');
+    expect(typeof builder.withTokenFactory).toBe('function');
   });
 
   it('DynamicAuctionBuilder implements BaseAuctionBuilder', () => {
@@ -38,6 +45,7 @@ describe('BaseAuctionBuilder interface', () => {
     expect(typeof builder.withUserAddress).toBe('function');
     expect(typeof builder.withIntegrator).toBe('function');
     expect(typeof builder.withGasLimit).toBe('function');
+    expect(typeof builder.withTokenFactory).toBe('function');
   });
 
   it('MulticurveBuilder implements BaseAuctionBuilder', () => {
@@ -53,5 +61,111 @@ describe('BaseAuctionBuilder interface', () => {
     expect(typeof builder.withUserAddress).toBe('function');
     expect(typeof builder.withIntegrator).toBe('function');
     expect(typeof builder.withGasLimit).toBe('function');
+    expect(typeof builder.withTokenFactory).toBe('function');
+  });
+
+  describe('token factory module overrides', () => {
+    it('sets token factory overrides on static builders', () => {
+      const params = StaticAuctionBuilder.forChain(CHAIN_IDS.BASE)
+        .tokenConfig({ name: 'Token', symbol: 'TKN', tokenURI: 'ipfs://token' })
+        .saleConfig({
+          initialSupply: 1_000n * WAD,
+          numTokensToSell: 500n * WAD,
+          numeraire: ZERO_ADDRESS,
+        })
+        .poolByTicks({ startTick: 174960, endTick: 225000, fee: 3000 })
+        .withGovernance({ type: 'default' })
+        .withMigration({ type: 'uniswapV2' })
+        .withTokenFactory(TOKEN_FACTORY)
+        .withUserAddress(USER)
+        .build();
+
+      expect(params.modules?.tokenFactory).toBe(TOKEN_FACTORY);
+    });
+
+    it('sets token factory overrides on dynamic builders', () => {
+      const params = DynamicAuctionBuilder.forChain(CHAIN_IDS.BASE)
+        .tokenConfig({ name: 'Token', symbol: 'TKN', tokenURI: 'ipfs://token' })
+        .saleConfig({
+          initialSupply: 1_000n * WAD,
+          numTokensToSell: 500n * WAD,
+          numeraire: ZERO_ADDRESS,
+        })
+        .poolConfig({ fee: 3000, tickSpacing: 30 })
+        .auctionByTicks({
+          startTick: -120000,
+          endTick: -90000,
+          minProceeds: 1n,
+          maxProceeds: 10n,
+        })
+        .withGovernance({ type: 'default' })
+        .withMigration({ type: 'uniswapV2' })
+        .withTokenFactory(TOKEN_FACTORY)
+        .withUserAddress(USER)
+        .build();
+
+      expect(params.modules?.tokenFactory).toBe(TOKEN_FACTORY);
+    });
+
+    it('sets token factory overrides on multicurve builders', () => {
+      const params = MulticurveBuilder.forChain(CHAIN_IDS.BASE)
+        .tokenConfig({ name: 'Token', symbol: 'TKN', tokenURI: 'ipfs://token' })
+        .saleConfig({
+          initialSupply: 1_000n * WAD,
+          numTokensToSell: 500n * WAD,
+          numeraire: ZERO_ADDRESS,
+        })
+        .poolConfig({
+          fee: 3000,
+          tickSpacing: 60,
+          curves: [
+            {
+              tickLower: 1000,
+              tickUpper: 2000,
+              numPositions: 2,
+              shares: WAD,
+            },
+          ],
+        })
+        .withGovernance({ type: 'default' })
+        .withMigration({ type: 'uniswapV2' })
+        .withTokenFactory(TOKEN_FACTORY)
+        .withUserAddress(USER)
+        .build();
+
+      expect(params.modules?.tokenFactory).toBe(TOKEN_FACTORY);
+    });
+
+    it('sets token factory overrides on opening auction builders', () => {
+      const params = OpeningAuctionBuilder.forChain(CHAIN_IDS.BASE)
+        .tokenConfig({ name: 'Token', symbol: 'TKN', tokenURI: 'ipfs://token' })
+        .saleConfig({
+          initialSupply: 1_000n * WAD,
+          numTokensToSell: 500n * WAD,
+          numeraire: ZERO_ADDRESS,
+        })
+        .openingAuctionConfig({
+          auctionDuration: 86_400,
+          minAcceptableTickToken0: -34_020,
+          minAcceptableTickToken1: -34_020,
+          incentiveShareBps: 1_000,
+          tickSpacing: 60,
+          fee: 3_000,
+          minLiquidity: 1n,
+          shareToAuctionBps: 10_000,
+        })
+        .dopplerConfig({
+          minProceeds: 0n,
+          maxProceeds: 10n,
+          startTick: -120_000,
+          endTick: -90_000,
+        })
+        .withMigration({ type: 'uniswapV2' })
+        .withTokenFactory(TOKEN_FACTORY)
+        .withUserAddress(USER)
+        .build();
+
+      expect(params.modules?.tokenFactory).toBe(TOKEN_FACTORY);
+    });
   });
 });

--- a/test/evm/unit/entities/DopplerERC20V1.test.ts
+++ b/test/evm/unit/entities/DopplerERC20V1.test.ts
@@ -1,0 +1,554 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseEther, type Address, type Hex, type PublicClient } from 'viem';
+import { dopplerERC20V1Abi } from '../../../../src/evm/abis';
+import { DopplerERC20V1 } from '../../../../src/evm/entities/token/derc20/DopplerERC20V1';
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+} from '../../setup/fixtures/clients';
+import { mockTokenAddress } from '../../setup/fixtures/addresses';
+
+describe('DopplerERC20V1', () => {
+  let token: DopplerERC20V1;
+  let publicClient: PublicClient;
+  let walletClient: ReturnType<typeof createMockWalletClient>;
+
+  const beneficiary = '0x1234567890123456789012345678901234567890' as Address;
+  const controller = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address;
+  const delegatee = '0x2222222222222222222222222222222222222222' as Address;
+  const owner = '0x3333333333333333333333333333333333333333' as Address;
+  const spender = '0x4444444444444444444444444444444444444444' as Address;
+  const pool = '0x5555555555555555555555555555555555555555' as Address;
+  const bytes32A = `0x${'11'.repeat(32)}` as Hex;
+  const bytes32B = `0x${'22'.repeat(32)}` as Hex;
+  const signature = `0x${'11'.repeat(32)}${'22'.repeat(32)}1b` as Hex;
+  const txHash =
+    '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' as Hex;
+
+  const functionNames = () =>
+    dopplerERC20V1Abi
+      .filter((entry) => entry.type === 'function')
+      .map((entry) => entry.name);
+
+  const eventNames = () =>
+    dopplerERC20V1Abi
+      .filter((entry) => entry.type === 'event')
+      .map((entry) => entry.name);
+
+  const errorNames = () =>
+    dopplerERC20V1Abi
+      .filter((entry) => entry.type === 'error')
+      .map((entry) => entry.name);
+
+  it('exports the canonical amount-based overloads', () => {
+    const releaseForEntries = dopplerERC20V1Abi.filter(
+      (entry) => entry.type === 'function' && entry.name === 'releaseFor',
+    );
+    const availableEntries = dopplerERC20V1Abi.filter(
+      (entry) =>
+        entry.type === 'function' &&
+        entry.name === 'computeAvailableVestedAmount',
+    );
+
+    expect(releaseForEntries).toHaveLength(2);
+    const [amountReleaseFor, scheduleReleaseFor] = releaseForEntries;
+    if (!amountReleaseFor || !scheduleReleaseFor) {
+      throw new Error('Expected both releaseFor overloads');
+    }
+
+    expect(releaseForEntries.map((entry) => entry.inputs.length)).toEqual([2, 3]);
+    expect(amountReleaseFor.inputs[1]?.name).toBe('amount');
+    expect([
+      scheduleReleaseFor.inputs[0]?.name,
+      scheduleReleaseFor.inputs[1]?.name,
+      scheduleReleaseFor.inputs[2]?.name,
+    ]).toEqual(['beneficiary', 'scheduleId', 'amount']);
+    expect(availableEntries.map((entry) => entry.inputs.length)).toEqual([
+      2,
+      1,
+    ]);
+  });
+
+  it('includes full deployed ABI groups', () => {
+    const initialize = dopplerERC20V1Abi.find(
+      (entry) => entry.type === 'function' && entry.name === 'initialize',
+    );
+    if (!initialize || initialize.type !== 'function') {
+      throw new Error('Expected initialize function');
+    }
+
+    expect(initialize.inputs.map((input) => input.type)).toEqual([
+      'string',
+      'string',
+      'uint256',
+      'address',
+      'address',
+      'tuple[]',
+      'address[]',
+      'uint256[]',
+      'uint256[]',
+      'string',
+      'uint256',
+      'uint48',
+      'address',
+      'address[]',
+    ]);
+    expect(initialize.inputs[5]?.type).toBe('tuple[]');
+
+    expect(functionNames()).toEqual(
+      expect.arrayContaining([
+        'CLOCK_MODE',
+        'clock',
+        'delegates',
+        'getVotes',
+        'getPastVotes',
+        'delegate',
+        'delegateBySig',
+        'checkpointCount',
+        'checkpointAt',
+        'getVotesTotalSupply',
+        'getPastVotesTotalSupply',
+        'permit',
+        'nonces',
+        'DOMAIN_SEPARATOR',
+        'owner',
+        'transferOwnership',
+        'renounceOwnership',
+        'requestOwnershipHandover',
+        'cancelOwnershipHandover',
+        'completeOwnershipHandover',
+        'ownershipHandoverExpiresAt',
+        'pool',
+        'isPoolLocked',
+        'lockPool',
+        'unlockPool',
+        'vestingStart',
+        'vestedTotalAmount',
+        'burn',
+      ]),
+    );
+
+    expect(eventNames()).toEqual(
+      expect.arrayContaining([
+        'VestingScheduleCreated',
+        'VestingAllocated',
+        'TokensReleased',
+        'UpdateTokenURI',
+        'BalanceLimitDisabled',
+        'Transfer',
+        'Approval',
+        'DelegateChanged',
+        'DelegateVotesChanged',
+        'OwnershipTransferred',
+        'OwnershipHandoverRequested',
+        'OwnershipHandoverCanceled',
+      ]),
+    );
+
+    expect(errorNames()).toEqual(
+      expect.arrayContaining([
+        'ArrayLengthsMismatch',
+        'PoolLocked',
+        'PoolAlreadyLocked',
+        'PoolAlreadyUnlocked',
+        'NoReleasableAmount',
+        'BalanceLimitNotActive',
+        'UnknownScheduleId',
+        'InvalidSchedule',
+        'InvalidAllocation',
+        'InvalidBalanceLimitTimestamp',
+        'InvalidBalanceLimit',
+        'BalanceLimitExceeded',
+        'InsufficientReleasableAmount',
+        'TotalSupplyOverflow',
+        'AllowanceOverflow',
+        'AllowanceUnderflow',
+        'InsufficientBalance',
+        'InsufficientAllowance',
+        'InvalidPermit',
+        'PermitExpired',
+        'Permit2AllowanceIsFixedAtInfinity',
+        'ERC5805FutureLookup',
+        'ERC5805DelegateSignatureExpired',
+        'ERC5805DelegateInvalidSignature',
+        'ERC5805CheckpointIndexOutOfBounds',
+        'ERC5805CheckpointValueOverflow',
+        'ERC5805CheckpointValueUnderflow',
+        'Unauthorized',
+        'NewOwnerIsZeroAddress',
+        'NoHandoverRequest',
+        'AlreadyInitialized',
+        'InvalidInitialization',
+        'NotInitializing',
+      ]),
+    );
+  });
+
+  beforeEach(() => {
+    publicClient = createMockPublicClient() as PublicClient;
+    walletClient = createMockWalletClient();
+    token = new DopplerERC20V1(publicClient, walletClient, mockTokenAddress);
+  });
+
+  it('reads votes, permit, ownership, pool, and vesting direct state', async () => {
+    vi.mocked(publicClient.readContract)
+      .mockResolvedValueOnce(delegatee)
+      .mockResolvedValueOnce(100n)
+      .mockResolvedValueOnce(90n)
+      .mockResolvedValueOnce(1_000n)
+      .mockResolvedValueOnce(900n)
+      .mockResolvedValueOnce(12345n)
+      .mockResolvedValueOnce('mode=blocknumber&from=default')
+      .mockResolvedValueOnce(2n)
+      .mockResolvedValueOnce([123n, 456n] as never)
+      .mockResolvedValueOnce(3n)
+      .mockResolvedValueOnce(bytes32A)
+      .mockResolvedValueOnce(owner)
+      .mockResolvedValueOnce(1_700_000_000n)
+      .mockResolvedValueOnce(pool)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(1_690_000_000n)
+      .mockResolvedValueOnce(parseEther('50000'));
+
+    await expect(token.getDelegates(beneficiary)).resolves.toBe(delegatee);
+    await expect(token.getVotes(beneficiary)).resolves.toBe(100n);
+    await expect(token.getPastVotes(beneficiary, 50n)).resolves.toBe(90n);
+    await expect(token.getVotesTotalSupply()).resolves.toBe(1_000n);
+    await expect(token.getPastVotesTotalSupply(50n)).resolves.toBe(900n);
+    await expect(token.getClock()).resolves.toBe(12345);
+    await expect(token.getClockMode()).resolves.toBe('mode=blocknumber&from=default');
+    await expect(token.getCheckpointCount(beneficiary)).resolves.toBe(2n);
+    await expect(token.getCheckpointAt(beneficiary, 1n)).resolves.toEqual({
+      checkpointClock: 123,
+      checkpointValue: 456n,
+    });
+    await expect(token.getNonce(owner)).resolves.toBe(3n);
+    await expect(token.getDomainSeparator()).resolves.toBe(bytes32A);
+    await expect(token.getOwner()).resolves.toBe(owner);
+    await expect(token.getOwnershipHandoverExpiresAt(owner)).resolves.toBe(
+      1_700_000_000n,
+    );
+    await expect(token.getPool()).resolves.toBe(pool);
+    await expect(token.isPoolLocked()).resolves.toBe(true);
+    await expect(token.getVestingStart()).resolves.toBe(1_690_000_000n);
+    await expect(token.getVestedTotalAmount()).resolves.toBe(
+      parseEther('50000'),
+    );
+
+    const expectedCalls: Array<{ functionName: string; args?: unknown[] }> = [
+      { functionName: 'delegates', args: [beneficiary] },
+      { functionName: 'getVotes', args: [beneficiary] },
+      { functionName: 'getPastVotes', args: [beneficiary, 50n] },
+      { functionName: 'getVotesTotalSupply' },
+      { functionName: 'getPastVotesTotalSupply', args: [50n] },
+      { functionName: 'clock' },
+      { functionName: 'CLOCK_MODE' },
+      { functionName: 'checkpointCount', args: [beneficiary] },
+      { functionName: 'checkpointAt', args: [beneficiary, 1n] },
+      { functionName: 'nonces', args: [owner] },
+      { functionName: 'DOMAIN_SEPARATOR' },
+      { functionName: 'owner' },
+      { functionName: 'ownershipHandoverExpiresAt', args: [owner] },
+      { functionName: 'pool' },
+      { functionName: 'isPoolLocked' },
+      { functionName: 'vestingStart' },
+      { functionName: 'vestedTotalAmount' },
+    ];
+
+    expectedCalls.forEach((expectedCall, index) => {
+      const baseCall = {
+        address: mockTokenAddress,
+        abi: expect.any(Array),
+        functionName: expectedCall.functionName,
+      };
+      expect(publicClient.readContract).toHaveBeenNthCalledWith(
+        index + 1,
+        expectedCall.args
+          ? { ...baseCall, args: expectedCall.args }
+          : baseCall,
+      );
+    });
+  });
+
+  it('reads schedule vesting data', async () => {
+    vi.mocked(publicClient.readContract)
+      .mockResolvedValueOnce(2n)
+      .mockResolvedValueOnce([90n, 180n] as never)
+      .mockResolvedValueOnce([0n, 1n] as never)
+      .mockResolvedValueOnce(parseEther('100000'))
+      .mockResolvedValueOnce(parseEther('1234'))
+      .mockResolvedValueOnce(parseEther('5678'))
+      .mockResolvedValueOnce([
+        parseEther('10000'),
+        parseEther('2500'),
+      ] as never);
+
+    await expect(token.getVestingScheduleCount()).resolves.toBe(2n);
+    await expect(token.getVestingSchedule(0n)).resolves.toEqual({
+      cliffDuration: 90n,
+      duration: 180n,
+    });
+    await expect(token.getScheduleIdsOf(beneficiary)).resolves.toEqual([
+      0n,
+      1n,
+    ]);
+    await expect(token.getTotalAllocatedOf(beneficiary)).resolves.toBe(
+      parseEther('100000'),
+    );
+    await expect(
+      token.getAvailableVestedAmountForSchedule(beneficiary, 1n),
+    ).resolves.toBe(parseEther('1234'));
+    await expect(token.getAvailableVestedAmount(beneficiary)).resolves.toBe(
+      parseEther('5678'),
+    );
+    await expect(
+      token.getVestingDataForSchedule(beneficiary, 1n),
+    ).resolves.toEqual({
+      totalAmount: parseEther('10000'),
+      releasedAmount: parseEther('2500'),
+    });
+
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(1, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'vestingScheduleCount',
+    });
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(2, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'vestingSchedules',
+      args: [0n],
+    });
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(3, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'getScheduleIdsOf',
+      args: [beneficiary],
+    });
+  });
+
+  it('reads balance-limit state', async () => {
+    vi.mocked(publicClient.readContract)
+      .mockResolvedValueOnce(parseEther('10000'))
+      .mockResolvedValueOnce(1_800_000_000)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(controller)
+      .mockResolvedValueOnce(false);
+
+    await expect(token.getMaxBalanceLimit()).resolves.toBe(parseEther('10000'));
+    await expect(token.getBalanceLimitEnd()).resolves.toBe(1_800_000_000);
+    await expect(token.isBalanceLimitActive()).resolves.toBe(true);
+    await expect(token.getController()).resolves.toBe(controller);
+    await expect(token.isExcludedFromBalanceLimit(beneficiary)).resolves.toBe(
+      false,
+    );
+
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(5, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'isExcludedFromBalanceLimit',
+      args: [beneficiary],
+    });
+  });
+
+  it('writes governance, permit, ownership, pool, and burn actions', async () => {
+    const expectedWrites: Array<{
+      run: () => Promise<Hex>;
+      functionName: string;
+      args: unknown[];
+    }> = [
+      {
+        run: () => token.delegate(delegatee),
+        functionName: 'delegate',
+        args: [delegatee],
+      },
+      {
+        run: () => token.permit(owner, spender, 100n, 200n, signature),
+        functionName: 'permit',
+        args: [owner, spender, 100n, 200n, 27, bytes32A, bytes32B],
+      },
+      {
+        run: () => token.transferOwnership(owner),
+        functionName: 'transferOwnership',
+        args: [owner],
+      },
+      {
+        run: () => token.renounceOwnership(),
+        functionName: 'renounceOwnership',
+        args: [],
+      },
+      {
+        run: () => token.requestOwnershipHandover(),
+        functionName: 'requestOwnershipHandover',
+        args: [],
+      },
+      {
+        run: () => token.cancelOwnershipHandover(),
+        functionName: 'cancelOwnershipHandover',
+        args: [],
+      },
+      {
+        run: () => token.completeOwnershipHandover(owner),
+        functionName: 'completeOwnershipHandover',
+        args: [owner],
+      },
+      {
+        run: () => token.lockPool(pool),
+        functionName: 'lockPool',
+        args: [pool],
+      },
+      {
+        run: () => token.unlockPool(),
+        functionName: 'unlockPool',
+        args: [],
+      },
+      {
+        run: () => token.burn(123n),
+        functionName: 'burn',
+        args: [123n],
+      },
+    ];
+
+    vi.mocked(publicClient.simulateContract).mockImplementation(
+      async (call: unknown) => ({ request: call }) as never,
+    );
+    vi.mocked(walletClient.writeContract).mockResolvedValue(txHash);
+
+    for (const expectedWrite of expectedWrites) {
+      await expect(expectedWrite.run()).resolves.toBe(txHash);
+    }
+
+    expectedWrites.forEach((expectedWrite, index) => {
+      expect(publicClient.simulateContract).toHaveBeenNthCalledWith(index + 1, {
+        address: mockTokenAddress,
+        abi: expect.any(Array),
+        functionName: expectedWrite.functionName,
+        args: expectedWrite.args,
+        account: walletClient.account,
+      });
+    });
+    expect(walletClient.writeContract).toHaveBeenCalledTimes(expectedWrites.length);
+  });
+
+  it('writes delegateBySig from wallet typed data', async () => {
+    vi.mocked(publicClient.readContract)
+      .mockResolvedValueOnce(7n)
+      .mockResolvedValueOnce('Doppler Token');
+    vi.mocked(publicClient.simulateContract).mockImplementation(
+      async (call: unknown) => ({ request: call }) as never,
+    );
+    walletClient.signTypedData = vi.fn().mockResolvedValue(signature);
+    const walletAccount = walletClient.account as { address: Address };
+    vi.mocked(walletClient.writeContract).mockResolvedValue(txHash);
+
+    await expect(token.delegateBySig(delegatee, 999n)).resolves.toBe(txHash);
+
+    expect(walletClient.signTypedData).toHaveBeenCalledWith({
+      domain: {
+        name: 'Doppler Token',
+        version: '1',
+        chainId: 1,
+        verifyingContract: mockTokenAddress,
+      },
+      types: {
+        Delegation: [
+          { name: 'delegatee', type: 'address' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'expiry', type: 'uint256' },
+        ],
+      },
+      primaryType: 'Delegation',
+      message: { delegatee, nonce: 7n, expiry: 999n },
+      account: walletAccount.address,
+    });
+    expect(publicClient.simulateContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'delegateBySig',
+      args: [delegatee, 7n, 999n, 27, bytes32A, bytes32B],
+      account: walletAccount,
+    });
+  });
+
+  it('writes partial release overloads and balance-limit controls', async () => {
+    vi.mocked(publicClient.simulateContract)
+      .mockResolvedValueOnce({
+        request: { functionName: 'release', args: [0n, 100n] },
+      } as never)
+      .mockResolvedValueOnce({
+        request: { functionName: 'release', args: [50n] },
+      } as never)
+      .mockResolvedValueOnce({
+        request: { functionName: 'releaseFor', args: [beneficiary, 1n, 25n] },
+      } as never)
+      .mockResolvedValueOnce({
+        request: { functionName: 'releaseFor', args: [beneficiary, 10n] },
+      } as never)
+      .mockResolvedValueOnce({
+        request: { functionName: 'disableBalanceLimit', args: [] },
+      } as never);
+    vi.mocked(walletClient.writeContract).mockResolvedValue(txHash);
+
+    await expect(token.releaseSchedule(0n, 100n)).resolves.toBe(txHash);
+    await expect(token.release(50n)).resolves.toBe(txHash);
+    await expect(token.releaseFor(beneficiary, 1n, 25n)).resolves.toBe(txHash);
+    await expect(token.releaseFor(beneficiary, 10n)).resolves.toBe(txHash);
+    await expect(token.disableBalanceLimit()).resolves.toBe(txHash);
+
+    expect(publicClient.simulateContract).toHaveBeenNthCalledWith(1, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'release',
+      args: [0n, 100n],
+      account: walletClient.account,
+    });
+    expect(publicClient.simulateContract).toHaveBeenNthCalledWith(2, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'release',
+      args: [50n],
+      account: walletClient.account,
+    });
+    expect(publicClient.simulateContract).toHaveBeenNthCalledWith(3, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'releaseFor',
+      args: [beneficiary, 1n, 25n],
+      account: walletClient.account,
+    });
+    expect(publicClient.simulateContract).toHaveBeenNthCalledWith(4, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'releaseFor',
+      args: [beneficiary, 10n],
+      account: walletClient.account,
+    });
+  });
+
+  it('throws on write methods without a wallet client', async () => {
+    const readOnly = new DopplerERC20V1(
+      publicClient,
+      undefined,
+      mockTokenAddress,
+    );
+
+    await expect(readOnly.release(1n)).rejects.toThrow(
+      'Wallet client required for write operations',
+    );
+    await expect(readOnly.disableBalanceLimit()).rejects.toThrow(
+      'Wallet client required for write operations',
+    );
+    await expect(readOnly.delegate(delegatee)).rejects.toThrow(
+      'Wallet client required for write operations',
+    );
+    await expect(readOnly.transferOwnership(owner)).rejects.toThrow(
+      'Wallet client required for write operations',
+    );
+    await expect(readOnly.lockPool(pool)).rejects.toThrow(
+      'Wallet client required for write operations',
+    );
+    await expect(readOnly.burn(1n)).rejects.toThrow(
+      'Wallet client required for write operations',
+    );
+  });
+});

--- a/test/evm/unit/entities/DopplerFactory.dopplerERC20V1.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.dopplerERC20V1.test.ts
@@ -1,0 +1,1098 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  decodeAbiParameters,
+  encodeAbiParameters,
+  encodePacked,
+  getAddress,
+  keccak256,
+  parseEther,
+  type Address,
+  type Hash,
+  type PublicClient,
+} from 'viem';
+import { DAY_SECONDS, DEAD_ADDRESS, WAD } from '../../../../src/evm/constants';
+import {
+  DynamicAuctionBuilder,
+  MulticurveBuilder,
+  OpeningAuctionBuilder,
+  StaticAuctionBuilder,
+} from '../../../../src/evm/builders';
+import { DopplerFactory } from '../../../../src/evm/entities/DopplerFactory';
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+} from '../../setup/fixtures/clients';
+import { mockAddresses } from '../../setup/fixtures/addresses';
+
+vi.mock('../../../../src/evm/addresses', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../src/evm/addresses')>();
+  return {
+    ...actual,
+    getAddresses: vi.fn(() => mockAddresses),
+  };
+});
+
+const userAddress = '0x1234567890123456789012345678901234567890' as Address;
+const beneficiary = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address;
+const controller = '0xfedcfedcfedcfedcfedcfedcfedcfedcfedcfedc' as Address;
+const excluded = '0x1111111111111111111111111111111111111111' as Address;
+const zeroAddress = '0x0000000000000000000000000000000000000000' as Address;
+const customTokenFactory =
+  '0x2222222222222222222222222222222222222222' as Address;
+const openingAuctionInitializer =
+  '0x3333333333333333333333333333333333333333' as Address;
+
+const UNISWAP_V2_PAIR_INIT_CODE_HASH =
+  '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' as const;
+const UNISWAP_V3_POOL_INIT_CODE_HASH =
+  '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54' as const;
+
+function computeUniswapV2PairAddress(tokenA: Address, tokenB: Address): Address {
+  const [token0, token1] =
+    BigInt(tokenA) < BigInt(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA];
+  const salt = keccak256(encodePacked(['address', 'address'], [token0, token1]));
+  const hash = keccak256(
+    `0xff${mockAddresses.uniswapV2Factory!.slice(2)}${salt.slice(2)}${UNISWAP_V2_PAIR_INIT_CODE_HASH.slice(2)}`,
+  );
+  return getAddress(`0x${hash.slice(-40)}`) as Address;
+}
+
+function computeUniswapV3PoolAddress(
+  tokenA: Address,
+  tokenB: Address,
+  fee: number,
+): Address {
+  const [token0, token1] =
+    BigInt(tokenA) < BigInt(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA];
+  const salt = keccak256(
+    encodeAbiParameters(
+      [{ type: 'address' }, { type: 'address' }, { type: 'uint24' }],
+      [token0, token1, fee],
+    ),
+  );
+  const hash = keccak256(
+    `0xff${mockAddresses.uniswapV3Factory!.slice(2)}${salt.slice(2)}${UNISWAP_V3_POOL_INIT_CODE_HASH.slice(2)}`,
+  );
+  return getAddress(`0x${hash.slice(-40)}`) as Address;
+}
+
+function computeCreate2Address(args: {
+  deployer: Address;
+  salt: Hash;
+  initCodeHash: Hash;
+}): Address {
+  const hash = keccak256(
+    encodePacked(
+      ['bytes1', 'address', 'bytes32', 'bytes32'],
+      ['0xff', args.deployer, args.salt, args.initCodeHash],
+    ),
+  );
+  return getAddress(`0x${hash.slice(-40)}`) as Address;
+}
+
+function computeSoladyCloneInitCodeHash(implementation: Address): Hash {
+  return keccak256(
+    `0x602c3d8160093d39f33d3d3d3d363d3d37363d73${implementation.slice(
+      2,
+    )}5af43d3d93803e602a57fd5bf3`,
+  ) as Hash;
+}
+
+function computeV1TokenAddress(salt: Hash): Address {
+  return computeCreate2Address({
+    deployer: mockAddresses.dopplerERC20V1Factory!,
+    salt,
+    initCodeHash: computeSoladyCloneInitCodeHash(
+      mockAddresses.dopplerERC20V1Implementation!,
+    ),
+  });
+}
+
+const DOPPLER_ERC20_V1_TOKEN_DATA_ABI = [
+  { type: 'string' },
+  { type: 'string' },
+  {
+    type: 'tuple[]',
+    components: [
+      { type: 'uint64', name: 'cliff' },
+      { type: 'uint64', name: 'duration' },
+    ],
+  },
+  { type: 'address[]' },
+  { type: 'uint256[]' },
+  { type: 'uint256[]' },
+  { type: 'string' },
+  { type: 'uint256' },
+  { type: 'uint48' },
+  { type: 'address' },
+  { type: 'address[]' },
+] as const;
+
+function decodeV1TokenFactoryData(data: `0x${string}`) {
+  return decodeAbiParameters(
+    DOPPLER_ERC20_V1_TOKEN_DATA_ABI,
+    data,
+  ) as readonly [
+    string,
+    string,
+    readonly { cliff: bigint; duration: bigint }[],
+    readonly Address[],
+    readonly bigint[],
+    readonly bigint[],
+    string,
+    bigint,
+    number,
+    Address,
+    readonly Address[],
+  ];
+}
+
+describe('DopplerFactory DopplerERC20V1 token routing', () => {
+  let factory: DopplerFactory;
+  let publicClient: PublicClient;
+
+  beforeEach(() => {
+    publicClient = createMockPublicClient() as PublicClient;
+    factory = new DopplerFactory(publicClient, createMockWalletClient(), 1);
+  });
+
+  it('routes static auctions with balance-limit fields through DopplerERC20V1Factory', async () => {
+    const balanceLimitEnd = Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS;
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Static Token',
+        symbol: 'SV1',
+        tokenURI: 'ipfs://static-token',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd,
+        controller,
+        excludedFromBalanceLimit: [excluded],
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withVesting({
+        duration: 180n * BigInt(DAY_SECONDS),
+        recipients: [beneficiary],
+        amounts: [parseEther('100000')],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const tokenAddress = computeV1TokenAddress(createParams.salt);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.dopplerERC20V1Factory);
+    expect(decoded[0]).toBe('Static Token');
+    expect(decoded[1]).toBe('SV1');
+    expect(decoded[2]).toEqual([
+      { cliff: 0n, duration: 180n * BigInt(DAY_SECONDS) },
+    ]);
+    expect(decoded[3]).toEqual([getAddress(beneficiary)]);
+    expect(decoded[4]).toEqual([0n]);
+    expect(decoded[5]).toEqual([parseEther('100000')]);
+    expect(decoded[6]).toBe('ipfs://static-token');
+    expect(decoded[7]).toBe(parseEther('10000'));
+    expect(decoded[8]).toBe(balanceLimitEnd);
+    expect(decoded[9]).toBe(getAddress(controller));
+    expect(decoded[10]).toEqual([
+      getAddress(excluded),
+      mockAddresses.v3Initializer,
+      mockAddresses.v2Migrator,
+      DEAD_ADDRESS,
+      computeUniswapV3PoolAddress(tokenAddress, mockAddresses.weth, 3000),
+      computeUniswapV2PairAddress(mockAddresses.weth, tokenAddress),
+    ]);
+    expect(decoded).toHaveLength(11);
+    expect(decoded).not.toContain(20_000_000_000_000_000n);
+  });
+
+  it('adds PoolManager to active static exclusions for Uniswap V4 migration', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Static Token V4 Migration',
+        symbol: 'SV1V4',
+        tokenURI: 'ipfs://static-token-v4',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd: Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV4', fee: 3000, tickSpacing: 60 })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const tokenAddress = computeV1TokenAddress(createParams.salt);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(decoded[10]).toEqual([
+      mockAddresses.v3Initializer,
+      mockAddresses.v4Migrator,
+      mockAddresses.poolManager,
+      DEAD_ADDRESS,
+      computeUniswapV3PoolAddress(tokenAddress, mockAddresses.weth, 3000),
+    ]);
+  });
+
+  it('adds launchpad governance multisig to active balance-limit exclusions', async () => {
+    const launchpadMultisig =
+      '0x4444444444444444444444444444444444444444' as Address;
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Static Token Launchpad',
+        symbol: 'SV1L',
+        tokenURI: 'ipfs://static-token-launchpad',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd: Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'launchpad', multisig: launchpadMultisig })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(decoded[10]).toContain(getAddress(launchpadMultisig));
+    expect(decoded[10]).not.toContain(DEAD_ADDRESS);
+  });
+
+  it('keeps standard cliff vesting on the DERC20 V2 route without DopplerERC20V1-specific fields', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Static Cliff',
+        symbol: 'STCL',
+        tokenURI: 'ipfs://static-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withVesting({
+        duration: 180n * BigInt(DAY_SECONDS),
+        cliffDuration: 90 * DAY_SECONDS,
+        recipients: [beneficiary],
+        amounts: [parseEther('100000')],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
+  });
+
+  it('honors generic tokenFactory overrides on the DopplerERC20V1 path', async () => {
+    const balanceLimitEnd = Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS;
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Static Token Override',
+        symbol: 'SV1O',
+        tokenURI: 'ipfs://static-token-override',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd,
+        excludedFromBalanceLimit: [excluded],
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withTokenFactory(customTokenFactory)
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(customTokenFactory);
+    expect(decoded[0]).toBe('Static Token Override');
+    expect(decoded[7]).toBe(parseEther('10000'));
+    expect(decoded[8]).toBe(balanceLimitEnd);
+    expect(decoded[9]).toBe(zeroAddress);
+    expect(decoded[10]).toEqual([getAddress(excluded)]);
+  });
+
+  it('does not inject protocol exclusions for custom tokenFactory overrides without explicit exclusions', async () => {
+    const balanceLimitEnd = Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS;
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Static Token Override Empty Exclusions',
+        symbol: 'SV1OE',
+        tokenURI: 'ipfs://static-token-override-empty-exclusions',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withTokenFactory(customTokenFactory)
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(customTokenFactory);
+    expect(decoded[0]).toBe('Static Token Override Empty Exclusions');
+    expect(decoded[7]).toBe(parseEther('10000'));
+    expect(decoded[8]).toBe(balanceLimitEnd);
+    expect(decoded[10]).toEqual([]);
+  });
+
+  it('treats raw dopplerERC20V1Factory overrides as custom balance-limit paths', async () => {
+    const balanceLimitEnd = Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS;
+    const params = {
+      ...StaticAuctionBuilder.forChain(1)
+        .tokenConfig({
+          type: 'dopplerERC20V1',
+          name: 'Static Token Raw Module Override',
+          symbol: 'SV1RM',
+          tokenURI: 'ipfs://static-token-raw-module-override',
+          maxBalanceLimit: parseEther('10000'),
+          balanceLimitEnd,
+        })
+        .saleConfig({
+          initialSupply: parseEther('1000000'),
+          numTokensToSell: parseEther('900000'),
+          numeraire: mockAddresses.weth,
+        })
+        .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+        .withGovernance({ type: 'noOp' })
+        .withMigration({ type: 'uniswapV2' })
+        .withUserAddress(userAddress)
+        .build(),
+      modules: {
+        dopplerERC20V1Factory: customTokenFactory,
+      },
+    };
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(customTokenFactory);
+    expect(decoded[7]).toBe(parseEther('10000'));
+    expect(decoded[8]).toBe(balanceLimitEnd);
+    expect(decoded[10]).toEqual([]);
+  });
+
+  it('defaults omitted controller to the zero address on explicitly typed dynamic auctions', async () => {
+    const params = DynamicAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Dynamic Token',
+        symbol: 'DT',
+        tokenURI: 'ipfs://dynamic-token',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .withMarketCapRange({
+        marketCap: { start: 500_000, min: 50_000 },
+        numerairePrice: 3000,
+        minProceeds: parseEther('100'),
+        maxProceeds: parseEther('10000'),
+        fee: 3000,
+        tickSpacing: 10,
+        duration: 7 * DAY_SECONDS,
+        epochLength: 3600,
+      })
+      .withVesting({ duration: 90n * BigInt(DAY_SECONDS) })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV4', fee: 3000, tickSpacing: 10 })
+      .withUserAddress(userAddress)
+      .build();
+
+    const { createParams } =
+      await factory.encodeCreateDynamicAuctionParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.dopplerERC20V1Factory);
+    expect(decoded[0]).toBe('Dynamic Token');
+    expect(decoded[2]).toEqual([
+      { cliff: 0n, duration: 90n * BigInt(DAY_SECONDS) },
+    ]);
+    expect(decoded[3]).toEqual([getAddress(userAddress)]);
+    expect(decoded[5]).toEqual([parseEther('100000')]);
+    expect(decoded[9]).toBe(zeroAddress);
+  });
+
+  it('routes dynamic auctions with exclusions through DopplerERC20V1Factory', async () => {
+    const params = DynamicAuctionBuilder.forChain(1)
+      .tokenConfig({
+        name: 'Dynamic Inferred Token',
+        symbol: 'DI',
+        tokenURI: 'ipfs://dynamic-inferred-token',
+        excludedFromBalanceLimit: [excluded],
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .withMarketCapRange({
+        marketCap: { start: 500_000, min: 50_000 },
+        numerairePrice: 3000,
+        minProceeds: parseEther('100'),
+        maxProceeds: parseEther('10000'),
+        fee: 3000,
+        tickSpacing: 10,
+        duration: 7 * DAY_SECONDS,
+        epochLength: 3600,
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV4', fee: 3000, tickSpacing: 10 })
+      .withUserAddress(userAddress)
+      .build();
+
+    const { createParams } =
+      await factory.encodeCreateDynamicAuctionParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.dopplerERC20V1Factory);
+    expect(decoded[0]).toBe('Dynamic Inferred Token');
+    expect(decoded[9]).toBe(zeroAddress);
+    expect(decoded[10]).toEqual([getAddress(excluded)]);
+  });
+
+  it('keeps the route for shared cliff vesting on static auctions', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Static Token Cliff',
+        symbol: 'SV1C',
+        tokenURI: 'ipfs://static-token-cliff',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withVesting({
+        duration: 90n * BigInt(DAY_SECONDS),
+        cliffDuration: 30 * DAY_SECONDS,
+        recipients: [beneficiary],
+        amounts: [parseEther('100000')],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.dopplerERC20V1Factory);
+    expect(decoded[2]).toEqual([
+      { cliff: 30n * BigInt(DAY_SECONDS), duration: 90n * BigInt(DAY_SECONDS) },
+    ]);
+    expect(decoded[3]).toEqual([getAddress(beneficiary)]);
+    expect(decoded[5]).toEqual([parseEther('100000')]);
+  });
+
+  it('routes opening auctions through DopplerERC20V1Factory', async () => {
+    vi.mocked(publicClient.readContract)
+      .mockResolvedValueOnce(mockAddresses.poolManager)
+      .mockResolvedValueOnce(mockAddresses.dopplerDeployer);
+
+    const params = OpeningAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Opening Token',
+        symbol: 'OT',
+        tokenURI: 'ipfs://opening-token',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .openingAuctionConfig({
+        auctionDuration: 3600,
+        minAcceptableTickToken0: -120000,
+        minAcceptableTickToken1: -120000,
+        incentiveShareBps: 500,
+        tickSpacing: 60,
+        fee: 3000,
+        minLiquidity: 1n,
+        shareToAuctionBps: 8000,
+      })
+      .dopplerConfig({
+        minProceeds: parseEther('100'),
+        maxProceeds: parseEther('10000'),
+        startTick: -60000,
+        endTick: -120000,
+        epochLength: 3600,
+        duration: 7 * DAY_SECONDS,
+        fee: 3000,
+        tickSpacing: 10,
+      })
+      .withVesting({ duration: 45n * BigInt(DAY_SECONDS) })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV4', fee: 3000, tickSpacing: 10 })
+      .withOpeningAuctionInitializer(openingAuctionInitializer)
+      .withUserAddress(userAddress)
+      .build();
+
+    const { createParams } =
+      await factory.encodeCreateOpeningAuctionParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.dopplerERC20V1Factory);
+    expect(decoded[0]).toBe('Opening Token');
+    expect(decoded[2]).toEqual([
+      { cliff: 0n, duration: 45n * BigInt(DAY_SECONDS) },
+    ]);
+  });
+
+  it('routes multicurve auctions through DopplerERC20V1Factory', () => {
+    const params = MulticurveBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Multicurve Token',
+        symbol: 'MV1',
+        tokenURI: 'ipfs://multicurve-token',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('700000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolConfig({
+        fee: 0,
+        tickSpacing: 8,
+        curves: [
+          { tickLower: 0, tickUpper: 80000, numPositions: 8, shares: WAD },
+        ],
+      })
+      .withVesting({
+        allocations: [
+          {
+            recipient: beneficiary,
+            amount: parseEther('300000'),
+            schedule: {
+              duration: 365n * BigInt(DAY_SECONDS),
+              cliffDuration: 30 * DAY_SECONDS,
+            },
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = factory.encodeCreateMulticurveParams(params);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.tokenFactory).toBe(mockAddresses.dopplerERC20V1Factory);
+    expect(decoded[0]).toBe('Multicurve Token');
+    expect(decoded[2]).toEqual([
+      {
+        cliff: 30n * BigInt(DAY_SECONDS),
+        duration: 365n * BigInt(DAY_SECONDS),
+      },
+    ]);
+    expect(decoded[3]).toEqual([getAddress(beneficiary)]);
+    expect(decoded[4]).toEqual([0n]);
+    expect(decoded[5]).toEqual([parseEther('300000')]);
+  });
+
+  it('rejects zero beneficiary allocations', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Allocation',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-allocation',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: 1n,
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withVesting({
+        allocations: [
+          {
+            recipient: zeroAddress,
+            amount: parseEther('1'),
+            schedule: {
+              duration: BigInt(DAY_SECONDS),
+              cliffDuration: 0,
+            },
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.vesting allocations[0].beneficiary must not be the zero address',
+    );
+  });
+
+  it('rejects zero amount allocations', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Allocation',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-allocation',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: 1n,
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withVesting({
+        allocations: [
+          {
+            recipient: beneficiary,
+            amount: 0n,
+            schedule: {
+              duration: BigInt(DAY_SECONDS),
+              cliffDuration: 0,
+            },
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.vesting allocations[0].amount must be greater than 0',
+    );
+  });
+
+  it('rejects per-beneficiary premint cap breaches', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Allocation',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-allocation',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: 1n,
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withVesting({
+        allocations: [
+          {
+            recipient: beneficiary,
+            amount: parseEther('800000.000000000000001'),
+            schedule: {
+              duration: BigInt(DAY_SECONDS),
+              cliffDuration: 0,
+            },
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.vesting allocations[0] exceed the per-beneficiary premint cap',
+    );
+  });
+
+  it('rejects mixed-case duplicate beneficiary allocations', async () => {
+    const mixedCaseBeneficiary =
+      '0xAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCd' as Address;
+
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Allocation',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-allocation',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: 1n,
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withVesting({
+        allocations: [
+          {
+            recipient: mixedCaseBeneficiary,
+            amount: parseEther('500000'),
+            schedule: {
+              duration: BigInt(DAY_SECONDS),
+              cliffDuration: 0,
+            },
+          },
+          {
+            recipient: mixedCaseBeneficiary.toLowerCase() as Address,
+            amount: parseEther('300000.000000000000001'),
+            schedule: {
+              duration: BigInt(DAY_SECONDS),
+              cliffDuration: 0,
+            },
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.vesting allocations[1] exceed the per-beneficiary premint cap',
+    );
+  });
+
+  it('rejects total premint cap breaches', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Allocation',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-allocation',
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: 1n,
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withVesting({
+        allocations: [
+          {
+            recipient: beneficiary,
+            amount: parseEther('500000'),
+            schedule: {
+              duration: BigInt(DAY_SECONDS),
+              cliffDuration: 0,
+            },
+          },
+          {
+            recipient: controller,
+            amount: parseEther('300000.000000000000001'),
+            schedule: {
+              duration: BigInt(DAY_SECONDS),
+              cliffDuration: 0,
+            },
+          },
+        ],
+      })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow('token.vesting allocations exceed the total premint cap');
+  });
+
+  it('rejects only maxBalanceLimit without balanceLimitEnd', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Limit',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-limit',
+        maxBalanceLimit: parseEther('10000'),
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.maxBalanceLimit and token.balanceLimitEnd must both be set when balance limiting is enabled',
+    );
+  });
+
+  it('allows balance-limited launches when unallocated supply exceeds the balance limit', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Static Token Excess',
+        symbol: 'SV1E',
+        tokenURI: 'ipfs://static-token-excess',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd: Math.floor(Date.now() / 1000) + 3600,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const tokenAddress = computeV1TokenAddress(createParams.salt);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(decoded[10]).toEqual([
+      mockAddresses.v3Initializer,
+      mockAddresses.v2Migrator,
+      DEAD_ADDRESS,
+      computeUniswapV3PoolAddress(tokenAddress, mockAddresses.weth, 3000),
+      computeUniswapV2PairAddress(mockAddresses.weth, tokenAddress),
+    ]);
+  });
+
+  it('rejects only balanceLimitEnd without maxBalanceLimit', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Limit',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-limit',
+        balanceLimitEnd: Math.floor(Date.now() / 1000) + 3600,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.maxBalanceLimit and token.balanceLimitEnd must both be set when balance limiting is enabled',
+    );
+  });
+
+  it('rejects zero maxBalanceLimit with future balanceLimitEnd', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Limit',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-limit',
+        maxBalanceLimit: 0n,
+        balanceLimitEnd: Math.floor(Date.now() / 1000) + 3600,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.maxBalanceLimit and token.balanceLimitEnd must both be set when balance limiting is enabled',
+    );
+  });
+
+  it('rejects positive maxBalanceLimit with zero balanceLimitEnd', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Limit',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-limit',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd: 0,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.maxBalanceLimit and token.balanceLimitEnd must both be set when balance limiting is enabled',
+    );
+  });
+
+  it('rejects maxBalanceLimit equal to initialSupply', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Limit',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-limit',
+        maxBalanceLimit: parseEther('1000000'),
+        balanceLimitEnd: Math.floor(Date.now() / 1000) + 3600,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.maxBalanceLimit must be below sale.initialSupply when balance limiting is enabled',
+    );
+  });
+
+  it('rejects maxBalanceLimit greater than initialSupply', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Limit',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-limit',
+        maxBalanceLimit: parseEther('1000001'),
+        balanceLimitEnd: Math.floor(Date.now() / 1000) + 3600,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.maxBalanceLimit must be below sale.initialSupply when balance limiting is enabled',
+    );
+  });
+
+  it('rejects expired balanceLimitEnd with positive maxBalanceLimit', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Limit',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-limit',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd: Math.floor(Date.now() / 1000) - 1,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
+      'token.balanceLimitEnd must be in the future when balance limiting is enabled',
+    );
+  });
+
+  it('rejects incompatible balance limit end values', async () => {
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Bad Limit',
+        symbol: 'BAD',
+        tokenURI: 'ipfs://bad-limit',
+        balanceLimitEnd: Number.MAX_SAFE_INTEGER,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'noOp' })
+      .withMigration({ type: 'uniswapV2' })
+      .withUserAddress(userAddress)
+      .build();
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow('token.balanceLimitEnd must fit in uint48');
+  });
+});

--- a/test/evm/unit/entities/DopplerFactory.openingAuction.openingMiner.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.openingAuction.openingMiner.test.ts
@@ -52,6 +52,22 @@ describe('DopplerFactory opening auction miner', () => {
     tokenURI: 'https://example.com/omt.json',
   } as const;
 
+  const DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA = {
+    kind: 'dopplerERC20V1',
+    name: 'Opening Miner Token',
+    symbol: 'OMT',
+    schedules: [{ cliff: 30n * 24n * 60n * 60n, duration: 180n * 24n * 60n * 60n }],
+    beneficiaries: [getAddress('0x2222222222222222222222222222222222222222') as Address],
+    scheduleIds: [0n],
+    amounts: [parseEther('2')],
+    tokenURI: 'https://example.com/omt.json',
+    maxBalanceLimit: parseEther('1000'),
+    balanceLimitEnd: 1_800_000_000,
+    controller: getAddress('0x3333333333333333333333333333333333333333') as Address,
+    excludedFromBalanceLimit: [getAddress('0x4444444444444444444444444444444444444444') as Address],
+    implementation: mockAddresses.dopplerERC20V1Implementation!,
+  } as const;
+
   const baseParams = {
     auctionDeployer: AUCTION_DEPLOYER as Address,
     openingAuctionInitializer: OPENING_AUCTION_INITIALIZER,
@@ -175,5 +191,63 @@ describe('DopplerFactory opening auction miner', () => {
 
     expect(encodedTokenFactoryData).toBe(expected);
   });
-});
 
+  it('returns encodedTokenFactoryData matching encodeAbiParameters for dopplerERC20V1 variant', () => {
+    const mineOpeningAuctionHookAddress = (
+      factory as unknown as {
+        mineOpeningAuctionHookAddress(
+          params: unknown,
+        ): readonly [string, Address, Address, `0x${string}`];
+      }
+    ).mineOpeningAuctionHookAddress.bind(factory);
+
+    const [_salt, hookAddress, _tokenAddress, encodedTokenFactoryData] =
+      mineOpeningAuctionHookAddress({
+        ...baseParams,
+        tokenVariant: 'dopplerERC20V1',
+        tokenFactory: mockAddresses.dopplerERC20V1Factory,
+        tokenFactoryData: DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA,
+        includeProtocolBalanceLimitExclusions: true,
+      });
+
+    const expected = encodeAbiParameters(
+      [
+        { type: 'string' },
+        { type: 'string' },
+        {
+          type: 'tuple[]',
+          components: [
+            { type: 'uint64', name: 'cliff' },
+            { type: 'uint64', name: 'duration' },
+          ],
+        },
+        { type: 'address[]' },
+        { type: 'uint256[]' },
+        { type: 'uint256[]' },
+        { type: 'string' },
+        { type: 'uint256' },
+        { type: 'uint48' },
+        { type: 'address' },
+        { type: 'address[]' },
+      ],
+      [
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.name,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.symbol,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.schedules,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.beneficiaries,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.scheduleIds,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.amounts,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.tokenURI,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.maxBalanceLimit,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.balanceLimitEnd,
+        DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.controller,
+        [
+          ...DOPPLER_ERC20_V1_TOKEN_FACTORY_DATA.excludedFromBalanceLimit,
+          hookAddress,
+        ],
+      ],
+    );
+
+    expect(encodedTokenFactoryData).toBe(expected);
+  });
+});

--- a/test/evm/unit/token-address-miner.test.ts
+++ b/test/evm/unit/token-address-miner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest';
 import {
   type Address,
   type Hash,
@@ -7,15 +7,20 @@ import {
   encodePacked,
   keccak256,
   getAddress,
-} from 'viem'
-import { mineTokenAddress } from '../../../src/evm/utils/tokenAddressMiner'
-import { DERC20Bytecode, DERC2080Bytecode, DopplerDN404Bytecode } from '../../../src/evm/abis'
+} from 'viem';
+import { mineTokenAddress } from '../../../src/evm/utils/tokenAddressMiner';
+import {
+  DERC20Bytecode,
+  DERC2080Bytecode,
+  DopplerDN404Bytecode,
+} from '../../../src/evm/abis';
 
-const TOKEN_FACTORY = '0x0000000000000000000000000000000000000fac' as Address
-const TOKEN_FACTORY_80 = '0xf0B5141dD9096254B2ca624dff26024f46087229' as Address
-const RECIPIENT = '0x000000000000000000000000000000000000beef' as Address
-const OWNER = '0x000000000000000000000000000000000000c0de' as Address
-const HOOK_DEPLOYER = '0x000000000000000000000000000000000000dEaD' as Address
+const TOKEN_FACTORY = '0x0000000000000000000000000000000000000fac' as Address;
+const TOKEN_FACTORY_80 =
+  '0xf0B5141dD9096254B2ca624dff26024f46087229' as Address;
+const RECIPIENT = '0x000000000000000000000000000000000000beef' as Address;
+const OWNER = '0x000000000000000000000000000000000000c0de' as Address;
+const HOOK_DEPLOYER = '0x000000000000000000000000000000000000dEaD' as Address;
 
 const STANDARD_TOKEN_ABI = [
   { type: 'string' },
@@ -25,7 +30,7 @@ const STANDARD_TOKEN_ABI = [
   { type: 'address[]' },
   { type: 'uint256[]' },
   { type: 'string' },
-] as const
+] as const;
 
 const STANDARD_TOKEN_V2_ABI = [
   { type: 'string' },
@@ -42,48 +47,50 @@ const STANDARD_TOKEN_V2_ABI = [
   { type: 'uint256[]' },
   { type: 'uint256[]' },
   { type: 'string' },
-] as const
+] as const;
 
 const DOPPLER404_TOKEN_ABI = [
   { type: 'string' },
   { type: 'string' },
   { type: 'string' },
   { type: 'uint256' },
-] as const
+] as const;
 
-const V2_IMPLEMENTATION = '0x4BBfed1c27CDE12eF6638251D81ab4e3be7556b7' as Address
+const V2_IMPLEMENTATION =
+  '0x4BBfed1c27CDE12eF6638251D81ab4e3be7556b7' as Address;
 
-function computeCreate2Address(salt: Hash, initCodeHash: Hash, deployer: Address): Address {
+function computeCreate2Address(
+  salt: Hash,
+  initCodeHash: Hash,
+  deployer: Address,
+): Address {
   const encoded = encodePacked(
     ['bytes1', 'address', 'bytes32', 'bytes32'],
-    ['0xff', deployer, salt, initCodeHash]
-  )
-  return getAddress(`0x${keccak256(encoded).slice(-40)}`)
+    ['0xff', deployer, salt, initCodeHash],
+  );
+  return getAddress(`0x${keccak256(encoded).slice(-40)}`);
 }
 
 function computeSoladyCloneInitCodeHash(implementation: Address): Hash {
   return keccak256(
     `0x602c3d8160093d39f33d3d3d3d363d3d37363d73${implementation.slice(
-      2
-    )}5af43d3d93803e602a57fd5bf3`
-  ) as Hash
+      2,
+    )}5af43d3d93803e602a57fd5bf3`,
+  ) as Hash;
 }
 
 describe('mineTokenAddress', () => {
   it('mines a matching prefix for standard tokens', () => {
-    const initialSupply = 1_000_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_ABI,
-      [
-        'Vanity Token',
-        'VNY',
-        1000n,
-        30n,
-        [RECIPIENT],
-        [100n],
-        'ipfs://token',
-      ]
-    )
+    const initialSupply = 1_000_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_ABI, [
+      'Vanity Token',
+      'VNY',
+      1000n,
+      30n,
+      [RECIPIENT],
+      [100n],
+      'ipfs://token',
+    ]);
 
     const result = mineTokenAddress({
       prefix: '0',
@@ -92,10 +99,12 @@ describe('mineTokenAddress', () => {
       recipient: RECIPIENT,
       owner: OWNER,
       tokenData,
-    })
+    });
 
-    expect(result.tokenAddress.slice(2).toLowerCase().startsWith('0')).toBe(true)
-    expect(result.iterations).toBeGreaterThan(0)
+    expect(result.tokenAddress.slice(2).toLowerCase().startsWith('0')).toBe(
+      true,
+    );
+    expect(result.iterations).toBeGreaterThan(0);
 
     const initHashData = encodeAbiParameters(
       [
@@ -121,29 +130,30 @@ describe('mineTokenAddress', () => {
         [RECIPIENT],
         [100n],
         'ipfs://token',
-      ]
-    )
+      ],
+    );
     const initHash = keccak256(
-      encodePacked(['bytes', 'bytes'], [DERC20Bytecode as Hex, initHashData])
-    ) as Hash
-    const manualAddress = computeCreate2Address(result.salt, initHash, TOKEN_FACTORY)
-    expect(manualAddress).toBe(result.tokenAddress)
-  })
+      encodePacked(['bytes', 'bytes'], [DERC20Bytecode as Hex, initHashData]),
+    ) as Hash;
+    const manualAddress = computeCreate2Address(
+      result.salt,
+      initHash,
+      TOKEN_FACTORY,
+    );
+    expect(manualAddress).toBe(result.tokenAddress);
+  });
 
   it('uses v80 bytecode when tokenFactory is TokenFactory80', () => {
-    const initialSupply = 1_000_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_ABI,
-      [
-        'Vanity Token',
-        'VNY',
-        1000n,
-        30n,
-        [RECIPIENT],
-        [100n],
-        'ipfs://token',
-      ]
-    )
+    const initialSupply = 1_000_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_ABI, [
+      'Vanity Token',
+      'VNY',
+      1000n,
+      30n,
+      [RECIPIENT],
+      [100n],
+      'ipfs://token',
+    ]);
 
     const result = mineTokenAddress({
       prefix: '0',
@@ -153,7 +163,7 @@ describe('mineTokenAddress', () => {
       owner: OWNER,
       tokenData,
       maxIterations: 200_000,
-    })
+    });
 
     const initHashData = encodeAbiParameters(
       [
@@ -179,30 +189,31 @@ describe('mineTokenAddress', () => {
         [RECIPIENT],
         [100n],
         'ipfs://token',
-      ]
-    )
+      ],
+    );
     const initHash = keccak256(
-      encodePacked(['bytes', 'bytes'], [DERC2080Bytecode as Hex, initHashData])
-    ) as Hash
+      encodePacked(['bytes', 'bytes'], [DERC2080Bytecode as Hex, initHashData]),
+    ) as Hash;
 
-    const manualAddress = computeCreate2Address(result.salt, initHash, TOKEN_FACTORY_80)
-    expect(manualAddress).toBe(result.tokenAddress)
-  })
+    const manualAddress = computeCreate2Address(
+      result.salt,
+      initHash,
+      TOKEN_FACTORY_80,
+    );
+    expect(manualAddress).toBe(result.tokenAddress);
+  });
 
   it('mines a matching suffix for standard tokens', () => {
-    const initialSupply = 1_000_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_ABI,
-      [
-        'Vanity Token',
-        'VNY',
-        1000n,
-        30n,
-        [RECIPIENT],
-        [100n],
-        'ipfs://token',
-      ]
-    )
+    const initialSupply = 1_000_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_ABI, [
+      'Vanity Token',
+      'VNY',
+      1000n,
+      30n,
+      [RECIPIENT],
+      [100n],
+      'ipfs://token',
+    ]);
 
     const result = mineTokenAddress({
       prefix: '',
@@ -213,27 +224,24 @@ describe('mineTokenAddress', () => {
       owner: OWNER,
       tokenData,
       maxIterations: 100_000,
-    })
+    });
 
-    expect(result.tokenAddress.slice(2).toLowerCase().endsWith('0')).toBe(true)
-    expect(result.iterations).toBeGreaterThan(0)
-  })
+    expect(result.tokenAddress.slice(2).toLowerCase().endsWith('0')).toBe(true);
+    expect(result.iterations).toBeGreaterThan(0);
+  });
 
   it('mines standard-v2 token addresses using the clone init code hash', () => {
-    const initialSupply = 1_000_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_V2_ABI,
-      [
-        'Vanity Token V2',
-        'VNY2',
-        1000n,
-        [{ cliff: 90n, duration: 180n }],
-        [RECIPIENT],
-        [0n],
-        [100n],
-        'ipfs://token-v2',
-      ]
-    )
+    const initialSupply = 1_000_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_V2_ABI, [
+      'Vanity Token V2',
+      'VNY2',
+      1000n,
+      [{ cliff: 90n, duration: 180n }],
+      [RECIPIENT],
+      [0n],
+      [100n],
+      'ipfs://token-v2',
+    ]);
 
     const result = mineTokenAddress({
       prefix: '0',
@@ -244,29 +252,32 @@ describe('mineTokenAddress', () => {
       tokenData,
       tokenVariant: 'standard-v2',
       v2Implementation: V2_IMPLEMENTATION,
-    })
+    });
 
-    expect(result.tokenAddress.slice(2).toLowerCase().startsWith('0')).toBe(true)
+    expect(result.tokenAddress.slice(2).toLowerCase().startsWith('0')).toBe(
+      true,
+    );
 
-    const initHash = computeSoladyCloneInitCodeHash(V2_IMPLEMENTATION)
-    const manualAddress = computeCreate2Address(result.salt, initHash, TOKEN_FACTORY)
-    expect(manualAddress).toBe(result.tokenAddress)
-  })
+    const initHash = computeSoladyCloneInitCodeHash(V2_IMPLEMENTATION);
+    const manualAddress = computeCreate2Address(
+      result.salt,
+      initHash,
+      TOKEN_FACTORY,
+    );
+    expect(manualAddress).toBe(result.tokenAddress);
+  });
 
   it('throws when standard-v2 mining is attempted without a v2 implementation address', () => {
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_V2_ABI,
-      [
-        'Vanity Token V2',
-        'VNY2',
-        1000n,
-        [{ cliff: 90n, duration: 180n }],
-        [RECIPIENT],
-        [0n],
-        [100n],
-        'ipfs://token-v2',
-      ]
-    )
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_V2_ABI, [
+      'Vanity Token V2',
+      'VNY2',
+      1000n,
+      [{ cliff: 90n, duration: 180n }],
+      [RECIPIENT],
+      [0n],
+      [100n],
+      'ipfs://token-v2',
+    ]);
 
     expect(() =>
       mineTokenAddress({
@@ -277,26 +288,23 @@ describe('mineTokenAddress', () => {
         owner: OWNER,
         tokenData,
         tokenVariant: 'standard-v2',
-      })
+      }),
     ).toThrow(
-      'TokenAddressMiner: v2Implementation is required for standard-v2 tokens'
-    )
-  })
+      'TokenAddressMiner: v2Implementation is required for standard-v2 tokens',
+    );
+  });
 
   it('mines a matching prefix and suffix together', () => {
-    const initialSupply = 1_000_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_ABI,
-      [
-        'Vanity Token',
-        'VNY',
-        1000n,
-        30n,
-        [RECIPIENT],
-        [100n],
-        'ipfs://token',
-      ]
-    )
+    const initialSupply = 1_000_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_ABI, [
+      'Vanity Token',
+      'VNY',
+      1000n,
+      30n,
+      [RECIPIENT],
+      [100n],
+      'ipfs://token',
+    ]);
 
     const result = mineTokenAddress({
       prefix: '0',
@@ -307,19 +315,21 @@ describe('mineTokenAddress', () => {
       owner: OWNER,
       tokenData,
       maxIterations: 500_000,
-    })
+    });
 
-    const addr = result.tokenAddress.slice(2).toLowerCase()
-    expect(addr.startsWith('0')).toBe(true)
-    expect(addr.endsWith('0')).toBe(true)
-  })
+    const addr = result.tokenAddress.slice(2).toLowerCase();
+    expect(addr.startsWith('0')).toBe(true);
+    expect(addr.endsWith('0')).toBe(true);
+  });
 
   it('mines doppler404 token addresses', () => {
-    const initialSupply = 42_000n
-    const tokenData = encodeAbiParameters(
-      DOPPLER404_TOKEN_ABI,
-      ['Vanity404', 'VNY404', 'ipfs://metadata', 1000n]
-    )
+    const initialSupply = 42_000n;
+    const tokenData = encodeAbiParameters(DOPPLER404_TOKEN_ABI, [
+      'Vanity404',
+      'VNY404',
+      'ipfs://metadata',
+      1000n,
+    ]);
 
     const result = mineTokenAddress({
       prefix: '1',
@@ -329,9 +339,11 @@ describe('mineTokenAddress', () => {
       owner: OWNER,
       tokenData,
       tokenVariant: 'doppler404',
-    })
+    });
 
-    expect(result.tokenAddress.slice(2).toLowerCase().startsWith('1')).toBe(true)
+    expect(result.tokenAddress.slice(2).toLowerCase().startsWith('1')).toBe(
+      true,
+    );
 
     const initHashData = encodeAbiParameters(
       [
@@ -342,33 +354,44 @@ describe('mineTokenAddress', () => {
         { type: 'address' },
         { type: 'string' },
       ],
-      ['Vanity404', 'VNY404', initialSupply, RECIPIENT, OWNER, 'ipfs://metadata']
-    )
+      [
+        'Vanity404',
+        'VNY404',
+        initialSupply,
+        RECIPIENT,
+        OWNER,
+        'ipfs://metadata',
+      ],
+    );
     const initHash = keccak256(
-      encodePacked(['bytes', 'bytes'], [DopplerDN404Bytecode as Hex, initHashData])
-    ) as Hash
-    const manualAddress = computeCreate2Address(result.salt, initHash, TOKEN_FACTORY)
-    expect(manualAddress).toBe(result.tokenAddress)
-  })
+      encodePacked(
+        ['bytes', 'bytes'],
+        [DopplerDN404Bytecode as Hex, initHashData],
+      ),
+    ) as Hash;
+    const manualAddress = computeCreate2Address(
+      result.salt,
+      initHash,
+      TOKEN_FACTORY,
+    );
+    expect(manualAddress).toBe(result.tokenAddress);
+  });
 
   it('returns hook address when hook configuration is provided', () => {
-    const initialSupply = 250_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_ABI,
-      [
-        'Hook Vanity',
-        'HVNY',
-        1500n,
-        60n,
-        [RECIPIENT],
-        [500n],
-        'ipfs://hook-token',
-      ]
-    )
+    const initialSupply = 250_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_ABI, [
+      'Hook Vanity',
+      'HVNY',
+      1500n,
+      60n,
+      [RECIPIENT],
+      [500n],
+      'ipfs://hook-token',
+    ]);
 
     const hookInitHash = keccak256(
-      encodePacked(['bytes'], ['0xfeedface'])
-    ) as Hash
+      encodePacked(['bytes'], ['0xfeedface']),
+    ) as Hash;
 
     const result = mineTokenAddress({
       prefix: '12',
@@ -383,37 +406,36 @@ describe('mineTokenAddress', () => {
         prefix: 'a',
       },
       maxIterations: 500_000,
-    })
+    });
 
-    expect(result.hookAddress).toBeDefined()
-    expect(result.hookAddress!.slice(2).toLowerCase().startsWith('a')).toBe(true)
+    expect(result.hookAddress).toBeDefined();
+    expect(result.hookAddress!.slice(2).toLowerCase().startsWith('a')).toBe(
+      true,
+    );
 
     const recomputedHook = getAddress(
       `0x${keccak256(
         encodePacked(
           ['bytes1', 'address', 'bytes32', 'bytes32'],
-          ['0xff', HOOK_DEPLOYER, result.salt, hookInitHash]
-        )
-      ).slice(-40)}`
-    )
+          ['0xff', HOOK_DEPLOYER, result.salt, hookInitHash],
+        ),
+      ).slice(-40)}`,
+    );
 
-    expect(recomputedHook).toBe(result.hookAddress)
-  })
+    expect(recomputedHook).toBe(result.hookAddress);
+  });
 
   it('throws when prefix cannot be mined within iteration limit', () => {
-    const initialSupply = 1_000_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_ABI,
-      [
-        'Vanity Token',
-        'VNY',
-        1000n,
-        30n,
-        [RECIPIENT],
-        [100n],
-        'ipfs://token',
-      ]
-    )
+    const initialSupply = 1_000_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_ABI, [
+      'Vanity Token',
+      'VNY',
+      1000n,
+      30n,
+      [RECIPIENT],
+      [100n],
+      'ipfs://token',
+    ]);
 
     const initHashData = encodeAbiParameters(
       [
@@ -439,17 +461,18 @@ describe('mineTokenAddress', () => {
         [RECIPIENT],
         [100n],
         'ipfs://token',
-      ]
-    )
+      ],
+    );
     const initHash = keccak256(
-      encodePacked(['bytes', 'bytes'], [DERC20Bytecode as Hex, initHashData])
-    ) as Hash
+      encodePacked(['bytes', 'bytes'], [DERC20Bytecode as Hex, initHashData]),
+    ) as Hash;
     const firstCandidate = computeCreate2Address(
       '0x'.padEnd(66, '0') as Hash,
       initHash,
-      TOKEN_FACTORY
-    )
-    const impossiblePrefix = firstCandidate.slice(2, 6) === 'dead' ? 'feed' : 'dead'
+      TOKEN_FACTORY,
+    );
+    const impossiblePrefix =
+      firstCandidate.slice(2, 6) === 'dead' ? 'feed' : 'dead';
 
     expect(() =>
       mineTokenAddress({
@@ -460,24 +483,21 @@ describe('mineTokenAddress', () => {
         owner: OWNER,
         tokenData,
         maxIterations: 1,
-      })
-    ).toThrowError(/could not find salt/i)
-  })
+      }),
+    ).toThrowError(/could not find salt/i);
+  });
 
   it('throws when neither prefix nor suffix is provided', () => {
-    const initialSupply = 1_000_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_ABI,
-      [
-        'Vanity Token',
-        'VNY',
-        1000n,
-        30n,
-        [RECIPIENT],
-        [100n],
-        'ipfs://token',
-      ]
-    )
+    const initialSupply = 1_000_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_ABI, [
+      'Vanity Token',
+      'VNY',
+      1000n,
+      30n,
+      [RECIPIENT],
+      [100n],
+      'ipfs://token',
+    ]);
 
     expect(() =>
       mineTokenAddress({
@@ -487,24 +507,21 @@ describe('mineTokenAddress', () => {
         recipient: RECIPIENT,
         owner: OWNER,
         tokenData,
-      })
-    ).toThrowError(/must provide prefix and\/or suffix/i)
-  })
+      }),
+    ).toThrowError(/must provide prefix and\/or suffix/i);
+  });
 
   it('throws on invalid suffix', () => {
-    const initialSupply = 1_000_000n
-    const tokenData = encodeAbiParameters(
-      STANDARD_TOKEN_ABI,
-      [
-        'Vanity Token',
-        'VNY',
-        1000n,
-        30n,
-        [RECIPIENT],
-        [100n],
-        'ipfs://token',
-      ]
-    )
+    const initialSupply = 1_000_000n;
+    const tokenData = encodeAbiParameters(STANDARD_TOKEN_ABI, [
+      'Vanity Token',
+      'VNY',
+      1000n,
+      30n,
+      [RECIPIENT],
+      [100n],
+      'ipfs://token',
+    ]);
 
     expect(() =>
       mineTokenAddress({
@@ -515,7 +532,7 @@ describe('mineTokenAddress', () => {
         recipient: RECIPIENT,
         owner: OWNER,
         tokenData,
-      } as any)
-    ).toThrowError(/suffix must be a hexadecimal string/i)
-  })
-})
+      }),
+    ).toThrowError(/suffix must be a hexadecimal string/i);
+  });
+});


### PR DESCRIPTION
Adds SDK support for the `DopplerERC20V1` token template across builders, factory encoding, chain addresses, token entity helpers, docs, examples, and unit coverage. This introduces explicit and inferred `dopplerERC20V1` token config routing, encodes the factory token data tuple with vesting and balance-limit controls, exposes `sdk.getDopplerERC20V1(...)`, and documents how default protocol balance-limit exclusions differ from custom token factory overrides.

- `README.md`: Added `DopplerERC20V1` usage docs, routing rules, balance-limit notes, and token interaction examples.
- `docs/api-builders.md`: Documented builder behavior for explicit/inferred `DopplerERC20V1` token configs and exclusions.
- `examples/README.md`: Added the new `DopplerERC20V1` example to the examples index.
- `examples/doppler-erc20-v1.ts`: Added a runnable `DopplerERC20V1` launch and token interaction example.
- `src/evm/DopplerSDK.ts`: Added `getDopplerERC20V1(...)` for constructing the new token entity.
- `src/evm/abis/index.ts`: Added the `DopplerERC20V1` ABI export.
- `src/evm/addresses.ts`: Added `DopplerERC20V1` factory and implementation address fields for supported chains.
- `src/evm/builders/DynamicAuctionBuilder.ts`: Updated dynamic auction `tokenConfig` typing to accept `DopplerERC20V1` configs.
- `src/evm/builders/MulticurveBuilder.ts`: Updated multicurve `tokenConfig` typing to accept `DopplerERC20V1` configs.
- `src/evm/builders/OpeningAuctionBuilder.ts`: Updated opening auction `tokenConfig` typing to accept `DopplerERC20V1` configs.
- `src/evm/builders/StaticAuctionBuilder.ts`: Updated static auction `tokenConfig` typing to accept `DopplerERC20V1` configs.
- `src/evm/builders/shared.ts`: Added `DopplerERC20V1` config detection and normalization helpers.
- `src/evm/entities/DopplerFactory.ts`: Added `DopplerERC20V1` routing, validation, factory-data encoding, address prediction, and balance-limit exclusion handling.
- `src/evm/entities/token/derc20/DopplerERC20V1.ts`: Added the `DopplerERC20V1` token wrapper with reads/writes for vesting, votes, ownership, pool lock, releases, and balance limits.
- `src/evm/entities/token/derc20/index.ts`: Re-exported the new `DopplerERC20V1` token entity.
- `src/evm/entities/token/index.ts`: Re-exported `DopplerERC20V1` from the token entity barrel.
- `src/evm/index.ts`: Added public exports for `DopplerERC20V1` and its config types.
- `src/evm/types.ts`: Added `DopplerERC20V1` token config types and module address override fields.
- `src/evm/utils/tokenAddressMiner.ts`: Applied formatting cleanup without adding public `DopplerERC20V1` mining support.
- `test/evm/setup/fixtures/addresses.ts`: Added mock `DopplerERC20V1` factory and implementation addresses for tests.
- `test/evm/unit/addresses.test.ts`: Added assertions for generated `DopplerERC20V1` chain addresses.
- `test/evm/unit/builders/interface.test.ts`: Added builder interface coverage for `DopplerERC20V1`-compatible token factory overrides.
- `test/evm/unit/entities/DopplerERC20V1.test.ts`: Added unit coverage for the new `DopplerERC20V1` token entity and ABI shape.
- `test/evm/unit/entities/DopplerFactory.dopplerERC20V1.test.ts`: Added factory routing, encoding, validation, and exclusion tests for `DopplerERC20V1`.
- `test/evm/unit/entities/DopplerFactory.openingAuction.openingMiner.test.ts`: Added opening-auction miner coverage for `DopplerERC20V1` `tokenFactoryData`.
- `test/evm/unit/token-address-miner.test.ts`: Applied formatting cleanup to token address miner tests.