### PR TITLE
feat: add DopplerERC20V1 example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -64,6 +64,10 @@ Create a multicurve auction whose vesting beneficiaries use different cliff and 
 
 Create a `dopplerERC20V1` token selected automatically from template-specific balance-limit fields, enumerate vesting schedules, release a partial vested amount by schedule or across schedules, and read max-balance-limit state. The default DopplerERC20V1 integration adds protocol balance-limit exclusions; custom `withTokenFactory(address)` paths must provide any required exclusions explicitly. This implementation does not configure or expose yearly mint inflation.
 
+### 12c. [Multicurve DopplerERC20V1 Multi-Schedule Vesting + Governance](./multicurve-derc20v1-multi-vesting-governance.ts)
+
+Build a Base multicurve configuration using the `dopplerERC20V1` token template, standard governance, and per-allocation vesting schedules. Includes multiple unique vesting schedules and one recipient with two vesting allocations on different schedules.
+
 ### 13. [Multicurve Vanity Launch (Market Cap)](./multicurve-vanity-by-marketcap.ts)
 
 Create a multicurve pool and mine a salt so the deployed token address ends with a chosen hex suffix (identifier). Launches on-chain (requires RPC + PRIVATE_KEY).

--- a/examples/multicurve-derc20v1-multi-vesting-governance.ts
+++ b/examples/multicurve-derc20v1-multi-vesting-governance.ts
@@ -1,0 +1,102 @@
+/**
+ * Example: Multicurve DopplerERC20V1 with Multi-Schedule Vesting + Governance
+ *
+ * This example builds the launch configuration only.
+ * Call `.build()` when you are ready to create final factory params.
+ */
+import './env';
+
+import { DAY_SECONDS, MulticurveBuilder, WAD } from '../src/evm';
+import { getAddress, parseEther } from 'viem';
+import { base } from 'viem/chains';
+
+const userAddress = getAddress('0x1111111111111111111111111111111111111111');
+const teamWallet = getAddress('0x2222222222222222222222222222222222222222');
+const advisorWallet = getAddress('0x3333333333333333333333333333333333333333');
+const treasuryWallet = getAddress('0x4444444444444444444444444444444444444444');
+const weth = getAddress('0x4200000000000000000000000000000000000006');
+
+const sixMonthVesting = {
+  duration: 180n * BigInt(DAY_SECONDS),
+  cliffDuration: 30 * DAY_SECONDS,
+};
+const oneYearVesting = {
+  duration: 365n * BigInt(DAY_SECONDS),
+  cliffDuration: 90 * DAY_SECONDS,
+};
+const twoYearVesting = {
+  duration: 730n * BigInt(DAY_SECONDS),
+  cliffDuration: 180 * DAY_SECONDS,
+};
+
+const multicurveDerc20V1Builder = MulticurveBuilder.forChain(base.id)
+  .tokenConfig({
+    type: 'dopplerERC20V1',
+    name: 'Multicurve Vesting Governance Token',
+    symbol: 'MVGT',
+    tokenURI: 'ipfs://multicurve-vesting-governance-token.json',
+    maxBalanceLimit: parseEther('10000'),
+    balanceLimitEnd: Math.floor(Date.now() / 1000) + 30 * DAY_SECONDS,
+    controller: userAddress,
+    // Vesting recipients are excluded from balance limits by DopplerERC20V1
+    // when their allocations are initialized, so they do not need to be listed
+    // in excludedFromBalanceLimit here.
+  })
+  .saleConfig({
+    initialSupply: 1_000_000n * WAD,
+    numTokensToSell: 900_000n * WAD,
+    numeraire: weth,
+  })
+  .poolConfig({
+    fee: 0,
+    tickSpacing: 8,
+    curves: [
+      {
+        tickLower: 0,
+        tickUpper: 160_000,
+        numPositions: 10,
+        shares: parseEther('0.4'),
+      },
+      {
+        tickLower: 80_000,
+        tickUpper: 240_000,
+        numPositions: 10,
+        shares: parseEther('0.35'),
+      },
+      {
+        tickLower: 160_000,
+        tickUpper: 320_000,
+        numPositions: 10,
+        shares: parseEther('0.25'),
+      },
+    ],
+  })
+  .withVesting({
+    allocations: [
+      {
+        recipient: teamWallet,
+        amount: parseEther('20000'),
+        schedule: sixMonthVesting,
+      },
+      // recipients can have multiple vesting schedules
+      {
+        recipient: teamWallet,
+        amount: parseEther('30000'),
+        schedule: twoYearVesting,
+      },
+      {
+        recipient: advisorWallet,
+        amount: parseEther('25000'),
+        schedule: oneYearVesting,
+      },
+      {
+        recipient: treasuryWallet,
+        amount: parseEther('25000'),
+        schedule: twoYearVesting,
+      },
+    ],
+  })
+  .withGovernance({ type: 'default' })
+  .withUserAddress(userAddress);
+
+export { multicurveDerc20V1Builder };


### PR DESCRIPTION
Adding an example of how to perform a multicurve launch for a `DopplerERC20V1` token with multiple vesting schedules and governance.