### PR TITLE
Add Solana program address configuration

### DIFF
--- a/src/solana/deployment.ts
+++ b/src/solana/deployment.ts
@@ -1,0 +1,47 @@
+import { type Address } from '@solana/kit';
+
+import {
+  CPMM_PROGRAM_ID,
+  getConfigAddress as getCpmmConfigAddress,
+} from './core/index.js';
+import {
+  CPMM_HOOK_PROGRAM_ID,
+  INITIALIZER_PROGRAM_ID,
+  getConfigAddress as getInitializerConfigAddress,
+} from './initializer/index.js';
+import { CPMM_MIGRATOR_PROGRAM_ID } from './migrators/cpmmMigrator/index.js';
+
+export interface SolanaCpmmProgramAddresses {
+  cpmmProgram: Address;
+  initializerProgram: Address;
+  cpmmMigratorProgram: Address;
+  cpmmHookProgram: Address;
+}
+
+export interface SolanaCpmmDeployment extends SolanaCpmmProgramAddresses {
+  cpmmConfig: Address;
+  initializerConfig: Address;
+}
+
+export const DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES: SolanaCpmmProgramAddresses =
+  {
+    cpmmProgram: CPMM_PROGRAM_ID,
+    initializerProgram: INITIALIZER_PROGRAM_ID,
+    cpmmMigratorProgram: CPMM_MIGRATOR_PROGRAM_ID,
+    cpmmHookProgram: CPMM_HOOK_PROGRAM_ID,
+  };
+
+export async function deriveSolanaCpmmDeployment(
+  programs: SolanaCpmmProgramAddresses = DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
+): Promise<SolanaCpmmDeployment> {
+  const [cpmmConfig] = await getCpmmConfigAddress(programs.cpmmProgram);
+  const [initializerConfig] = await getInitializerConfigAddress(
+    programs.initializerProgram,
+  );
+
+  return {
+    ...programs,
+    cpmmConfig,
+    initializerConfig,
+  };
+}

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -9,3 +9,10 @@ export * as initializer from './initializer/index.js';
 export * as cpmmMigrator from './migrators/cpmmMigrator/index.js';
 export * as predictionMigrator from './migrators/predictionMigrator/index.js';
 export * as trustedOracle from './trustedOracle/index.js';
+
+export {
+  DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
+  deriveSolanaCpmmDeployment,
+  type SolanaCpmmDeployment,
+  type SolanaCpmmProgramAddresses,
+} from './deployment.js';

--- a/src/solana/initializer/instructions/initializeLaunch.ts
+++ b/src/solana/initializer/instructions/initializeLaunch.ts
@@ -268,15 +268,24 @@ export async function createInitializeLaunchInstruction(
   );
 
   // When using the CPMM migrator, append the module-specific accounts required
-  // by register_launch:
-  //   [cpmm_migration_state, cpmm_config]
-  if (migratorProgram === CPMM_MIGRATOR_PROGRAM_ID) {
-    if (!accounts.cpmmConfig) {
+  // by register_launch. Custom deployments identify this path by passing
+  // cpmmConfig alongside their custom migrator program ID.
+  const shouldAppendCpmmMigratorAccounts =
+    accounts.cpmmConfig !== undefined ||
+    migratorProgram === CPMM_MIGRATOR_PROGRAM_ID;
+  if (shouldAppendCpmmMigratorAccounts) {
+    if (!migratorProgram) {
       throw new Error(
-        'cpmmConfig is required when migratorProgram is CPMM_MIGRATOR_PROGRAM_ID',
+        'migratorProgram is required when cpmmConfig is provided',
       );
     }
-    const [cpmmMigrationState] = await getCpmmMigratorStateAddress(launch);
+    if (!accounts.cpmmConfig) {
+      throw new Error('cpmmConfig is required when using the CPMM migrator');
+    }
+    const [cpmmMigrationState] = await getCpmmMigratorStateAddress(
+      launch,
+      migratorProgram,
+    );
     keys.push({ address: cpmmMigrationState, role: AccountRole.WRITABLE });
     keys.push({ address: accounts.cpmmConfig, role: AccountRole.READONLY });
   }

--- a/src/solana/migrators/cpmmMigrator/remainingAccounts.ts
+++ b/src/solana/migrators/cpmmMigrator/remainingAccounts.ts
@@ -10,6 +10,7 @@ import {
   getCpmmMigrationAuthorityAddress,
   getCpmmMigratorStateAddress,
 } from './pda.js';
+import { CPMM_MIGRATOR_PROGRAM_ID } from './constants.js';
 
 export interface CpmmMigrationRemainingAccountsInput {
   launch: Address;
@@ -20,6 +21,7 @@ export interface CpmmMigrationRemainingAccountsInput {
   adminQuoteAta: Address;
   recipientAtas: Address[];
   cpmmProgram?: Address;
+  cpmmMigratorProgram?: Address;
 }
 
 export interface CpmmMigrationRemainingAccounts {
@@ -46,9 +48,14 @@ export async function buildCpmmMigrationRemainingAccounts({
   adminQuoteAta,
   recipientAtas,
   cpmmProgram = CPMM_PROGRAM_ID,
+  cpmmMigratorProgram = CPMM_MIGRATOR_PROGRAM_ID,
 }: CpmmMigrationRemainingAccountsInput): Promise<CpmmMigrationRemainingAccounts> {
-  const [cpmmMigrationState] = await getCpmmMigratorStateAddress(launch);
-  const [migrationAuthority] = await getCpmmMigrationAuthorityAddress();
+  const [cpmmMigrationState] = await getCpmmMigratorStateAddress(
+    launch,
+    cpmmMigratorProgram,
+  );
+  const [migrationAuthority] =
+    await getCpmmMigrationAuthorityAddress(cpmmMigratorProgram);
   const poolInit = await getPoolInitAddresses(baseMint, quoteMint, cpmmProgram);
   const pool = poolInit.pool[0];
   const [launchLpPosition] = await getPositionAddress(

--- a/test/solana/deployment.test.ts
+++ b/test/solana/deployment.test.ts
@@ -140,7 +140,10 @@ describe('CPMM migrator custom deployment helpers', () => {
         migratorMigratePayload: new Uint8Array(),
         hookRemainingAccountsHash: initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
         migratorInitRemainingAccountsHash:
-          initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
+          initializer.computeRemainingAccountsHash([
+            cpmmMigrationState,
+            cpmmConfig,
+          ]),
         migratorRemainingAccountsHash:
           initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
         metadataName: '',

--- a/test/solana/deployment.test.ts
+++ b/test/solana/deployment.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { address } from '@solana/kit';
+
+import {
+  cpmm,
+  cpmmMigrator,
+  DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
+  deriveSolanaCpmmDeployment,
+  initializer,
+  type SolanaCpmmProgramAddresses,
+} from '../../src/solana/index.js';
+
+const CUSTOM_PROGRAMS: SolanaCpmmProgramAddresses = {
+  cpmmProgram: address('ComputeBudget111111111111111111111111111111'),
+  initializerProgram: address('BPFLoaderUpgradeab1e11111111111111111111111'),
+  cpmmMigratorProgram: address('AddressLookupTab1e1111111111111111111111111'),
+  cpmmHookProgram: address('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
+};
+
+describe('Solana deployment helpers', () => {
+  it('derives the default devnet CPMM deployment', async () => {
+    const deployment = await deriveSolanaCpmmDeployment();
+
+    expect(deployment).toMatchObject(DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES);
+    expect(deployment.cpmmConfig).toBeDefined();
+    expect(deployment.initializerConfig).toBeDefined();
+  });
+
+  it('derives config PDAs from supplied program IDs', async () => {
+    const deployment = await deriveSolanaCpmmDeployment(CUSTOM_PROGRAMS);
+    const [expectedCpmmConfig] = await cpmm.getConfigAddress(
+      CUSTOM_PROGRAMS.cpmmProgram,
+    );
+    const [expectedInitializerConfig] = await initializer.getConfigAddress(
+      CUSTOM_PROGRAMS.initializerProgram,
+    );
+
+    expect(deployment).toMatchObject(CUSTOM_PROGRAMS);
+    expect(deployment.cpmmConfig).toBe(expectedCpmmConfig);
+    expect(deployment.initializerConfig).toBe(expectedInitializerConfig);
+  });
+});
+
+describe('CPMM migrator custom deployment helpers', () => {
+  it('derives remaining accounts with custom CPMM and migrator programs', async () => {
+    const launch = address('SysvarC1ock11111111111111111111111111111111');
+    const launchAuthority = address(
+      'Sysvar1nstructions1111111111111111111111111',
+    );
+    const baseMint = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+    const quoteMint = address('So11111111111111111111111111111111111111112');
+    const adminBaseAta = address('SysvarRecentB1ockHashes11111111111111111111');
+    const adminQuoteAta = address(
+      'SysvarS1otHashes111111111111111111111111111',
+    );
+
+    const result = await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
+      launch,
+      baseMint,
+      quoteMint,
+      launchAuthority,
+      adminBaseAta,
+      adminQuoteAta,
+      recipientAtas: [],
+      cpmmProgram: CUSTOM_PROGRAMS.cpmmProgram,
+      cpmmMigratorProgram: CUSTOM_PROGRAMS.cpmmMigratorProgram,
+    });
+    const [expectedState] = await cpmmMigrator.getCpmmMigratorStateAddress(
+      launch,
+      CUSTOM_PROGRAMS.cpmmMigratorProgram,
+    );
+    const [expectedAuthority] =
+      await cpmmMigrator.getCpmmMigrationAuthorityAddress(
+        CUSTOM_PROGRAMS.cpmmMigratorProgram,
+      );
+    const [expectedCpmmConfig] = await cpmm.getConfigAddress(
+      CUSTOM_PROGRAMS.cpmmProgram,
+    );
+
+    expect(result.cpmmMigrationState).toBe(expectedState);
+    expect(result.migrationAuthority).toBe(expectedAuthority);
+    expect(result.cpmmConfig).toBe(expectedCpmmConfig);
+    expect(result.addresses).toContain(CUSTOM_PROGRAMS.cpmmProgram);
+  });
+
+  it('appends CPMM register-launch accounts for custom migrator programs', async () => {
+    const namespace = address('SysvarC1ock11111111111111111111111111111111');
+    const launchId = initializer.launchIdFromU64(1n);
+    const [launch] = await initializer.getLaunchAddress(
+      namespace,
+      launchId,
+      CUSTOM_PROGRAMS.initializerProgram,
+    );
+    const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
+      launch,
+      CUSTOM_PROGRAMS.initializerProgram,
+    );
+    const [cpmmConfig] = await cpmm.getConfigAddress(
+      CUSTOM_PROGRAMS.cpmmProgram,
+    );
+    const [cpmmMigrationState] = await cpmmMigrator.getCpmmMigratorStateAddress(
+      launch,
+      CUSTOM_PROGRAMS.cpmmMigratorProgram,
+    );
+
+    const ix = await initializer.createInitializeLaunchInstruction(
+      {
+        config: address('SysvarRent111111111111111111111111111111111'),
+        launch,
+        launchAuthority,
+        baseMint: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+        quoteMint: address('So11111111111111111111111111111111111111112'),
+        baseVault: address('SysvarS1otHashes111111111111111111111111111'),
+        quoteVault: address('SysvarRecentB1ockHashes11111111111111111111'),
+        payer: address('SysvarFees111111111111111111111111111111111'),
+        authority: address('SysvarFees111111111111111111111111111111111'),
+        migratorProgram: CUSTOM_PROGRAMS.cpmmMigratorProgram,
+        hookProgram: CUSTOM_PROGRAMS.cpmmHookProgram,
+        cpmmConfig,
+        rent: address('SysvarRent111111111111111111111111111111111'),
+      },
+      {
+        namespace,
+        launchId,
+        baseDecimals: 6,
+        baseTotalSupply: 1_000_000n,
+        baseForDistribution: 0n,
+        baseForLiquidity: 0n,
+        curveVirtualBase: 1n,
+        curveVirtualQuote: 1n,
+        curveFeeBps: 100,
+        curveKind: initializer.CURVE_KIND_XYK,
+        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
+        allowBuy: true,
+        allowSell: true,
+        hookProgram: CUSTOM_PROGRAMS.cpmmHookProgram,
+        hookFlags: 0,
+        hookPayload: new Uint8Array(),
+        migratorInitPayload: new Uint8Array(),
+        migratorMigratePayload: new Uint8Array(),
+        hookRemainingAccountsHash: initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
+        migratorInitRemainingAccountsHash:
+          initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
+        migratorRemainingAccountsHash:
+          initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
+        metadataName: '',
+        metadataSymbol: '',
+        metadataUri: '',
+      },
+      CUSTOM_PROGRAMS.initializerProgram,
+    );
+
+    expect(ix.accounts?.at(-2)?.address).toBe(cpmmMigrationState);
+    expect(ix.accounts?.at(-1)?.address).toBe(cpmmConfig);
+    expect(ix.programAddress).toBe(CUSTOM_PROGRAMS.initializerProgram);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Solana deployment helper for deriving CPMM and initializer config addresses from a supplied program address set.
- Allow initialize launch and CPMM migration account builders to derive accounts from supplied CPMM/migrator program IDs while preserving existing devnet defaults.
- Add Solana tests covering default and supplied program address behavior.

## Testing
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:solana`