### PR TITLE
chore: improve release readiness and coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chain: [base, base-sepolia, mainnet, eth-sepolia]
+        chain: [base, base-sepolia, mainnet, monad-mainnet]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test-airlock-whitelisting.yml
+++ b/.github/workflows/test-airlock-whitelisting.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       chains:
-        description: 'Chains to test (comma-separated: base,base-sepolia,mainnet,eth-sepolia,ink,unichain,unichain-sepolia,monad-testnet,monad-mainnet or "all")'
+        description: 'Chains to test (comma-separated: base,base-sepolia,mainnet,monad-mainnet or "all")'
         required: false
-        default: 'base,base-sepolia,mainnet,eth-sepolia,unichain,unichain-sepolia,monad-mainnet'
+        default: 'base,base-sepolia,mainnet,monad-mainnet'
         type: string
       rpc_delay_ms:
         description: 'Delay between RPC calls in ms (increase if rate limited)'
@@ -31,7 +31,7 @@ jobs:
     env:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
       # workflow_dispatch can specify chains; automated runs keep a reduced default set
-      TEST_CHAINS: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.chains || 'base,base-sepolia,mainnet,eth-sepolia,unichain,unichain-sepolia,monad-mainnet') || 'base,base-sepolia,mainnet,eth-sepolia,monad-mainnet' }}
+      TEST_CHAINS: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.chains || 'base,base-sepolia,mainnet,monad-mainnet') || 'base,base-sepolia,mainnet,monad-mainnet' }}
       RPC_DELAY_MS: ${{ github.event.inputs.rpc_delay_ms || '1000' }}
       CI: true
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -121,7 +121,7 @@ import { parseEther } from 'viem'
 import { DynamicAuctionBuilder } from '@whetstone-research/doppler-sdk/evm'
 
 // Build params with a fluent, type-safe builder
-const params = new DynamicAuctionBuilder()
+const params = new DynamicAuctionBuilder(chainId)
   .tokenConfig({
     name: 'Community Token',
     symbol: 'COMM',
@@ -447,7 +447,7 @@ import { parseEther } from 'viem'
 const sdk = new DopplerSDK({ publicClient, walletClient, chainId })
 
 // Build params with the builder
-const params = new DynamicAuctionBuilder()
+const params = new DynamicAuctionBuilder(chainId)
   .tokenConfig({ name: 'Example Token', symbol: 'EXT', tokenURI: 'ipfs://...' })
   .saleConfig({ initialSupply: parseEther('1000000'), numTokensToSell: parseEther('900000'), numeraire: wethAddress })
   .poolConfig({ fee: 3000, tickSpacing: 60 })

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Static auctions use Uniswap V3 pools with concentrated liquidity in a fixed pric
 
 ```typescript
 import { StaticAuctionBuilder } from '@whetstone-research/doppler-sdk/evm';
+import { base } from 'viem/chains';
 
-const params = new StaticAuctionBuilder()
+const params = new StaticAuctionBuilder(base.id)
   .tokenConfig({
     name: 'My Token',
     symbol: 'MTK',
@@ -186,8 +187,9 @@ import {
   DynamicAuctionBuilder,
   DAY_SECONDS,
 } from '@whetstone-research/doppler-sdk/evm';
+import { base } from 'viem/chains';
 
-const params = new DynamicAuctionBuilder()
+const params = new DynamicAuctionBuilder(base.id)
   .tokenConfig({
     name: 'My Token',
     symbol: 'MTK',
@@ -598,9 +600,10 @@ import {
   DynamicAuctionBuilder,
 } from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
+import { base } from 'viem/chains';
 
 // Dynamic auction via builder
-const dynamicParams = new DynamicAuctionBuilder()
+const dynamicParams = new DynamicAuctionBuilder(base.id)
   .tokenConfig({
     name: 'My Token',
     symbol: 'MTK',
@@ -624,7 +627,7 @@ const dynamicParams = new DynamicAuctionBuilder()
 const dyn = await sdk.factory.createDynamicAuction(dynamicParams);
 
 // Static auction via builder
-const staticParams = new StaticAuctionBuilder()
+const staticParams = new StaticAuctionBuilder(base.id)
   .tokenConfig({
     name: 'My Token',
     symbol: 'MTK',
@@ -652,7 +655,7 @@ The SDK intelligently applies defaults when parameters are omitted. Here are exa
 
 ```typescript
 // Minimal static auction via builder
-const staticMinimal = new StaticAuctionBuilder()
+const staticMinimal = new StaticAuctionBuilder(base.id)
   .tokenConfig({
     name: 'My Token',
     symbol: 'MTK',
@@ -671,7 +674,7 @@ const staticMinimal = new StaticAuctionBuilder()
 const staticResult = await sdk.factory.createStaticAuction(staticMinimal);
 
 // Minimal dynamic auction via builder
-const dynamicMinimal = new DynamicAuctionBuilder()
+const dynamicMinimal = new DynamicAuctionBuilder(base.id)
   .tokenConfig({
     name: 'My Token',
     symbol: 'MTK',
@@ -1450,7 +1453,7 @@ import {
 import { parseEther, keccak256, encodePacked, encodeAbiParameters } from 'viem';
 import { base } from 'viem/chains';
 
-const builder = new DynamicAuctionBuilder()
+const builder = new DynamicAuctionBuilder(base.id)
   .tokenConfig({
     name: 'My Token',
     symbol: 'MTK',
@@ -1704,8 +1707,6 @@ The SDK includes comprehensive tests covering:
 - **Multicurve Functionality**: Tests multicurve auction creation and quoting
 - **Token Address Mining**: Tests for generating optimized token addresses
 
-See [`test/README.md`](./test/README.md) for detailed testing documentation.
-
 To run whitelisting tests:
 
 ```bash
@@ -1719,7 +1720,7 @@ ALCHEMY_API_KEY=your_key_here pnpm test:whitelisting
 TEST_CHAINS=mainnet,base,base-sepolia,monad-mainnet pnpm test:whitelisting
 ```
 
-The whitelisting suite is scoped to Ethereum Mainnet, Monad Mainnet, Base Mainnet, and Base Sepolia.
+The whitelisting suite is scoped to the release-audit chains: Ethereum Mainnet, Monad Mainnet, Base Mainnet, and Base Sepolia.
 
 Whitelisting test RPC priority is:
 

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -62,7 +62,7 @@ Methods (chainable):
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
   - `allocations`: Optional array of `{ recipient, amount, schedule }` entries for per-beneficiary schedule vesting. Identical schedules are deduped internally.
-- withGovernance(GovernanceConfig | { useDefaults: true } | { noOp: true } | undefined)
+- withGovernance(GovernanceOption)
 - withMigration(MigrationConfig)
 - withUserAddress(address)
 - withIntegrator(address?)
@@ -104,7 +104,7 @@ const params = sdk.buildStaticAuction()
   .build()
 
 // Example 2: Single vesting beneficiary with price range (legacy)
-const paramsLegacy = new StaticAuctionBuilder()
+const paramsLegacy = new StaticAuctionBuilder(chainId)
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000_000'), numTokensToSell: parseEther('900_000_000'), numeraire: weth })
   .poolByPriceRange({ priceRange: { startPrice: 0.0001, endPrice: 0.001 }, fee: 3000 })
@@ -115,7 +115,7 @@ const paramsLegacy = new StaticAuctionBuilder()
   .build()
 
 // Example 3: Multiple vesting beneficiaries
-const paramsMultiVest = new StaticAuctionBuilder()
+const paramsMultiVest = new StaticAuctionBuilder(chainId)
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000_000'), numTokensToSell: parseEther('900_000_000'), numeraire: weth })
   .withMarketCapRange({
@@ -134,7 +134,7 @@ const paramsMultiVest = new StaticAuctionBuilder()
   .build()
 
 // Example 4: Per-beneficiary vesting schedules (DERC20 V2)
-const paramsPerSchedule = new StaticAuctionBuilder()
+const paramsPerSchedule = new StaticAuctionBuilder(chainId)
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000_000'), numTokensToSell: parseEther('900_000_000'), numeraire: weth })
   .withMarketCapRange({
@@ -254,7 +254,7 @@ const params = sdk.buildDynamicAuction()
   .build()
 
 // Example 2: Using raw ticks (for advanced users or custom fee/tickSpacing)
-const paramsManual = new DynamicAuctionBuilder()
+const paramsManual = new DynamicAuctionBuilder(chainId)
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000'), numTokensToSell: parseEther('900_000'), numeraire: weth })
   .poolConfig({ fee: 3000, tickSpacing: 10 }) // Use poolConfig() + auctionByTicks() for manual config (tickSpacing <= 30)
@@ -301,7 +301,7 @@ Methods (chainable):
 - withVesting({ duration?, cliffDuration?, recipients?, amounts?, allocations? } | undefined)
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
-- withGovernance(GovernanceConfig)
+- withGovernance(GovernanceOption)
   - Call is required; use `{ type: 'default' }`, `{ type: 'custom', ... }`, or `{ type: 'noOp' }` where supported
 - withMigration(MigrationConfig)
   - Supports `uniswapV2`, `uniswapV2Split`, `uniswapV4`, `uniswapV4Split`, and `noOp`

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -117,7 +117,7 @@ const { poolAddress, tokenAddress } = await factory.create({
 ```typescript
 import { StaticAuctionBuilder } from '@whetstone-research/doppler-sdk/evm'
 
-const params = new StaticAuctionBuilder()
+const params = new StaticAuctionBuilder(chainId)
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/token' })
   .saleConfig({
     initialSupply: parseEther('1000000'),
@@ -183,7 +183,7 @@ const { hookAddress, tokenAddress } = await factory.create({
 ```typescript
 import { DynamicAuctionBuilder, DAY_SECONDS } from '@whetstone-research/doppler-sdk/evm'
 
-const params = new DynamicAuctionBuilder()
+const params = new DynamicAuctionBuilder(chainId)
   .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/token' })
   .saleConfig({ initialSupply: parseEther('1000000'), numTokensToSell: parseEther('500000'), numeraire: wethAddress })
   .poolConfig({ fee: 3000, tickSpacing: 60 })

--- a/examples/README.md
+++ b/examples/README.md
@@ -239,7 +239,7 @@ const gasEstimate = await publicClient.estimateGas({
 
 ## Testing Examples
 
-The SDK includes fork tests for all examples to ensure they work correctly. These tests run against live testnet data and validate the complete example flows.
+The SDK includes fork tests for selected EVM example flows. These tests run against forked/live network state and validate the covered example paths without implying every example file has a dedicated fork test.
 
 ### Running Fork Tests
 
@@ -261,7 +261,7 @@ pnpm test:watch
 
 ### Test Coverage
 
-The following examples have corresponding fork tests:
+The following example groups have corresponding fork tests:
 
 - **Multicurve Examples**: `test/multicurve*.test.ts`
 - **Quote & Swap**: `test/multicurve-quote-swap.test.ts`
@@ -280,5 +280,5 @@ Fork tests validate:
 For questions or issues:
 
 - Read the [SDK documentation](../README.md)
-- Check the [migration guide](../docs/MIGRATION.md)
+- Check the [migration guide](../docs/migration-guide.md)
 - Open an issue on [GitHub](https://github.com/doppler-sdk/issues)

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -617,7 +617,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     numeraire: Address;
   }): Address | undefined {
     if (
-      args.migration.type !== 'uniswapV2' ||
+      (args.migration.type !== 'uniswapV2' &&
+        args.migration.type !== 'uniswapV2Split') ||
       !args.addresses.uniswapV2Factory
     ) {
       return undefined;
@@ -5635,7 +5636,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       }
       case 'noOp': {
         const noOpAddress = overrides?.noOpMigrator ?? addresses.noOpMigrator;
-        if (!noOpAddress) {
+        if (!noOpAddress || noOpAddress === ZERO_ADDRESS) {
           throw new Error(
             'NoOpMigrator not configured on this chain. Provide override via modules.noOpMigrator or update chain config.',
           );

--- a/test/evm/e2e/whitelisting.test.ts
+++ b/test/evm/e2e/whitelisting.test.ts
@@ -47,16 +47,17 @@ function getTestChainIds(): SupportedChainId[] {
     return [...WHITELIST_TEST_CHAIN_IDS];
   }
   const chainNames = testChains.split(',').map((s) => s.trim());
-  const chainIds: SupportedChainId[] = [];
-  for (const name of chainNames) {
-    const id = CHAIN_NAME_TO_ID[name];
-    if (id !== undefined) {
-      chainIds.push(id);
-    } else {
-      console.warn(`Unknown chain name: ${name}`);
-    }
+  const unknownChainNames = chainNames.filter(
+    (name) => !(name in CHAIN_NAME_TO_ID),
+  );
+  if (unknownChainNames.length > 0) {
+    throw new Error(
+      `Unknown TEST_CHAINS value(s): ${unknownChainNames.join(', ')}. ` +
+        `Supported values: all, ${Object.keys(CHAIN_NAME_TO_ID).join(', ')}`,
+    );
   }
-  return chainIds;
+
+  return chainNames.map((name) => CHAIN_NAME_TO_ID[name]);
 }
 
 // Track results for summary
@@ -73,7 +74,9 @@ interface TestResult {
 
 const testResults = new Map<string, TestResult>();
 
-function getTestResultKey(result: Pick<TestResult, 'chainId' | 'module' | 'address'>) {
+function getTestResultKey(
+  result: Pick<TestResult, 'chainId' | 'module' | 'address'>,
+) {
   return `${result.chainId}:${result.module}:${result.address}`;
 }
 
@@ -118,7 +121,9 @@ function shouldSkipAirlockModuleCase(
   chainId: SupportedChainId,
   moduleName: string,
 ) {
-  return Boolean(SKIPPED_AIRLOCK_MODULES_BY_CHAIN[chainId]?.includes(moduleName));
+  return Boolean(
+    SKIPPED_AIRLOCK_MODULES_BY_CHAIN[chainId]?.includes(moduleName),
+  );
 }
 
 function formatExpectation(value: number | string | undefined): string {
@@ -129,7 +134,6 @@ function formatExpectation(value: number | string | undefined): string {
   return value;
 }
 
-
 describe('Airlock Module Whitelisting', () => {
   // Use filtered chain IDs from env var (defaults to all)
   const supportedChainIds = getTestChainIds();
@@ -137,7 +141,15 @@ describe('Airlock Module Whitelisting', () => {
   // Print summary after all tests
   afterAll(() => {
     const finalResults = Array.from(testResults.values());
-    const failed = finalResults.filter(r => r.status === 'FAIL' || r.status === 'RPC_ERROR');
+    const failed = finalResults.filter(
+      (r) => r.status === 'FAIL' || r.status === 'RPC_ERROR',
+    );
+    if (finalResults.length === 0) {
+      throw new Error(
+        'Whitelist audit ran zero module checks. Verify TEST_CHAINS and RPC configuration before release.',
+      );
+    }
+
     if (failed.length > 0 || finalResults.length > 0) {
       console.log('\n' + '='.repeat(80));
       console.log('  TEST RESULTS SUMMARY');
@@ -152,15 +164,26 @@ describe('Airlock Module Whitelisting', () => {
 
       for (const [chainId, results] of byChain) {
         const chainName = results[0]?.chain || `Chain ${chainId}`;
-        const passed = results.filter(r => r.status === 'PASS').length;
-        const failedCount = results.filter(r => r.status === 'FAIL' || r.status === 'RPC_ERROR').length;
-        console.log(`\n  ${chainName} (${chainId}): ${passed} passed, ${failedCount} failed`);
+        const passed = results.filter((r) => r.status === 'PASS').length;
+        const failedCount = results.filter(
+          (r) => r.status === 'FAIL' || r.status === 'RPC_ERROR',
+        ).length;
+        console.log(
+          `\n  ${chainName} (${chainId}): ${passed} passed, ${failedCount} failed`,
+        );
 
         for (const r of results) {
-          const icon = r.status === 'PASS' ? '[PASS]' : r.status === 'SKIP' ? '[SKIP]' : '[FAIL]';
+          const icon =
+            r.status === 'PASS'
+              ? '[PASS]'
+              : r.status === 'SKIP'
+                ? '[SKIP]'
+                : '[FAIL]';
           console.log(`    ${icon} ${r.module}: ${r.address}`);
           if (r.status === 'FAIL') {
-            console.log(`           Expected: ${formatExpectation(r.expected)}`);
+            console.log(
+              `           Expected: ${formatExpectation(r.expected)}`,
+            );
             console.log(`           Actual:   ${formatExpectation(r.actual)}`);
           } else if (r.status === 'RPC_ERROR') {
             console.log(`           Error: ${r.error}`);
@@ -201,7 +224,7 @@ describe('Airlock Module Whitelisting', () => {
       async function testModule(
         moduleName: string,
         moduleAddress: Address,
-        expectedState: ModuleState
+        expectedState: ModuleState,
       ) {
         const result: TestResult = {
           chain: chainName,
@@ -226,7 +249,7 @@ describe('Airlock Module Whitelisting', () => {
             result.status = 'FAIL';
             recordTestResult(result);
             throw new Error(
-              `State=${formatExpectation(result.actual)}, expected ${formatExpectation(expectedState)} | ${moduleAddress}`
+              `State=${formatExpectation(result.actual)}, expected ${formatExpectation(expectedState)} | ${moduleAddress}`,
             );
           }
 

--- a/test/evm/unit/builders/MulticurveBuilder.test.ts
+++ b/test/evm/unit/builders/MulticurveBuilder.test.ts
@@ -375,6 +375,95 @@ describe('MulticurveBuilder', () => {
       );
     });
 
+    it.each([
+      ['Date', new Date('2027-01-01T00:00:00.000Z')],
+      ['bigint', 1_861_459_201n],
+    ] as const)(
+      'normalizes %s startingTime to seconds',
+      (_label, startingTime) => {
+        const expectedStartingTime =
+          startingTime instanceof Date
+            ? Math.floor(startingTime.getTime() / 1000)
+            : Number(startingTime);
+
+        const params = buildBaseBuilder()
+          .withRehypeDopplerHook({
+            hookAddress: '0x9999999999999999999999999999999999999999' as Address,
+            buybackDestination:
+              '0x8888888888888888888888888888888888888888' as Address,
+            startFee: 3000,
+            endFee: 3000,
+            durationSeconds: 0,
+            startingTime,
+            feeDistributionInfo: {
+              assetFeesToAssetBuybackWad: parseEther('0.25'),
+              assetFeesToNumeraireBuybackWad: parseEther('0.25'),
+              assetFeesToBeneficiaryWad: parseEther('0.25'),
+              assetFeesToLpWad: parseEther('0.25'),
+              numeraireFeesToAssetBuybackWad: parseEther('0.25'),
+              numeraireFeesToNumeraireBuybackWad: parseEther('0.25'),
+              numeraireFeesToBeneficiaryWad: parseEther('0.25'),
+              numeraireFeesToLpWad: parseEther('0.25'),
+            },
+          })
+          .build();
+
+        const rehype = (params.initializer as { type: 'rehype'; config: { startingTime: number } }).config;
+        expect(rehype.startingTime).toBe(expectedStartingTime);
+      },
+    );
+
+    it('rejects graduationMarketCap and farTick together', () => {
+      expect(() =>
+        buildBaseBuilder().withRehypeDopplerHook({
+          hookAddress: '0x9999999999999999999999999999999999999999' as Address,
+          buybackDestination:
+            '0x8888888888888888888888888888888888888888' as Address,
+          startFee: 3000,
+          endFee: 3000,
+          durationSeconds: 0,
+          graduationMarketCap: 500_000,
+          farTick: 100,
+          feeDistributionInfo: {
+            assetFeesToAssetBuybackWad: parseEther('0.25'),
+            assetFeesToNumeraireBuybackWad: parseEther('0.25'),
+            assetFeesToBeneficiaryWad: parseEther('0.25'),
+            assetFeesToLpWad: parseEther('0.25'),
+            numeraireFeesToAssetBuybackWad: parseEther('0.25'),
+            numeraireFeesToNumeraireBuybackWad: parseEther('0.25'),
+            numeraireFeesToBeneficiaryWad: parseEther('0.25'),
+            numeraireFeesToLpWad: parseEther('0.25'),
+          },
+        }),
+      ).toThrow('Cannot specify both graduationMarketCap and farTick');
+    });
+
+    it('rejects graduationMarketCap during build when numerairePrice is missing', () => {
+      const builder = buildBaseBuilder().withRehypeDopplerHook({
+        hookAddress: '0x9999999999999999999999999999999999999999' as Address,
+        buybackDestination:
+          '0x8888888888888888888888888888888888888888' as Address,
+        startFee: 3000,
+        endFee: 3000,
+        durationSeconds: 0,
+        graduationMarketCap: 500_000,
+        feeDistributionInfo: {
+          assetFeesToAssetBuybackWad: parseEther('0.25'),
+          assetFeesToNumeraireBuybackWad: parseEther('0.25'),
+          assetFeesToBeneficiaryWad: parseEther('0.25'),
+          assetFeesToLpWad: parseEther('0.25'),
+          numeraireFeesToAssetBuybackWad: parseEther('0.25'),
+          numeraireFeesToNumeraireBuybackWad: parseEther('0.25'),
+          numeraireFeesToBeneficiaryWad: parseEther('0.25'),
+          numeraireFeesToLpWad: parseEther('0.25'),
+        },
+      });
+
+      expect(() => builder.build()).toThrow(
+        'graduationMarketCap requires numerairePrice',
+      );
+    });
+
     it('normalizes legacy rehype fields into fee schedule and matrix fields', () => {
       const params = buildBaseBuilder()
         .withRehypeDopplerHook({

--- a/test/evm/unit/entities/DopplerERC20V1.test.ts
+++ b/test/evm/unit/entities/DopplerERC20V1.test.ts
@@ -270,6 +270,63 @@ describe('DopplerERC20V1', () => {
     });
   });
 
+  it('reads ERC20 metadata, balances, supply, and allowance', async () => {
+    vi.mocked(publicClient.readContract)
+      .mockResolvedValueOnce('Doppler V1')
+      .mockResolvedValueOnce('DPLR')
+      .mockResolvedValueOnce(18)
+      .mockResolvedValueOnce('ipfs://token-metadata')
+      .mockResolvedValueOnce(1234n)
+      .mockResolvedValueOnce(5678n)
+      .mockResolvedValueOnce(42n);
+
+    await expect(token.getName()).resolves.toBe('Doppler V1');
+    await expect(token.getSymbol()).resolves.toBe('DPLR');
+    await expect(token.getDecimals()).resolves.toBe(18);
+    await expect(token.getTokenURI()).resolves.toBe('ipfs://token-metadata');
+    await expect(token.getBalanceOf(beneficiary)).resolves.toBe(1234n);
+    await expect(token.getTotalSupply()).resolves.toBe(5678n);
+    await expect(token.getAllowance(owner, spender)).resolves.toBe(42n);
+
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(1, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'name',
+    });
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(2, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'symbol',
+    });
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(3, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'decimals',
+    });
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(4, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'tokenURI',
+    });
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(5, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'balanceOf',
+      args: [beneficiary],
+    });
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(6, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'totalSupply',
+    });
+    expect(publicClient.readContract).toHaveBeenNthCalledWith(7, {
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'allowance',
+      args: [owner, spender],
+    });
+  });
+
   it('reads schedule vesting data', async () => {
     vi.mocked(publicClient.readContract)
       .mockResolvedValueOnce(2n)
@@ -358,6 +415,21 @@ describe('DopplerERC20V1', () => {
       args: unknown[];
     }> = [
       {
+        run: () => token.approve(spender, 25n),
+        functionName: 'approve',
+        args: [spender, 25n],
+      },
+      {
+        run: () => token.transfer(beneficiary, 50n),
+        functionName: 'transfer',
+        args: [beneficiary, 50n],
+      },
+      {
+        run: () => token.transferFrom(owner, beneficiary, 75n),
+        functionName: 'transferFrom',
+        args: [owner, beneficiary, 75n],
+      },
+      {
         run: () => token.delegate(delegatee),
         functionName: 'delegate',
         args: [delegatee],
@@ -403,6 +475,11 @@ describe('DopplerERC20V1', () => {
         args: [],
       },
       {
+        run: () => token.updateTokenURI('ipfs://updated-token-uri'),
+        functionName: 'updateTokenURI',
+        args: ['ipfs://updated-token-uri'],
+      },
+      {
         run: () => token.burn(123n),
         functionName: 'burn',
         args: [123n],
@@ -428,6 +505,30 @@ describe('DopplerERC20V1', () => {
       });
     });
     expect(walletClient.writeContract).toHaveBeenCalledTimes(expectedWrites.length);
+  });
+
+  it('passes gas overrides through write simulations and wallet writes', async () => {
+    const gas = 123_456n;
+
+    vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
+      request: {
+        address: mockTokenAddress,
+        abi: dopplerERC20V1Abi,
+        functionName: 'approve',
+        args: [spender, 1n],
+      },
+    } as never);
+    vi.mocked(walletClient.writeContract).mockResolvedValueOnce(txHash);
+
+    await expect(token.approve(spender, 1n, { gas })).resolves.toBe(txHash);
+
+    expect(walletClient.writeContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: dopplerERC20V1Abi,
+      functionName: 'approve',
+      args: [spender, 1n],
+      gas,
+    });
   });
 
   it('writes delegateBySig from wallet typed data', async () => {

--- a/test/evm/unit/entities/DopplerFactory.dopplerERC20V1.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.dopplerERC20V1.test.ts
@@ -48,10 +48,15 @@ const UNISWAP_V2_PAIR_INIT_CODE_HASH =
 const UNISWAP_V3_POOL_INIT_CODE_HASH =
   '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54' as const;
 
-function computeUniswapV2PairAddress(tokenA: Address, tokenB: Address): Address {
+function computeUniswapV2PairAddress(
+  tokenA: Address,
+  tokenB: Address,
+): Address {
   const [token0, token1] =
     BigInt(tokenA) < BigInt(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA];
-  const salt = keccak256(encodePacked(['address', 'address'], [token0, token1]));
+  const salt = keccak256(
+    encodePacked(['address', 'address'], [token0, token1]),
+  );
   const hash = keccak256(
     `0xff${mockAddresses.uniswapV2Factory!.slice(2)}${salt.slice(2)}${UNISWAP_V2_PAIR_INIT_CODE_HASH.slice(2)}`,
   );
@@ -212,6 +217,44 @@ describe('DopplerFactory DopplerERC20V1 token routing', () => {
     ]);
     expect(decoded).toHaveLength(11);
     expect(decoded).not.toContain(20_000_000_000_000_000n);
+  });
+
+  it('adds the Uniswap V2 pair exclusion for V2 split migrations', async () => {
+    const balanceLimitEnd = Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS;
+    const params = StaticAuctionBuilder.forChain(1)
+      .tokenConfig({
+        type: 'dopplerERC20V1',
+        name: 'Split Token',
+        symbol: 'SPV1',
+        tokenURI: 'ipfs://split-token',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd,
+      })
+      .saleConfig({
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: mockAddresses.weth,
+      })
+      .poolByTicks({ startTick: -120000, endTick: -60000, fee: 3000 })
+      .withGovernance({ type: 'default' })
+      .withMigration({
+        type: 'uniswapV2Split',
+        proceedsSplit: {
+          recipient: beneficiary,
+          share: parseEther('0.1'),
+        },
+      })
+      .withUserAddress(userAddress)
+      .build();
+
+    const createParams = await factory.encodeCreateStaticAuctionParams(params);
+    const tokenAddress = computeV1TokenAddress(createParams.salt);
+    const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
+
+    expect(createParams.liquidityMigrator).toBe(mockAddresses.v2MigratorSplit);
+    expect(decoded[10]).toContain(
+      computeUniswapV2PairAddress(mockAddresses.weth, tokenAddress),
+    );
   });
 
   it('adds PoolManager to active static exclusions for Uniswap V4 migration', async () => {

--- a/test/evm/unit/entities/DopplerFactory.splitMigrators.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.splitMigrators.test.ts
@@ -2,10 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { privateKeyToAccount } from 'viem/accounts';
 import { decodeAbiParameters, parseEther, type Address } from 'viem';
 import { DopplerFactory } from '../../../../src/evm/entities/DopplerFactory';
-import {
-  CHAIN_IDS,
-  getAddresses,
-} from '../../../../src/evm/addresses';
+import { CHAIN_IDS, getAddresses } from '../../../../src/evm/addresses';
 import type {
   CreateDynamicAuctionParams,
   CreateStaticAuctionParams,
@@ -134,9 +131,8 @@ describe('DopplerFactory split migrator support', () => {
       blockTimestamp: 1,
     };
 
-    const { createParams } = await factory.encodeCreateDynamicAuctionParams(
-      params,
-    );
+    const { createParams } =
+      await factory.encodeCreateDynamicAuctionParams(params);
 
     expect(createParams.liquidityMigrator).toBe(
       getAddresses(CHAIN_IDS.BASE_SEPOLIA).v4MigratorSplit,
@@ -204,9 +200,41 @@ describe('DopplerFactory split migrator support', () => {
       userAddress: account.address,
     } as CreateStaticAuctionParams;
 
-    await expect(factory.encodeCreateStaticAuctionParams(params)).rejects.toThrow(
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
       'V4 split migration requires streamableFees configuration',
     );
+  });
+
+  it('rejects a zero-address no-op migrator override', async () => {
+    const params: CreateStaticAuctionParams = {
+      token: {
+        name: 'NoOp Token',
+        symbol: 'NOOP',
+        tokenURI: 'https://example.com/token.json',
+      },
+      sale: {
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('500000'),
+        numeraire: '0x4200000000000000000000000000000000000006' as Address,
+      },
+      pool: {
+        startTick: -276400,
+        endTick: -276200,
+        fee: 10000,
+      },
+      governance: { type: 'default' },
+      migration: { type: 'noOp' },
+      userAddress: account.address,
+      modules: {
+        noOpMigrator: '0x0000000000000000000000000000000000000000',
+      },
+    };
+
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow('NoOpMigrator not configured on this chain');
   });
 
   it('rejects split proceeds shares above the contract maximum', async () => {
@@ -237,7 +265,9 @@ describe('DopplerFactory split migrator support', () => {
       userAddress: account.address,
     };
 
-    await expect(factory.encodeCreateStaticAuctionParams(params)).rejects.toThrow(
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
       `V2 split migration proceeds split share cannot exceed ${parseEther('0.5')}`,
     );
   });

--- a/test/evm/unit/entities/DopplerSDK.dopplerERC20V1.test.ts
+++ b/test/evm/unit/entities/DopplerSDK.dopplerERC20V1.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Address, Hex, PublicClient } from 'viem';
+import { DopplerSDK } from '../../../../src/evm/DopplerSDK';
+import { DopplerERC20V1 } from '../../../../src/evm/entities/token/derc20/DopplerERC20V1';
+import { CHAIN_IDS } from '../../../../src/evm/addresses';
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+} from '../../setup/fixtures/clients';
+import { mockTokenAddress } from '../../setup/fixtures/addresses';
+
+describe('DopplerSDK DopplerERC20V1 helper', () => {
+  let publicClient: PublicClient;
+  let walletClient: ReturnType<typeof createMockWalletClient>;
+
+  beforeEach(() => {
+    publicClient = createMockPublicClient() as PublicClient;
+    walletClient = createMockWalletClient();
+  });
+
+  it('returns a token wired to the SDK clients and address', async () => {
+    const sdk = new DopplerSDK({
+      publicClient,
+      walletClient,
+      chainId: CHAIN_IDS.BASE,
+    });
+    const token = sdk.getDopplerERC20V1(mockTokenAddress);
+
+    expect(token).toBeInstanceOf(DopplerERC20V1);
+
+    vi.mocked(publicClient.readContract).mockResolvedValueOnce('Token Name');
+    vi.mocked(publicClient.simulateContract).mockResolvedValueOnce({
+      request: {
+        address: mockTokenAddress,
+        abi: [],
+        functionName: 'approve',
+        args: ['0x2345678901234567890123456789012345678901', 1n],
+      },
+    } as never);
+    vi.mocked(walletClient.writeContract).mockResolvedValueOnce(
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' as Hex,
+    );
+
+    await expect(token.getName()).resolves.toBe('Token Name');
+    await expect(
+      token.approve(
+        '0x2345678901234567890123456789012345678901' as Address,
+        1n,
+      ),
+    ).resolves.toBe(
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    );
+
+    expect(publicClient.readContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'name',
+    });
+    expect(publicClient.simulateContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: expect.any(Array),
+      functionName: 'approve',
+      args: ['0x2345678901234567890123456789012345678901', 1n],
+      account: walletClient.account,
+    });
+    expect(walletClient.writeContract).toHaveBeenCalledWith({
+      address: mockTokenAddress,
+      abi: [],
+      functionName: 'approve',
+      args: ['0x2345678901234567890123456789012345678901', 1n],
+    });
+  });
+});

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig, mergeConfig } from 'vitest/config'
-import baseConfig from './vitest.config'
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from './vitest.config';
 
 /**
  * Live test configuration
@@ -13,10 +13,7 @@ export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      include: [
-        'test/evm/e2e/**/*.test.ts',
-        'test/evm/airlock-whitelisting.test.ts',
-      ],
+      include: ['test/evm/e2e/**/*.test.ts'],
       exclude: [
         'node_modules/',
         'dist/',
@@ -44,5 +41,5 @@ export default mergeConfig(
       // Retry on flaky network issues
       retry: 2,
     },
-  })
-)
+  }),
+);


### PR DESCRIPTION
Tighten release and whitelist audit workflows, harden split and no-op migrator handling, expand `DopplerERC20V1`/SDK wiring/split migrator/Rehype builder regression test coverage, and update docs and examples to match chainId-aware builder usage.

- `.github/workflows/release.yml`: Updates the release whitelist matrix to audit Base, Base Sepolia, Mainnet, and Monad Mainnet.
- `.github/workflows/test-airlock-whitelisting.yml`: Aligns standalone whitelist audit defaults and descriptions with the release chain set.
- `MIGRATION.md`: Updates builder examples to pass an explicit `chainId`.
- `README.md`: Refreshes builder examples and clarifies release/fork-test coverage language.
- `docs/api-builders.md`: Aligns builder API examples with chainId-aware usage and current governance option naming.
- `docs/migration-guide.md`: Updates migration snippets so copied builder construction remains valid.
- `examples/README.md`: Clarifies tested example coverage and fixes the migration-guide link.
- `src/evm/entities/DopplerFactory.ts`: Handles `uniswapV2Split` migration exclusion and rejects zero-address no-op migrator overrides.
- `test/evm/e2e/whitelisting.test.ts`: Makes whitelist audits fail fast on unknown chains or zero checked modules.
- `test/evm/unit/builders/MulticurveBuilder.test.ts`: Adds Rehype timing normalization and invalid configuration regression coverage.
- `test/evm/unit/entities/DopplerERC20V1.test.ts`: Expands ERC20 V1 wrapper read/write and gas override coverage.
- `test/evm/unit/entities/DopplerFactory.dopplerERC20V1.test.ts`: Adds split-migration routing coverage for `DopplerERC20V1` factory paths.
- `test/evm/unit/entities/DopplerFactory.splitMigrators.test.ts`: Adds regression coverage for zero-address no-op migrator rejection.
- `test/evm/unit/entities/DopplerSDK.dopplerERC20V1.test.ts`: Verifies SDK helper wiring for DopplerERC20V1 wrappers and clients.
- `vitest.live.config.ts`: Narrows live test discovery to the intended E2E live-test files.