### PR TITLE
fix(builders): reject duplicate beneficiary addresses

### DIFF
--- a/src/evm/builders/MulticurveBuilder.ts
+++ b/src/evm/builders/MulticurveBuilder.ts
@@ -37,6 +37,7 @@ import {
   buildCurvesFromPresets,
   normalizeBuilderTokenConfig,
   normalizeBuilderVestingSchedule,
+  sortBeneficiaries,
 } from './shared';
 
 export class MulticurveBuilder<
@@ -128,11 +129,7 @@ export class MulticurveBuilder<
     }
 
     const sortedBeneficiaries = params.beneficiaries
-      ? [...params.beneficiaries].sort((a, b) => {
-          const aAddr = a.beneficiary.toLowerCase();
-          const bAddr = b.beneficiary.toLowerCase();
-          return aAddr < bAddr ? -1 : aAddr > bAddr ? 1 : 0;
-        })
+      ? sortBeneficiaries(params.beneficiaries)
       : undefined;
 
     this.pool = {
@@ -928,11 +925,7 @@ export class MulticurveBuilder<
 
       // Sort beneficiaries by address if provided
       const sortedBeneficiaries = config.beneficiaries
-        ? [...config.beneficiaries].sort((a, b) => {
-            const aAddr = a.beneficiary.toLowerCase();
-            const bAddr = b.beneficiary.toLowerCase();
-            return aAddr < bAddr ? -1 : aAddr > bAddr ? 1 : 0;
-          })
+        ? sortBeneficiaries(config.beneficiaries)
         : undefined;
 
       // Set pool config

--- a/src/evm/builders/StaticAuctionBuilder.ts
+++ b/src/evm/builders/StaticAuctionBuilder.ts
@@ -32,6 +32,7 @@ import {
   computeTicks,
   normalizeBuilderTokenConfig,
   normalizeBuilderVestingSchedule,
+  sortBeneficiaries,
   type BaseAuctionBuilder,
   type BuilderVestingInput,
 } from './shared';
@@ -266,12 +267,9 @@ export class StaticAuctionBuilder<
   withBeneficiaries(
     beneficiaries: { beneficiary: Address; shares: bigint }[],
   ): this {
-    // Sort beneficiaries by address (ascending) as required by the contract
-    this.beneficiaries = [...beneficiaries].sort((a, b) => {
-      const aAddr = a.beneficiary.toLowerCase();
-      const bAddr = b.beneficiary.toLowerCase();
-      return aAddr < bAddr ? -1 : aAddr > bAddr ? 1 : 0;
-    });
+    // Sort by address (ascending) as required by the contract, and reject
+    // duplicate addresses up-front (contract reverts with UnorderedBeneficiaries).
+    this.beneficiaries = sortBeneficiaries(beneficiaries);
     return this;
   }
 

--- a/src/evm/builders/shared.ts
+++ b/src/evm/builders/shared.ts
@@ -10,6 +10,7 @@ import {
 } from '../constants';
 import { MAX_TICK, MIN_TICK } from '../utils';
 import type {
+  BeneficiaryData,
   Doppler404TokenConfig,
   DopplerERC20V1TokenConfig,
   PriceRange,
@@ -380,4 +381,40 @@ export function buildCurvesFromPresets(params: {
   }
 
   return { fee, tickSpacing, curves };
+}
+
+/**
+ * Sort beneficiaries by address (ascending) as required by the pool contract,
+ * rejecting duplicate addresses up-front.
+ *
+ * The contract enforces strictly ascending beneficiary addresses and reverts
+ * with `UnorderedBeneficiaries()` when two entries share an address. Catching
+ * the duplicate here surfaces a readable error before the transaction is
+ * broadcast, instead of an opaque on-chain revert that costs gas.
+ */
+export function sortBeneficiaries(
+  beneficiaries: BeneficiaryData[],
+): BeneficiaryData[] {
+  const sorted = [...beneficiaries].sort((a, b) => {
+    const aAddr = a.beneficiary.toLowerCase();
+    const bAddr = b.beneficiary.toLowerCase();
+    return aAddr < bAddr ? -1 : aAddr > bAddr ? 1 : 0;
+  });
+
+  for (let i = 1; i < sorted.length; i++) {
+    if (
+      sorted[i].beneficiary.toLowerCase() ===
+      sorted[i - 1].beneficiary.toLowerCase()
+    ) {
+      throw new Error(
+        `Duplicate beneficiary address: ${sorted[i].beneficiary}. ` +
+          'Each beneficiary address must be unique — the pool contract ' +
+          'requires strictly ascending addresses and reverts with ' +
+          'UnorderedBeneficiaries() otherwise. Merge the entries into a ' +
+          'single beneficiary with the combined shares.',
+      );
+    }
+  }
+
+  return sorted;
 }

--- a/test/evm/unit/builders/MulticurveBuilder.test.ts
+++ b/test/evm/unit/builders/MulticurveBuilder.test.ts
@@ -79,6 +79,31 @@ describe('MulticurveBuilder', () => {
     ]);
   });
 
+  it('rejects duplicate beneficiary addresses', () => {
+    // The pool contract requires strictly ascending beneficiary addresses and
+    // reverts with UnorderedBeneficiaries() on duplicates. The builder should
+    // surface this as a readable error before the transaction is broadcast.
+    const duplicateAddress =
+      '0x0000000000000000000000000000000000000001' as Address;
+    const beneficiaries = [
+      { beneficiary: duplicateAddress, shares: WAD / 2n },
+      { beneficiary: duplicateAddress, shares: WAD / 2n },
+    ];
+
+    const builder = MulticurveBuilder.forChain(CHAIN_IDS.BASE);
+
+    expect(() =>
+      builder.poolConfig({
+        fee: 3000,
+        tickSpacing: 60,
+        curves: [
+          { tickLower: 1000, tickUpper: 2000, numPositions: 2, shares: WAD },
+        ],
+        beneficiaries,
+      }),
+    ).toThrow(/Duplicate beneficiary address/);
+  });
+
   it('configures curves from market cap presets using defaults', () => {
     const expectedTickSpacing = (TICK_SPACINGS as Record<number, number>)[
       FEE_TIERS.LOW


### PR DESCRIPTION
## Problem

The multicurve and static auction builders sort `beneficiaries` by address but never check for duplicates. Two entries sharing an address pass straight through and produce parameters that revert on-chain with `UnorderedBeneficiaries()` — the pool contract requires strictly ascending addresses. The integrator only discovers this after spending gas, with an opaque revert.

This is easy to hit in practice, e.g. when the token creator and an integrator/treasury address happen to be the same wallet.

Fixes #137.

## Change

- Add a shared `sortBeneficiaries` helper in `builders/shared.ts` that sorts beneficiaries by address (ascending) and throws a readable error on duplicate addresses, before the transaction is broadcast.
- Use it in the three places that previously sorted inline:
  - `MulticurveBuilder.poolConfig()`
  - `MulticurveBuilder` `withCurves()` build path
  - `StaticAuctionBuilder.withBeneficiaries()`

This mirrors the existing fail-fast validation (e.g. shares must sum to `WAD`). Behavior for valid input is unchanged — only duplicates, which would have reverted on-chain anyway, now fail early with a clear message.

## Testing

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm test:unit` builder suites — 41 tests pass, including a new `MulticurveBuilder` test asserting duplicate beneficiary addresses throw.