### PR TITLE
fix: scheduled multicurve monad test

### DIFF
--- a/test/evm/fork/multicurve-scheduled.monad-mainnet.test.ts
+++ b/test/evm/fork/multicurve-scheduled.monad-mainnet.test.ts
@@ -156,8 +156,8 @@ describe('Scheduled Multicurve (Monad Mainnet) smoke test', () => {
 
     expect(decoded.startingTime).toBe(oneHourFromNow)
 
-    const { asset, pool } = await sdk.factory.simulateCreateMulticurve(params)
-    expect(asset).toMatch(/^0x[a-fA-F0-9]{40}$/)
-    expect(pool).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    const { tokenAddress, poolId } = await sdk.factory.simulateCreateMulticurve(params)
+    expect(tokenAddress).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    expect(poolId).toMatch(/^0x[a-fA-F0-9]{64}$/)
   })
 })


### PR DESCRIPTION
Updates the Monad scheduled multicurve smoke test to use the current `simulateCreateMulticurve()` return shape by replacing stale `asset` / `pool` assertions with `tokenAddress` / `poolId`.