### PR TITLE
ci: support release candidate publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,29 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
+  # Run Solana unit tests
+  solana-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Solana unit tests
+        run: pnpm test:solana
+
   # Run fork tests for each chain
   fork-tests:
     runs-on: ubuntu-latest
@@ -144,7 +167,7 @@ jobs:
   # Release job runs after tests pass
   release:
     runs-on: ubuntu-latest
-    needs: [unit-tests, fork-tests, whitelisting-tests]
+    needs: [unit-tests, solana-tests, fork-tests, whitelisting-tests]
     environment: npm-publish
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
           - patch
           - minor
           - major
+          - rc
         default: 'patch'
       release_notes:
         description: 'Release notes (optional changelog entry)'
@@ -190,13 +191,24 @@ jobs:
 
           case "$RELEASE_TYPE" in
             patch)
-              NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+              if [[ "$CURRENT" == *-* ]]; then
+                NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+              else
+                NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+              fi
               ;;
             minor)
               NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
               ;;
             major)
               NEW_VERSION="$((MAJOR + 1)).0.0"
+              ;;
+            rc)
+              if [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-rc\.([0-9]+)$ ]]; then
+                NEW_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}-rc.$((BASH_REMATCH[4] + 1))"
+              else
+                NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))-rc.0"
+              fi
               ;;
           esac
 
@@ -206,8 +218,15 @@ jobs:
       - name: Determine dist-tags
         id: dist_tags
         run: |
-          # Publish release builds under the `latest` dist-tag.
-          echo "primary_tag=latest" >> $GITHUB_OUTPUT
+          VERSION="${{ steps.new_version.outputs.version }}"
+
+          if [[ "$VERSION" == *-* ]]; then
+            echo "primary_tag=rc" >> $GITHUB_OUTPUT
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "primary_tag=latest" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
           echo "secondary_tag=" >> $GITHUB_OUTPUT
 
       - name: Configure git
@@ -275,6 +294,7 @@ jobs:
         with:
           tag_name: v${{ steps.new_version.outputs.version }}
           name: v${{ steps.new_version.outputs.version }}
+          prerelease: ${{ steps.dist_tags.outputs.is_prerelease == 'true' }}
           body: |
             ${{ inputs.release_notes }}
 


### PR DESCRIPTION
## Summary
- Add an `rc` option to the manual release workflow.
- Publish prerelease versions under the `rc` npm dist-tag instead of `latest`.
- Mark GitHub releases for prerelease versions as prereleases.

## Notes
- With current `1.0.18`, `release_type=rc` would produce `1.0.19-rc.0`.
- Running a stable `patch` release from an RC version promotes it to the matching stable version.

## Tests
- Version-calculation sanity check locally
- `git diff --check .github/workflows/release.yml`