### PR TITLE
chore: simplify Solana examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,16 @@ console.log('CPMM config:', cpmmConfig);
 console.log('Pool:', pool?.address ?? 'not found');
 ```
 
-For runnable Solana flows, see:
+For runnable Solana flows, configure `examples/.env` and run with `pnpm tsx`, for example `pnpm tsx examples/solana-launch-by-marketcap.ts`:
 
 - [examples/solana-launch-by-marketcap.ts](./examples/solana-launch-by-marketcap.ts)
+- [examples/solana-adv-launch.ts](./examples/solana-adv-launch.ts)
 - [examples/solana-adv-e2e-launch.ts](./examples/solana-adv-e2e-launch.ts)
+- [examples/solana-cosigner-gated-launch.ts](./examples/solana-cosigner-gated-launch.ts)
+- [examples/solana-cosigner-gated-buy.ts](./examples/solana-cosigner-gated-buy.ts)
+- [examples/solana-usdc-e2e-launch.ts](./examples/solana-usdc-e2e-launch.ts)
+- [examples/solana-usdc-cosigner-gated-buy.ts](./examples/solana-usdc-cosigner-gated-buy.ts)
+- [examples/solana-prediction-market.ts](./examples/solana-prediction-market.ts)
 - [examples/solana-swap.ts](./examples/solana-swap.ts)
 
 ## Creating Auctions

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -78,7 +78,7 @@ RPC_URL=https://mainnet.base.org
 # COSIGNER_KEYPAIR=[1,2,...64 byte secret key JSON array]
 # Optional for examples/solana-cosigner-gated-buy.ts:
 # SOLANA_COSIGNER_BUY_AMOUNT_SOL=0.2
-# Required by examples/solana-usdc-cosigner-gated-buy.ts:
+# Required by examples/solana-usdc-e2e-launch.ts and examples/solana-usdc-cosigner-gated-buy.ts:
 # The payer's devnet USDC ATA must be funded before running.
 # SOLANA_COSIGNER_BUY_AMOUNT_USDC=0.2
 # Required by cosigner gated-buy examples:

--- a/examples/README.md
+++ b/examples/README.md
@@ -130,12 +130,15 @@ Minimal builder examples for `uniswapV2Split` / `uniswapV4Split` migrations and 
 
 The Solana examples use `@whetstone-research/doppler-sdk/solana`. Set `SOLANA_NETWORK=devnet` for the checked-in Doppler Solana deployment defaults, or `SOLANA_NETWORK=custom` with explicit RPC URLs and deployment program IDs.
 
-- [`solana-launch-by-marketcap.ts`](./solana-launch-by-marketcap.ts): simple XYK launch with CPMM migration configured.
-- [`solana-adv-launch.ts`](./solana-adv-launch.ts): launch with custom allocations, recipients, fees, and migration price floor.
-- [`solana-adv-e2e-launch.ts`](./solana-adv-e2e-launch.ts): create, buy, migrate, and inspect the graduated CPMM pool.
-- [`solana-swap.ts`](./solana-swap.ts): quote and submit an exact-in CPMM swap.
+- [`solana-launch-by-marketcap.ts`](./solana-launch-by-marketcap.ts): simple WSOL XYK launch with CPMM migration configured.
+- [`solana-adv-launch.ts`](./solana-adv-launch.ts): WSOL launch with custom allocations, recipients, fees, and migration price floor.
+- [`solana-adv-e2e-launch.ts`](./solana-adv-e2e-launch.ts): create, buy, migrate, and inspect a graduated WSOL CPMM pool.
+- [`solana-usdc-e2e-launch.ts`](./solana-usdc-e2e-launch.ts): same lifecycle with devnet USDC and fee arithmetic checks.
 - [`solana-cosigner-gated-launch.ts`](./solana-cosigner-gated-launch.ts): E2E launch with bonding-curve swaps gated by the configured cosigner hook.
-- [`solana-cosigner-gated-buy.ts`](./solana-cosigner-gated-buy.ts): create a cosigner-gated launch with three env-configured beneficiaries, execute one cosigned bonding-curve buy, migrate, then execute an ungated CPMM swap.
+- [`solana-cosigner-gated-buy.ts`](./solana-cosigner-gated-buy.ts): cosigner-gated WSOL buy flow with env-configured fee beneficiaries.
+- [`solana-usdc-cosigner-gated-buy.ts`](./solana-usdc-cosigner-gated-buy.ts): cosigner-gated devnet USDC buy flow.
+- [`solana-prediction-market.ts`](./solana-prediction-market.ts): create a two-outcome prediction market with trusted oracle and prediction migrator.
+- [`solana-swap.ts`](./solana-swap.ts): quote and submit an exact-in CPMM swap.
 
 Quick run:
 
@@ -169,7 +172,7 @@ For larger CPMM launch metadata, use a launch-specific ALT:
 4. Wait for the ALT to be usable in a later slot.
 5. Rebuild the transaction and call `initializer.compressTransactionMessageWithLookupTable(...)`.
 
-The advanced examples demonstrate this flow and call `assertTransactionFits` before signing so metadata and account-pressure failures surface before broadcast.
+The shared example helper performs this flow and checks transaction size before signing so metadata and account-pressure failures surface before broadcast.
 
 `SOL_PRICE_USD` can be set to bypass the CoinGecko price lookup in launch examples. `SOLANA_KEYPAIR_PATH` is preferred for local development; `SOLANA_KEYPAIR` also works with a 64-byte JSON secret key array.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -130,7 +130,8 @@ Minimal builder examples for `uniswapV2Split` / `uniswapV4Split` migrations and 
 
 The Solana examples use `@whetstone-research/doppler-sdk/solana`. Set `SOLANA_NETWORK=devnet` for the checked-in Doppler Solana deployment defaults, or `SOLANA_NETWORK=custom` with explicit RPC URLs and deployment program IDs.
 
-- [`solana-launch-by-marketcap.ts`](./solana-launch-by-marketcap.ts): simple WSOL XYK launch with CPMM migration configured.
+- [`solana-minimal-launch.ts`](./solana-minimal-launch.ts): smallest practical WSOL XYK launch using `createLaunch` defaults.
+- [`solana-launch-by-marketcap.ts`](./solana-launch-by-marketcap.ts): WSOL XYK launch with CPMM migration configured from market cap inputs.
 - [`solana-adv-launch.ts`](./solana-adv-launch.ts): WSOL launch with custom allocations, recipients, fees, and migration price floor.
 - [`solana-adv-e2e-launch.ts`](./solana-adv-e2e-launch.ts): create, buy, migrate, and inspect a graduated WSOL CPMM pool.
 - [`solana-usdc-e2e-launch.ts`](./solana-usdc-e2e-launch.ts): same lifecycle with devnet USDC and fee arithmetic checks.
@@ -148,7 +149,7 @@ export SOLANA_KEYPAIR_PATH=~/.config/solana/id.json
 export SOLANA_NETWORK=devnet
 export SOLANA_RPC_URL=https://api.devnet.solana.com
 export SOLANA_WS_URL=wss://api.devnet.solana.com
-pnpm tsx examples/solana-launch-by-marketcap.ts
+pnpm tsx examples/solana-minimal-launch.ts
 ```
 
 For a custom deployment, also set:
@@ -161,7 +162,7 @@ export SOLANA_CPMM_HOOK_PROGRAM_ID=...
 export SOLANA_COSIGNER_HOOK_PROGRAM_ID=...
 ```
 
-The cosigner-gated launch example derives the hook config PDA from `SOLANA_COSIGNER_HOOK_PROGRAM_ID`. Provide `COSIGNER_KEYPAIR_PATH` or `COSIGNER_KEYPAIR` for one of the cosigners registered in that config.
+On devnet, the cosigner-gated examples default to the Doppler native cosigner hook. For a custom deployment, `SOLANA_COSIGNER_HOOK_PROGRAM_ID` should be the hook program that owns the cosigner config. Provide `COSIGNER_KEYPAIR_PATH` or `COSIGNER_KEYPAIR` for one of the cosigners registered in that config.
 
 The launch examples use ALTs where possible. ALTs reduce account-key bytes, but they do not compress instruction data, so long `metadataName`, `metadataSymbol`, or `metadataUri` values can still exceed Solana's 1232-byte transaction limit.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -136,6 +136,7 @@ The Solana examples use `@whetstone-research/doppler-sdk/solana`. Set `SOLANA_NE
 - [`solana-usdc-e2e-launch.ts`](./solana-usdc-e2e-launch.ts): same lifecycle with devnet USDC and fee arithmetic checks.
 - [`solana-cosigner-gated-launch.ts`](./solana-cosigner-gated-launch.ts): E2E launch with bonding-curve swaps gated by the configured cosigner hook.
 - [`solana-cosigner-gated-buy.ts`](./solana-cosigner-gated-buy.ts): cosigner-gated WSOL buy flow with env-configured fee beneficiaries.
+- [`solana-cosigner-gated-buy-token-2022.ts`](./solana-cosigner-gated-buy-token-2022.ts): same cosigner-gated WSOL flow with a Token-2022 base mint and Metaplex metadata.
 - [`solana-usdc-cosigner-gated-buy.ts`](./solana-usdc-cosigner-gated-buy.ts): cosigner-gated devnet USDC buy flow.
 - [`solana-prediction-market.ts`](./solana-prediction-market.ts): create a two-outcome prediction market with trusted oracle and prediction migrator.
 - [`solana-swap.ts`](./solana-swap.ts): quote and submit an exact-in CPMM swap.

--- a/examples/solana-adv-e2e-launch.ts
+++ b/examples/solana-adv-e2e-launch.ts
@@ -15,6 +15,20 @@
 import './env.js';
 
 import {
+  TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getSyncNativeInstruction,
+} from '@solana-program/token';
+import {
+  SYSTEM_PROGRAM_ADDRESS,
+  getTransferSolInstruction,
+} from '@solana-program/system';
+import { generateKeyPairSigner } from '@solana/kit';
+import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
+
+import { cpmm, cpmmMigrator, initializer } from '../src/solana/index.js';
+import {
   DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,

--- a/examples/solana-adv-e2e-launch.ts
+++ b/examples/solana-adv-e2e-launch.ts
@@ -15,47 +15,21 @@
 import './env.js';
 
 import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
-  getSyncNativeInstruction,
-} from '@solana-program/token';
-import {
-  SYSTEM_PROGRAM_ADDRESS,
-  getTransferSolInstruction,
-} from '@solana-program/system';
-import {
-  generateKeyPairSigner,
-  getBase64EncodedWireTransaction,
-  pipe,
-  createTransactionMessage,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  type Address,
-} from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
-
-import { cpmm, initializer, cpmmMigrator } from '../src/solana/index.js';
-import {
-  assertTransactionFits,
+  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  DEFAULT_SWAP_FEE_BPS,
+  DEFAULT_TEST_METADATA,
+  WSOL_MINT,
   assertSolanaExampleNetwork,
-  createLookupTableForInstruction,
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
-  getMetadataByteLength,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
   getTokenAccountRentLamports,
   loadKeypairSignerFromEnv,
+  sendInitializeLaunchWithLookupTable,
+  sendInstructions,
+  simulateInstructions,
 } from './solanaExampleHelpers.js';
-
-// WSOL mint — pools use the wrapped SPL mint since native SOL can't live in token vaults.
-const WSOL_MINT: Address =
-  'So11111111111111111111111111111111111111112' as Address;
 
 // ============================================================================
 // Main
@@ -84,9 +58,9 @@ async function main() {
   const END_MARKET_CAP_USD = 10_000_000;
 
   // ── Fee configuration ───────────────────────────────────────────────────
-  const SWAP_FEE_BPS = 200; // 2%; must fit this deployment's configured fee bounds
+  const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
   const CPMM_SWAP_FEE_BPS = SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = 10_000; // migrated launch fees route through LaunchFeeState
+  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
 
   // ── Graduation threshold and price floor ────────────────────────────────
   const MIN_SOL_RAISE = 0.1; // low example threshold
@@ -188,11 +162,7 @@ async function main() {
   // ── Build, sign, and send ────────────────────────────────────────────────
   console.log('Building launch instruction...');
   try {
-    const metadata = {
-      metadataName: 'TEST',
-      metadataSymbol: 'TEST',
-      metadataUri: 'https://example.com/metadata/test-token.json',
-    };
+    const metadata = DEFAULT_TEST_METADATA;
 
     const ix = await initializer.createInitializeLaunchInstruction(
       {
@@ -245,54 +215,18 @@ async function main() {
       },
       deployment.initializerProgram,
     );
-    const lookupTable = await createLookupTableForInstruction({
+    const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,
       payer,
       instruction: ix,
-      label: 'initialize_launch lookup table',
+      metadata,
     });
-
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const transactionMessage =
-      initializer.compressTransactionMessageWithLookupTable(
-        pipe(
-          createTransactionMessage({ version: 0 }),
-          (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-          (tx) =>
-            setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-          (tx) => appendTransactionMessageInstructions([ix], tx),
-        ),
-        lookupTable,
-      );
-    assertTransactionFits(transactionMessage, {
-      label: 'initialize_launch',
-      metadataBytes: getMetadataByteLength(metadata),
-    });
-
-    const signedTransaction =
-      await signTransactionMessageWithSigners(transactionMessage);
-
-    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-      rpc,
-      rpcSubscriptions,
-    });
-    await sendAndConfirmTransaction(
-      signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-      {
-        commitment: 'confirmed',
-      },
-    );
-
     console.log('');
     console.log('Token launch created successfully!');
     console.log('  Launch address:', launch);
     console.log('  Base mint:     ', baseMint.address);
-    console.log(
-      '  Transaction:   ',
-      getSignatureFromTransaction(signedTransaction),
-    );
+    console.log('  Transaction:   ', launchSignature);
 
     // ── Step 2: Enumerate launches by this wallet (indexer-style) ───────────
     console.log('Step 2: Listing launches owned by this wallet...');
@@ -330,25 +264,11 @@ async function main() {
       deployment.initializerProgram,
     );
 
-    // simulateTransaction is the idiomatic way to run a read-only instruction.
-    const { value: previewBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const previewMessage = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(previewBlockhash, tx),
-      (tx) => appendTransactionMessageInstructions([previewIx], tx),
-    );
-
-    const signedPreview =
-      await signTransactionMessageWithSigners(previewMessage);
-
-    const { value: simulateResult } = await rpc
-      .simulateTransaction(getBase64EncodedWireTransaction(signedPreview), {
-        encoding: 'base64',
-        replaceRecentBlockhash: true,
-      })
-      .send();
+    const simulateResult = await simulateInstructions({
+      rpc,
+      payer,
+      instructions: [previewIx],
+    });
 
     if (simulateResult.returnData?.data) {
       const returnBytes = Uint8Array.from(
@@ -436,46 +356,27 @@ async function main() {
     );
 
     {
-      const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+      const signature = await sendInstructions({
+        rpc,
+        rpcSubscriptions,
+        payer,
+        instructions: [
+          createBaseAtaIx,
+          createQuoteAtaIx,
+          transferSolIx,
+          syncNativeIx,
+          swapIx,
+        ],
+      });
 
-      const transactionMessage = pipe(
-        createTransactionMessage({ version: 0 }),
-        (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-        (tx) =>
-          setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-        (tx) =>
-          appendTransactionMessageInstructions(
-            [
-              createBaseAtaIx,
-              createQuoteAtaIx,
-              transferSolIx,
-              syncNativeIx,
-              swapIx,
-            ],
-            tx,
-          ),
-      );
-
-      const signedTransaction =
-        await signTransactionMessageWithSigners(transactionMessage);
-
-      await sendAndConfirmTransaction(
-        signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-        {
-          commitment: 'confirmed',
-        },
-      );
-
-      console.log(
-        '  Curve buy confirmed:',
-        getSignatureFromTransaction(signedTransaction),
-      );
+      console.log('  Curve buy confirmed:', signature);
     }
     console.log('');
 
     // ── Step 5: Migrate launch to CPMM pool ─────────────────────────────────
     //
-    // Anyone can call migrate_launch once quoteDeposited >= minRaiseQuote.
+    // Anyone can call migrate_launch once quote_vault_amount - pending_quote_fees
+    // is at least minRaiseQuote.
     // The migrator creates the canonical CPMM pool graph inline, then seeds
     // liquidity into it. The remaining accounts must match the hash committed
     // at launch creation.
@@ -510,34 +411,17 @@ async function main() {
     };
 
     {
-      const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+      const signature = await sendInstructions({
+        rpc,
+        rpcSubscriptions,
+        payer,
+        instructions: [
+          createSetComputeUnitLimitInstruction(400_000),
+          migrateLaunchIx,
+        ],
+      });
 
-      const transactionMessage = pipe(
-        createTransactionMessage({ version: 0 }),
-        (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-        (tx) =>
-          setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-        (tx) =>
-          appendTransactionMessageInstructions(
-            [createSetComputeUnitLimitInstruction(400_000), migrateLaunchIx],
-            tx,
-          ),
-      );
-
-      const signedTransaction =
-        await signTransactionMessageWithSigners(transactionMessage);
-
-      await sendAndConfirmTransaction(
-        signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-        {
-          commitment: 'confirmed',
-        },
-      );
-
-      console.log(
-        '  Migration confirmed:',
-        getSignatureFromTransaction(signedTransaction),
-      );
+      console.log('  Migration confirmed:', signature);
     }
     console.log('');
 

--- a/examples/solana-adv-e2e-launch.ts
+++ b/examples/solana-adv-e2e-launch.ts
@@ -27,9 +27,13 @@ import {
 import { generateKeyPairSigner } from '@solana/kit';
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
-import { cpmm, cpmmMigrator, initializer } from '../src/solana/index.js';
 import {
-  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  cpmm,
+  cpmmMigrator,
+  createLaunch,
+  initializer,
+} from '../src/solana/index.js';
+import {
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
@@ -73,8 +77,6 @@ async function main() {
 
   // ── Fee configuration ───────────────────────────────────────────────────
   const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_BPS = SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
 
   // ── Graduation threshold and price floor ────────────────────────────────
   const MIN_SOL_RAISE = 0.1; // low example threshold
@@ -99,136 +101,73 @@ async function main() {
   const baseMint = await generateKeyPairSigner();
   const baseVault = await generateKeyPairSigner();
   const quoteVault = await generateKeyPairSigner();
-  const metadataAccount = await initializer.getTokenMetadataAddress(
-    baseMint.address,
-  );
+  const metadata = DEFAULT_TEST_METADATA;
 
   const namespace = payer.address;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-
-  const [launch] = await initializer.getLaunchAddress(
+  const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+    deployment,
     namespace,
     launchId,
-    deployment.initializerProgram,
-  );
-  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const initializerConfig = deployment.initializerConfig;
-
-  const [payerBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    baseMint,
+    metadata,
   });
-  const [payerQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: WSOL_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-
-  const migrationAccounts =
-    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
-      launch,
-      baseMint: baseMint.address,
-      quoteMint: WSOL_MINT,
-      launchAuthority,
-      adminBaseAta: payerBaseAta,
-      adminQuoteAta: payerQuoteAta,
-      recipientAtas: [payerBaseAta, payerBaseAta],
-      cpmmProgram: deployment.cpmmProgram,
-      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
-    });
-  const cpmmConfig = migrationAccounts.cpmmConfig;
-  const cpmmMigrationState = migrationAccounts.cpmmMigrationState;
-
-  console.log('Derived addresses:');
-  console.log('  Launch:          ', launch);
-  console.log('  Launch authority:', launchAuthority);
-  console.log('  Initializer config:', initializerConfig);
-  console.log('  CPMM config:     ', cpmmConfig);
-  console.log('  CPMM migrator state:', cpmmMigrationState);
-  console.log('');
-
-  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
-    cpmmConfig: cpmmConfig,
-    initialSwapFeeBps: CPMM_SWAP_FEE_BPS,
-    initialFeeSplitBps: CPMM_SWAP_FEE_SPLIT_BPS,
-    recipients: [
-      { wallet: payer.address, amount: CREATOR_SHARE },
-      { wallet: payer.address, amount: TEAM_SHARE }, // use payer as team wallet in this example
-    ],
-    minRaiseQuote,
-    minMigrationPriceQ64Opt: null,
-    migratedPoolHookConfig: null,
-  });
-
-  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
-    baseForDistribution: BASE_FOR_DISTRIBUTION,
-    baseForLiquidity: BASE_FOR_LIQUIDITY,
-  });
+  const { launch, launchAuthority, launchFeeState } = launchAddresses;
+  const initializerConfig = launchAddresses.config;
+  const recipients = [
+    { wallet: payer.address, amount: CREATOR_SHARE },
+    { wallet: payer.address, amount: TEAM_SHARE },
+  ];
 
   // ── Build, sign, and send ────────────────────────────────────────────────
   console.log('Building launch instruction...');
   try {
-    const metadata = DEFAULT_TEST_METADATA;
-
-    const ix = await initializer.createInitializeLaunchInstruction(
-      {
-        config: initializerConfig,
-        launch,
-        launchAuthority,
+    const { instruction: ix, cpmmMigration } = await createLaunch({
+      deployment,
+      namespace,
+      launchId,
+      addresses: launchAddresses,
+      launchAccounts: {
         baseMint,
         quoteMint: WSOL_MINT,
         baseVault,
         quoteVault,
-        launchFeeState,
-        payer,
-        authority: payer,
-        hookProgram: deployment.cpmmHookProgram,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        cpmmConfig,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-        metadataAccount,
       },
-      {
-        namespace,
-        launchId,
+      payer,
+      authority: payer,
+      supply: {
         baseDecimals: BASE_DECIMALS,
         baseTotalSupply: BASE_TOTAL_SUPPLY,
         baseForDistribution: BASE_FOR_DISTRIBUTION,
         baseForLiquidity: BASE_FOR_LIQUIDITY,
+      },
+      curve: {
         curveVirtualBase: start.curveVirtualBase,
         curveVirtualQuote: start.curveVirtualQuote,
         swapFeeBps: SWAP_FEE_BPS,
-        curveKind: initializer.CURVE_KIND_XYK,
-        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
-        allowBuy: true,
-        allowSell: true,
-        hookFlags: initializer.HF_BEFORE_SWAP,
-        hookPayload: new Uint8Array(),
-        migratorInitPayload,
-        migratorMigratePayload,
-        hookRemainingAccountsHash: initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
-        migratorInitRemainingAccountsHash:
-          initializer.computeRemainingAccountsHash([
-            cpmmMigrationState,
-            cpmmConfig,
-          ]),
-        migratorRemainingAccountsHash: migrationAccounts.hash,
-        feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
-        ...metadata,
       },
-      deployment.initializerProgram,
-    );
+      migration: {
+        recipients,
+        minRaiseQuote,
+      },
+      metadata,
+      feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
+    });
+    if (!cpmmMigration) {
+      throw new Error('CPMM migration accounts were not prepared');
+    }
+    const migrationAccounts = cpmmMigration;
+    const cpmmConfig = migrationAccounts.cpmmConfig;
+    const cpmmMigrationState = migrationAccounts.cpmmMigrationState;
+
+    console.log('Derived addresses:');
+    console.log('  Launch:          ', launch);
+    console.log('  Launch authority:', launchAuthority);
+    console.log('  Initializer config:', initializerConfig);
+    console.log('  CPMM config:     ', cpmmConfig);
+    console.log('  CPMM migrator state:', cpmmMigrationState);
+    console.log('');
+
     const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,

--- a/examples/solana-adv-launch.ts
+++ b/examples/solana-adv-launch.ts
@@ -19,6 +19,15 @@
 import './env.js';
 
 import {
+  TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda,
+} from '@solana-program/token';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import { generateKeyPairSigner } from '@solana/kit';
+import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
+
+import { cpmm, cpmmMigrator, initializer } from '../src/solana/index.js';
+import {
   DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,

--- a/examples/solana-adv-launch.ts
+++ b/examples/solana-adv-launch.ts
@@ -18,17 +18,10 @@
  */
 import './env.js';
 
-import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-} from '@solana-program/token';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
-import { cpmm, cpmmMigrator, initializer } from '../src/solana/index.js';
+import { cpmm, createLaunch, initializer } from '../src/solana/index.js';
 import {
-  DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
@@ -64,8 +57,6 @@ async function main() {
 
   // ── Fee configuration ───────────────────────────────────────────────────
   const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_BPS = SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
 
   // ── Graduation threshold and price floor ────────────────────────────────
   const MIN_SOL_RAISE = 50;
@@ -94,140 +85,73 @@ async function main() {
   const baseMint = await generateKeyPairSigner();
   const baseVault = await generateKeyPairSigner();
   const quoteVault = await generateKeyPairSigner();
-  const metadataAccount = await initializer.getTokenMetadataAddress(
-    baseMint.address,
-  );
+  const metadata = DEFAULT_TEST_METADATA;
 
   const namespace = payer.address;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-
-  const [launch] = await initializer.getLaunchAddress(
+  const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+    deployment,
     namespace,
     launchId,
-    deployment.initializerProgram,
-  );
-  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const initializerConfig = deployment.initializerConfig;
-
-  // Payer receives admin dust and both example recipient allocations.
-  const [payerBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    baseMint,
+    metadata,
   });
-  const [payerQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: WSOL_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-
-  const migrationAccounts =
-    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
-      launch,
-      baseMint: baseMint.address,
-      quoteMint: WSOL_MINT,
-      launchAuthority,
-      adminBaseAta: payerBaseAta,
-      adminQuoteAta: payerQuoteAta,
-      recipientAtas: [payerBaseAta, payerBaseAta],
-      cpmmProgram: deployment.cpmmProgram,
-      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
-    });
-  const cpmmConfig = migrationAccounts.cpmmConfig;
-  const cpmmMigrationState = migrationAccounts.cpmmMigrationState;
-
-  console.log('Derived addresses:');
-  console.log('  Launch:          ', launch);
-  console.log('  Launch authority:', launchAuthority);
-  console.log('  Initializer config:', initializerConfig);
-  console.log('  CPMM config:     ', cpmmConfig);
-  console.log('  CPMM migrator state:', cpmmMigrationState);
-  console.log('');
-
-  // ── Encode migrator payloads ────────────────────────────────────────────
-  // migratorInitPayload registers graduation params; migratorMigratePayload
-  // is forwarded at migration. minRaiseQuote is the graduation threshold.
-  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
-    cpmmConfig: cpmmConfig,
-    initialSwapFeeBps: CPMM_SWAP_FEE_BPS,
-    initialFeeSplitBps: CPMM_SWAP_FEE_SPLIT_BPS,
-    recipients: [
-      { wallet: payer.address, amount: CREATOR_SHARE },
-      { wallet: payer.address, amount: TEAM_SHARE }, // use payer as team wallet in this example
-    ],
-    minRaiseQuote,
-    minMigrationPriceQ64Opt,
-    migratedPoolHookConfig: null,
-  });
-
-  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
-    baseForDistribution: BASE_FOR_DISTRIBUTION,
-    baseForLiquidity: BASE_FOR_LIQUIDITY,
-  });
+  const { launch, launchAuthority } = launchAddresses;
+  const initializerConfig = launchAddresses.config;
+  const recipients = [
+    { wallet: payer.address, amount: CREATOR_SHARE },
+    { wallet: payer.address, amount: TEAM_SHARE },
+  ];
 
   // ── Build, sign, and send ────────────────────────────────────────────────
   console.log('Creating advanced XYK token launch...');
   try {
-    const metadata = DEFAULT_TEST_METADATA;
-
-    const ix = await initializer.createInitializeLaunchInstruction(
-      {
-        config: initializerConfig,
-        launch,
-        launchAuthority,
+    const { instruction: ix, cpmmMigration } = await createLaunch({
+      deployment,
+      namespace,
+      launchId,
+      addresses: launchAddresses,
+      launchAccounts: {
         baseMint,
         quoteMint: WSOL_MINT,
         baseVault,
         quoteVault,
-        launchFeeState,
-        payer,
-        authority: payer,
-        hookProgram: deployment.cpmmHookProgram,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        cpmmConfig,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-        metadataAccount,
       },
-      {
-        namespace,
-        launchId,
+      payer,
+      authority: payer,
+      supply: {
         baseDecimals: BASE_DECIMALS,
         baseTotalSupply: BASE_TOTAL_SUPPLY,
         baseForDistribution: BASE_FOR_DISTRIBUTION,
         baseForLiquidity: BASE_FOR_LIQUIDITY,
+      },
+      curve: {
         curveVirtualBase: start.curveVirtualBase,
         curveVirtualQuote: start.curveVirtualQuote,
         swapFeeBps: SWAP_FEE_BPS,
-        curveKind: initializer.CURVE_KIND_XYK,
-        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
-        allowBuy: true,
-        allowSell: true,
-        hookFlags: initializer.HF_BEFORE_SWAP,
-        hookPayload: new Uint8Array(),
-        migratorInitPayload,
-        migratorMigratePayload,
-        hookRemainingAccountsHash: initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
-        migratorInitRemainingAccountsHash:
-          initializer.computeRemainingAccountsHash([
-            cpmmMigrationState,
-            cpmmConfig,
-          ]),
-        migratorRemainingAccountsHash: migrationAccounts.hash,
-        feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
-        ...metadata,
       },
-      deployment.initializerProgram,
-    );
+      migration: {
+        recipients,
+        minRaiseQuote,
+        minMigrationPriceQ64Opt,
+      },
+      metadata,
+      feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
+    });
+    if (!cpmmMigration) {
+      throw new Error('CPMM migration accounts were not prepared');
+    }
+    const cpmmConfig = cpmmMigration.cpmmConfig;
+    const cpmmMigrationState = cpmmMigration.cpmmMigrationState;
+
+    console.log('Derived addresses:');
+    console.log('  Launch:          ', launch);
+    console.log('  Launch authority:', launchAuthority);
+    console.log('  Initializer config:', initializerConfig);
+    console.log('  CPMM config:     ', cpmmConfig);
+    console.log('  CPMM migrator state:', cpmmMigrationState);
+    console.log('');
+
     const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,

--- a/examples/solana-adv-launch.ts
+++ b/examples/solana-adv-launch.ts
@@ -19,39 +19,17 @@
 import './env.js';
 
 import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-} from '@solana-program/token';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
-import {
-  generateKeyPairSigner,
-  pipe,
-  createTransactionMessage,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  type Address,
-} from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
-
-import { cpmm, initializer, cpmmMigrator } from '../src/solana/index.js';
-import {
-  assertTransactionFits,
+  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  DEFAULT_SWAP_FEE_BPS,
+  DEFAULT_TEST_METADATA,
+  WSOL_MINT,
   assertSolanaExampleNetwork,
-  createLookupTableForInstruction,
   createSolanaClientsFromEnv,
-  getMetadataByteLength,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
   loadKeypairSignerFromEnv,
+  sendInitializeLaunchWithLookupTable,
 } from './solanaExampleHelpers.js';
-
-// WSOL mint — pools use the wrapped SPL mint since native SOL can't live in token vaults.
-const WSOL_MINT: Address =
-  'So11111111111111111111111111111111111111112' as Address;
 
 async function main() {
   const payer = await loadKeypairSignerFromEnv();
@@ -76,9 +54,9 @@ async function main() {
   const TEAM_SHARE = BASE_FOR_DISTRIBUTION - CREATOR_SHARE;
 
   // ── Fee configuration ───────────────────────────────────────────────────
-  const SWAP_FEE_BPS = 200; // 2%; must fit this deployment's configured fee bounds
+  const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
   const CPMM_SWAP_FEE_BPS = SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = 10_000; // migrated launch fees route through LaunchFeeState
+  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
 
   // ── Graduation threshold and price floor ────────────────────────────────
   const MIN_SOL_RAISE = 50;
@@ -188,11 +166,7 @@ async function main() {
   // ── Build, sign, and send ────────────────────────────────────────────────
   console.log('Creating advanced XYK token launch...');
   try {
-    const metadata = {
-      metadataName: 'TEST',
-      metadataSymbol: 'TEST',
-      metadataUri: 'https://example.com/metadata/test-token.json',
-    };
+    const metadata = DEFAULT_TEST_METADATA;
 
     const ix = await initializer.createInitializeLaunchInstruction(
       {
@@ -245,54 +219,19 @@ async function main() {
       },
       deployment.initializerProgram,
     );
-    const lookupTable = await createLookupTableForInstruction({
+    const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,
       payer,
       instruction: ix,
-      label: 'initialize_launch lookup table',
+      metadata,
     });
-
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const transactionMessage =
-      initializer.compressTransactionMessageWithLookupTable(
-        pipe(
-          createTransactionMessage({ version: 0 }),
-          (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-          (tx) =>
-            setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-          (tx) => appendTransactionMessageInstructions([ix], tx),
-        ),
-        lookupTable,
-      );
-    assertTransactionFits(transactionMessage, {
-      label: 'initialize_launch',
-      metadataBytes: getMetadataByteLength(metadata),
-    });
-
-    const signedTransaction =
-      await signTransactionMessageWithSigners(transactionMessage);
-
-    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-      rpc,
-      rpcSubscriptions,
-    });
-    await sendAndConfirmTransaction(
-      signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-      {
-        commitment: 'confirmed',
-      },
-    );
 
     console.log('');
     console.log('Token launch created successfully!');
     console.log('  Launch address:', launch);
     console.log('  Base mint:     ', baseMint.address);
-    console.log(
-      '  Transaction:   ',
-      getSignatureFromTransaction(signedTransaction),
-    );
+    console.log('  Transaction:   ', launchSignature);
 
     // ── Verify launch state ──────────────────────────────────────────────
     const launchAccount = await initializer.fetchLaunch(rpc, launch, {

--- a/examples/solana-cosigner-gated-buy-token-2022.ts
+++ b/examples/solana-cosigner-gated-buy-token-2022.ts
@@ -45,10 +45,8 @@ import {
   assertSolanaExampleNetwork,
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
-  getCosignerHookRemainingAccounts,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
-  getSwapFeeAmount,
   getTokenAccountRentLamports,
   loadCosigner,
   loadKeypairSignerFromEnv,
@@ -170,7 +168,7 @@ async function main() {
     signedHookRemainingAccounts,
     unsignedHookRemainingAccounts,
     hookRemainingAccountsHash,
-  } = getCosignerHookRemainingAccounts({ namespace, cosigner });
+  } = cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
 
   console.log('Creating Token-2022 cosigner-gated launch...');
   console.log('  Launch:            ', launch);
@@ -240,7 +238,6 @@ async function main() {
         curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
         allowBuy: true,
         allowSell: true,
-        hookProgram: deployment.cosignerHookProgram,
         hookFlags:
           initializer.HF_BEFORE_SWAP | initializer.HF_FORWARD_READONLY_SIGNERS,
         hookPayload: new Uint8Array(),
@@ -365,7 +362,10 @@ async function main() {
     await assertMigrationQuoteThreshold({
       rpc,
       quoteVault: quoteVault.address,
-      pendingQuoteFees: getSwapFeeAmount(BUY_AMOUNT_IN, SWAP_FEE_BPS),
+      pendingQuoteFees: initializer.getCurveSwapFeeAmount(
+        BUY_AMOUNT_IN,
+        SWAP_FEE_BPS,
+      ),
       minRaiseQuote,
     });
   console.log('  Quote vault amount:', quoteVaultAmount.toString());

--- a/examples/solana-cosigner-gated-buy-token-2022.ts
+++ b/examples/solana-cosigner-gated-buy-token-2022.ts
@@ -29,13 +29,12 @@ import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import {
   cosignerHook,
   cpmm,
+  createLaunch,
   initializer,
-  cpmmMigrator,
 } from '../src/solana/index.js';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '../src/solana/core/constants.js';
 
 import {
-  DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
@@ -83,7 +82,6 @@ async function main() {
     BASE_TOTAL_SUPPLY - BASE_FOR_DISTRIBUTION - BASE_FOR_LIQUIDITY;
   const QUOTE_DECIMALS = 9;
   const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS;
   const BUY_AMOUNT_IN = parseDecimalTokenAmount(
     'SOLANA_COSIGNER_BUY_AMOUNT_SOL',
     QUOTE_DECIMALS,
@@ -111,64 +109,21 @@ async function main() {
   const baseMint = await generateKeyPairSigner();
   const baseVault = await generateKeyPairSigner();
   const quoteVault = await generateKeyPairSigner();
-  const metadataAccount = await initializer.getTokenMetadataAddress(
-    baseMint.address,
-  );
+  const metadata = DEFAULT_TEST_METADATA;
 
   const namespace = cosignerConfig;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-  const [launch] = await initializer.getLaunchAddress(
+  const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+    deployment,
     namespace,
     launchId,
-    deployment.initializerProgram,
-  );
-  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [payerBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    baseMint,
+    metadata,
   });
-  const [payerQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: WSOL_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const recipientAtas = await Promise.all(
-    launchBeneficiaries.recipients.map(async ({ wallet }) => {
-      const [ata] = await findAssociatedTokenPda({
-        owner: wallet,
-        mint: baseMint.address,
-        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-      });
-      return ata;
-    }),
-  );
+  const { launch, launchAuthority, launchFeeState } = launchAddresses;
 
-  const migrationAccounts =
-    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
-      launch,
-      baseMint: baseMint.address,
-      quoteMint: WSOL_MINT,
-      launchAuthority,
-      adminBaseAta: payerBaseAta,
-      adminQuoteAta: payerQuoteAta,
-      recipientAtas,
-      cpmmProgram: deployment.cpmmProgram,
-      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
-    });
-
-  const {
-    signedHookRemainingAccounts,
-    unsignedHookRemainingAccounts,
-    hookRemainingAccountsHash,
-  } = cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
+  const { signedHookRemainingAccounts, unsignedHookRemainingAccounts } =
+    cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
 
   console.log('Creating Token-2022 cosigner-gated launch...');
   console.log('  Launch:            ', launch);
@@ -188,73 +143,45 @@ async function main() {
     );
   }
 
-  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
-    cpmmConfig: migrationAccounts.cpmmConfig,
-    initialSwapFeeBps: SWAP_FEE_BPS,
-    initialFeeSplitBps: CPMM_SWAP_FEE_SPLIT_BPS,
-    recipients: launchBeneficiaries.recipients,
-    minRaiseQuote,
-    minMigrationPriceQ64Opt: null,
-    migratedPoolHookConfig: null,
-  });
-  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
-    baseForDistribution: BASE_FOR_DISTRIBUTION,
-    baseForLiquidity: BASE_FOR_LIQUIDITY,
-  });
-
-  const metadata = DEFAULT_TEST_METADATA;
-  const initializeLaunchIx =
-    await initializer.createInitializeLaunchInstruction(
-      {
-        config: deployment.initializerConfig,
-        launch,
-        launchAuthority,
+  const { instruction: initializeLaunchIx, cpmmMigration } = await createLaunch(
+    {
+      deployment,
+      namespace,
+      launchId,
+      addresses: launchAddresses,
+      launchAccounts: {
         baseMint,
         quoteMint: WSOL_MINT,
         baseVault,
         quoteVault,
-        launchFeeState,
-        payer,
-        authority: payer,
-        hookProgram: deployment.cosignerHookProgram,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        cpmmConfig: migrationAccounts.cpmmConfig,
-        baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-        metadataAccount,
       },
-      {
-        namespace,
-        launchId,
+      payer,
+      authority: payer,
+      supply: {
         baseDecimals: BASE_DECIMALS,
         baseTotalSupply: BASE_TOTAL_SUPPLY,
         baseForDistribution: BASE_FOR_DISTRIBUTION,
         baseForLiquidity: BASE_FOR_LIQUIDITY,
+      },
+      curve: {
         curveVirtualBase: start.curveVirtualBase,
         curveVirtualQuote: start.curveVirtualQuote,
         swapFeeBps: SWAP_FEE_BPS,
-        curveKind: initializer.CURVE_KIND_XYK,
-        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
-        allowBuy: true,
-        allowSell: true,
-        hookFlags:
-          initializer.HF_BEFORE_SWAP | initializer.HF_FORWARD_READONLY_SIGNERS,
-        hookPayload: new Uint8Array(),
-        migratorInitPayload,
-        migratorMigratePayload,
-        hookRemainingAccountsHash,
-        migratorInitRemainingAccountsHash:
-          initializer.computeRemainingAccountsHash([
-            migrationAccounts.cpmmMigrationState,
-            migrationAccounts.cpmmConfig,
-          ]),
-        migratorRemainingAccountsHash: migrationAccounts.hash,
-        feeBeneficiaries: launchBeneficiaries.feeBeneficiaries,
-        ...metadata,
       },
-      deployment.initializerProgram,
-    );
+      tokenPrograms: initializer.launchTokenPrograms.token2022Base(),
+      cosigner,
+      migration: {
+        recipients: launchBeneficiaries.recipients,
+        minRaiseQuote,
+      },
+      metadata,
+      feeBeneficiaries: launchBeneficiaries.feeBeneficiaries,
+    },
+  );
+  if (!cpmmMigration) {
+    throw new Error('CPMM migration accounts were not prepared');
+  }
+  const migrationAccounts = cpmmMigration;
 
   const launchSignature = await sendInitializeLaunchWithLookupTable({
     rpc,
@@ -372,14 +299,15 @@ async function main() {
   console.log('  Pending quote fees:', pendingQuoteFees.toString());
   console.log('');
 
-  const createRecipientAtaIxs = recipientAtas.map((ata, index) =>
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata,
-      owner: launchBeneficiaries.recipients[index].wallet,
-      mint: baseMint.address,
-      tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-    }),
+  const createRecipientAtaIxs = migrationAccounts.recipientAtas.map(
+    (ata, index) =>
+      getCreateAssociatedTokenIdempotentInstruction({
+        payer,
+        ata,
+        owner: launchBeneficiaries.recipients[index].wallet,
+        mint: baseMint.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+      }),
   );
 
   const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(

--- a/examples/solana-cosigner-gated-buy-token-2022.ts
+++ b/examples/solana-cosigner-gated-buy-token-2022.ts
@@ -1,0 +1,503 @@
+/**
+ * Example: Cosigner-Gated Bonding Curve Buy With Token-2022 Base (Solana)
+ *
+ * Creates a CPMM-migratable Token-2022 base launch with the cosigner hook enabled for
+ * pre-migration swaps, proves an unsigned buy fails, executes one cosigned
+ * bonding-curve buy, migrates, then performs an ungated CPMM swap.
+ *
+ * Configure two launch beneficiaries with:
+ *   SOLANA_FEE_BENEFICIARY_1_WALLET / _BASE_AMOUNT / _SHARE_BPS
+ *   SOLANA_FEE_BENEFICIARY_2_WALLET / _BASE_AMOUNT / _SHARE_BPS
+ * The *_BASE_AMOUNT values are human token amounts and must sum to the launch
+ * distribution allocation. The *_SHARE_BPS values must sum to 10000.
+ */
+import './env.js';
+
+import {
+  TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getSyncNativeInstruction,
+} from '@solana-program/token';
+import {
+  SYSTEM_PROGRAM_ADDRESS,
+  getTransferSolInstruction,
+} from '@solana-program/system';
+import { generateKeyPairSigner } from '@solana/kit';
+import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
+
+import {
+  cosignerHook,
+  cpmm,
+  initializer,
+  cpmmMigrator,
+} from '../src/solana/index.js';
+import { TOKEN_2022_PROGRAM_ADDRESS } from '../src/solana/core/constants.js';
+
+import {
+  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  DEFAULT_SWAP_FEE_BPS,
+  DEFAULT_TEST_METADATA,
+  WSOL_MINT,
+  assertCosignerRegistered,
+  assertMigrationQuoteThreshold,
+  assertSimulationRejected,
+  assertSolanaExampleNetwork,
+  createSetComputeUnitLimitInstruction,
+  createSolanaClientsFromEnv,
+  getCosignerHookRemainingAccounts,
+  getSolPriceUsd,
+  getSolanaCpmmDeploymentFromEnv,
+  getSwapFeeAmount,
+  getTokenAccountRentLamports,
+  loadCosigner,
+  loadKeypairSignerFromEnv,
+  loadLaunchBeneficiaries,
+  parseDecimalTokenAmount,
+  sendInitializeLaunchWithLookupTable,
+  sendInstructions,
+  simulateInstructions,
+} from './solanaExampleHelpers.js';
+
+async function main() {
+  const payer = await loadKeypairSignerFromEnv();
+  const cosigner = await loadCosigner();
+  const { rpc, rpcSubscriptions, network } = createSolanaClientsFromEnv();
+  assertSolanaExampleNetwork(network, ['devnet', 'custom']);
+  const deployment = await getSolanaCpmmDeploymentFromEnv(network);
+  const [cosignerConfig] = await cosignerHook.getCosignerHookConfigAddress(
+    deployment.cosignerHookProgram,
+  );
+
+  console.log('Checking cosigner hook config...');
+  await assertCosignerRegistered({
+    rpc,
+    cosignerHookProgram: deployment.cosignerHookProgram,
+    cosignerConfig,
+    cosigner,
+  });
+
+  const BASE_DECIMALS = 6;
+  const BASE_TOTAL_SUPPLY = 1_000_000_000n * 10n ** BigInt(BASE_DECIMALS);
+  const BASE_FOR_DISTRIBUTION = 200_000_000n * 10n ** BigInt(BASE_DECIMALS);
+  const BASE_FOR_LIQUIDITY = 50_000_000n * 10n ** BigInt(BASE_DECIMALS);
+  const BASE_FOR_CURVE =
+    BASE_TOTAL_SUPPLY - BASE_FOR_DISTRIBUTION - BASE_FOR_LIQUIDITY;
+  const QUOTE_DECIMALS = 9;
+  const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
+  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS;
+  const BUY_AMOUNT_IN = parseDecimalTokenAmount(
+    'SOLANA_COSIGNER_BUY_AMOUNT_SOL',
+    QUOTE_DECIMALS,
+  );
+  if (BUY_AMOUNT_IN === 0n) {
+    throw new Error('SOLANA_COSIGNER_BUY_AMOUNT_SOL must be greater than zero');
+  }
+  const minRaiseQuote = BUY_AMOUNT_IN > 1_000n ? BUY_AMOUNT_IN / 2n : 1n;
+  const launchBeneficiaries = loadLaunchBeneficiaries({
+    baseDecimals: BASE_DECIMALS,
+    expectedDistributionAmount: BASE_FOR_DISTRIBUTION,
+  });
+
+  const solPriceUsd = await getSolPriceUsd();
+  const { start } = cpmm.marketCapToCurveParams({
+    startMarketCapUSD: 100_000,
+    endMarketCapUSD: 10_000_000,
+    baseTotalSupply: BASE_TOTAL_SUPPLY,
+    baseForCurve: BASE_FOR_CURVE,
+    baseDecimals: BASE_DECIMALS,
+    quoteDecimals: QUOTE_DECIMALS,
+    numerairePriceUSD: solPriceUsd,
+  });
+
+  const baseMint = await generateKeyPairSigner();
+  const baseVault = await generateKeyPairSigner();
+  const quoteVault = await generateKeyPairSigner();
+  const metadataAccount = await initializer.getTokenMetadataAddress(
+    baseMint.address,
+  );
+
+  const namespace = cosignerConfig;
+  const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
+  const [launch] = await initializer.getLaunchAddress(
+    namespace,
+    launchId,
+    deployment.initializerProgram,
+  );
+  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
+    launch,
+    deployment.initializerProgram,
+  );
+  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
+    launch,
+    deployment.initializerProgram,
+  );
+  const [payerBaseAta] = await findAssociatedTokenPda({
+    owner: payer.address,
+    mint: baseMint.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+  const [payerQuoteAta] = await findAssociatedTokenPda({
+    owner: payer.address,
+    mint: WSOL_MINT,
+    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+  });
+  const recipientAtas = await Promise.all(
+    launchBeneficiaries.recipients.map(async ({ wallet }) => {
+      const [ata] = await findAssociatedTokenPda({
+        owner: wallet,
+        mint: baseMint.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+      });
+      return ata;
+    }),
+  );
+
+  const migrationAccounts =
+    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
+      launch,
+      baseMint: baseMint.address,
+      quoteMint: WSOL_MINT,
+      launchAuthority,
+      adminBaseAta: payerBaseAta,
+      adminQuoteAta: payerQuoteAta,
+      recipientAtas,
+      cpmmProgram: deployment.cpmmProgram,
+      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
+    });
+
+  const {
+    signedHookRemainingAccounts,
+    unsignedHookRemainingAccounts,
+    hookRemainingAccountsHash,
+  } = getCosignerHookRemainingAccounts({ namespace, cosigner });
+
+  console.log('Creating Token-2022 cosigner-gated launch...');
+  console.log('  Launch:            ', launch);
+  console.log('  Base mint:         ', baseMint.address);
+  console.log('  Cosigner hook:     ', deployment.cosignerHookProgram);
+  console.log('  Cosigner config:   ', cosignerConfig);
+  console.log('  Signing cosigner:  ', cosigner.address);
+  console.log('  Buy amount atoms:  ', BUY_AMOUNT_IN.toString());
+  console.log('  Migration threshold atoms:', minRaiseQuote.toString());
+  console.log('  Fee beneficiaries: ');
+  for (const [
+    index,
+    beneficiary,
+  ] of launchBeneficiaries.feeBeneficiaries.entries()) {
+    console.log(
+      `    [${index}] ${beneficiary.wallet} share=${beneficiary.shareBps}bps allocation=${launchBeneficiaries.recipients[index].amount}`,
+    );
+  }
+
+  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
+    cpmmConfig: migrationAccounts.cpmmConfig,
+    initialSwapFeeBps: SWAP_FEE_BPS,
+    initialFeeSplitBps: CPMM_SWAP_FEE_SPLIT_BPS,
+    recipients: launchBeneficiaries.recipients,
+    minRaiseQuote,
+    minMigrationPriceQ64Opt: null,
+    migratedPoolHookConfig: null,
+  });
+  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
+    baseForDistribution: BASE_FOR_DISTRIBUTION,
+    baseForLiquidity: BASE_FOR_LIQUIDITY,
+  });
+
+  const metadata = DEFAULT_TEST_METADATA;
+  const initializeLaunchIx =
+    await initializer.createInitializeLaunchInstruction(
+      {
+        config: deployment.initializerConfig,
+        launch,
+        launchAuthority,
+        baseMint,
+        quoteMint: WSOL_MINT,
+        baseVault,
+        quoteVault,
+        launchFeeState,
+        payer,
+        authority: payer,
+        hookProgram: deployment.cosignerHookProgram,
+        migratorProgram: deployment.cpmmMigratorProgram,
+        cpmmConfig: migrationAccounts.cpmmConfig,
+        baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
+        rent: SYSVAR_RENT_ADDRESS,
+        metadataAccount,
+      },
+      {
+        namespace,
+        launchId,
+        baseDecimals: BASE_DECIMALS,
+        baseTotalSupply: BASE_TOTAL_SUPPLY,
+        baseForDistribution: BASE_FOR_DISTRIBUTION,
+        baseForLiquidity: BASE_FOR_LIQUIDITY,
+        curveVirtualBase: start.curveVirtualBase,
+        curveVirtualQuote: start.curveVirtualQuote,
+        swapFeeBps: SWAP_FEE_BPS,
+        curveKind: initializer.CURVE_KIND_XYK,
+        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
+        allowBuy: true,
+        allowSell: true,
+        hookProgram: deployment.cosignerHookProgram,
+        hookFlags:
+          initializer.HF_BEFORE_SWAP | initializer.HF_FORWARD_READONLY_SIGNERS,
+        hookPayload: new Uint8Array(),
+        migratorInitPayload,
+        migratorMigratePayload,
+        hookRemainingAccountsHash,
+        migratorInitRemainingAccountsHash:
+          initializer.computeRemainingAccountsHash([
+            migrationAccounts.cpmmMigrationState,
+            migrationAccounts.cpmmConfig,
+          ]),
+        migratorRemainingAccountsHash: migrationAccounts.hash,
+        feeBeneficiaries: launchBeneficiaries.feeBeneficiaries,
+        ...metadata,
+      },
+      deployment.initializerProgram,
+    );
+
+  const launchSignature = await sendInitializeLaunchWithLookupTable({
+    rpc,
+    rpcSubscriptions,
+    payer,
+    instruction: initializeLaunchIx,
+    metadata,
+  });
+  console.log('  Launch tx:         ', launchSignature);
+
+  const [userBaseAta] = await findAssociatedTokenPda({
+    owner: payer.address,
+    mint: baseMint.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+  const [userQuoteAta] = await findAssociatedTokenPda({
+    owner: payer.address,
+    mint: WSOL_MINT,
+    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+  });
+  const setupAndFund = [
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer,
+      ata: userBaseAta,
+      owner: payer.address,
+      mint: baseMint.address,
+      tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    }),
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer,
+      ata: userQuoteAta,
+      owner: payer.address,
+      mint: WSOL_MINT,
+    }),
+    getTransferSolInstruction({
+      source: payer,
+      destination: userQuoteAta,
+      amount: BUY_AMOUNT_IN + getTokenAccountRentLamports(),
+    }),
+    getSyncNativeInstruction({ account: userQuoteAta }),
+  ];
+  const swapAccounts = {
+    config: deployment.initializerConfig,
+    launch,
+    launchAuthority,
+    baseVault: baseVault.address,
+    quoteVault: quoteVault.address,
+    launchFeeState,
+    userBaseAccount: userBaseAta,
+    userQuoteAccount: userQuoteAta,
+    baseMint: baseMint.address,
+    quoteMint: WSOL_MINT,
+    user: payer,
+    hookProgram: deployment.cosignerHookProgram,
+    baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
+  };
+
+  const unsignedSwapIx = initializer.createCurveSwapExactInInstruction(
+    { ...swapAccounts, remainingAccounts: unsignedHookRemainingAccounts },
+    {
+      amountIn: BUY_AMOUNT_IN,
+      minAmountOut: 1n,
+      tradeDirection: initializer.TRADE_DIRECTION_BUY,
+    },
+    deployment.initializerProgram,
+  );
+  const unsignedResult = await simulateInstructions({
+    rpc,
+    payer,
+    instructions: [...setupAndFund, unsignedSwapIx],
+  });
+  assertSimulationRejected('Unsigned bonding curve buy', unsignedResult.err);
+
+  const signedSwapIx = initializer.createCurveSwapExactInInstruction(
+    { ...swapAccounts, remainingAccounts: signedHookRemainingAccounts },
+    {
+      amountIn: BUY_AMOUNT_IN,
+      minAmountOut: 1n,
+      tradeDirection: initializer.TRADE_DIRECTION_BUY,
+    },
+    deployment.initializerProgram,
+  );
+  const buySignature = await sendInstructions({
+    rpc,
+    rpcSubscriptions,
+    payer,
+    instructions: [...setupAndFund, signedSwapIx],
+  });
+  console.log('  Cosigned buy tx:   ', buySignature);
+
+  const launchAccount = await initializer.fetchLaunch(rpc, launch, {
+    commitment: 'confirmed',
+    programId: deployment.initializerProgram,
+  });
+  if (!launchAccount) {
+    throw new Error('Launch account was not found after buy');
+  }
+  console.log(
+    '  Launch phase:      ',
+    initializer.phaseLabel(launchAccount.phase),
+  );
+
+  const { quoteVaultAmount, pendingQuoteFees } =
+    await assertMigrationQuoteThreshold({
+      rpc,
+      quoteVault: quoteVault.address,
+      pendingQuoteFees: getSwapFeeAmount(BUY_AMOUNT_IN, SWAP_FEE_BPS),
+      minRaiseQuote,
+    });
+  console.log('  Quote vault amount:', quoteVaultAmount.toString());
+  console.log('  Pending quote fees:', pendingQuoteFees.toString());
+  console.log('');
+
+  const createRecipientAtaIxs = recipientAtas.map((ata, index) =>
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer,
+      ata,
+      owner: launchBeneficiaries.recipients[index].wallet,
+      mint: baseMint.address,
+      tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    }),
+  );
+
+  const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(
+    {
+      config: deployment.initializerConfig,
+      launch,
+      launchAuthority,
+      baseMint: baseMint.address,
+      quoteMint: WSOL_MINT,
+      baseVault: baseVault.address,
+      quoteVault: quoteVault.address,
+      launchFeeState,
+      migratorProgram: deployment.cpmmMigratorProgram,
+      payer,
+      baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+      quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
+      systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      rent: SYSVAR_RENT_ADDRESS,
+    },
+    deployment.initializerProgram,
+  );
+  const migrateLaunchIx = {
+    ...migrateLaunchIxBase,
+    accounts: [
+      ...(migrateLaunchIxBase.accounts ?? []),
+      ...migrationAccounts.metas,
+    ],
+  };
+  const migrationSignature = await sendInstructions({
+    rpc,
+    rpcSubscriptions,
+    payer,
+    instructions: [
+      createSetComputeUnitLimitInstruction(800_000),
+      ...createRecipientAtaIxs,
+      migrateLaunchIx,
+    ],
+  });
+  console.log('  Migration tx:      ', migrationSignature);
+
+  const migratedLaunch = await initializer.fetchLaunch(rpc, launch, {
+    commitment: 'confirmed',
+    programId: deployment.initializerProgram,
+  });
+  if (!migratedLaunch) {
+    throw new Error('Launch account was not found after migration');
+  }
+  console.log(
+    '  Migrated phase:    ',
+    initializer.phaseLabel(migratedLaunch.phase),
+  );
+
+  const poolResult = await cpmm.getPoolByMints(
+    rpc,
+    baseMint.address,
+    WSOL_MINT,
+    {
+      commitment: 'confirmed',
+      programId: deployment.cpmmProgram,
+    },
+  );
+  if (!poolResult) {
+    throw new Error('CPMM pool was not found after migration');
+  }
+
+  const { address: poolAddress, account: pool } = poolResult;
+  if (pool.hookProgram !== SYSTEM_PROGRAM_ADDRESS || pool.hookFlags !== 0) {
+    throw new Error(
+      `Migrated pool hook mismatch: got program ${pool.hookProgram} flags ${pool.hookFlags}, expected no CPMM hook`,
+    );
+  }
+
+  const tradeDirection = pool.token0Mint === baseMint.address ? 0 : 1;
+  const CPMM_SWAP_AMOUNT_IN = 1_000_000n;
+  const quote = cpmm.getSwapQuote(pool, CPMM_SWAP_AMOUNT_IN, tradeDirection);
+  const minAmountOut = (quote.amountOut * 9_500n) / 10_000n;
+  const userToken0 =
+    pool.token0Mint === baseMint.address ? userBaseAta : userQuoteAta;
+  const userToken1 =
+    pool.token1Mint === baseMint.address ? userBaseAta : userQuoteAta;
+  const cpmmSwapIx = cpmm.createSwapInstruction({
+    config: migrationAccounts.cpmmConfig,
+    pool: poolAddress,
+    authority: pool.authority,
+    vault0: pool.vault0,
+    vault1: pool.vault1,
+    token0Mint: pool.token0Mint,
+    token1Mint: pool.token1Mint,
+    userToken0,
+    userToken1,
+    user: payer,
+    amountIn: CPMM_SWAP_AMOUNT_IN,
+    minAmountOut,
+    tradeDirection,
+    token0Program:
+      pool.token0Mint === baseMint.address
+        ? TOKEN_2022_PROGRAM_ADDRESS
+        : TOKEN_PROGRAM_ADDRESS,
+    token1Program:
+      pool.token1Mint === baseMint.address
+        ? TOKEN_2022_PROGRAM_ADDRESS
+        : TOKEN_PROGRAM_ADDRESS,
+    programId: deployment.cpmmProgram,
+  });
+  const cpmmSwapSignature = await sendInstructions({
+    rpc,
+    rpcSubscriptions,
+    payer,
+    instructions: [createSetComputeUnitLimitInstruction(400_000), cpmmSwapIx],
+  });
+  console.log('  Ungated CPMM swap tx:', cpmmSwapSignature);
+  console.log('');
+  console.log(
+    'Token-2022 cosigner-gated buy and ungated CPMM migration flow complete.',
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/solana-cosigner-gated-buy.ts
+++ b/examples/solana-cosigner-gated-buy.ts
@@ -23,20 +23,7 @@ import {
   SYSTEM_PROGRAM_ADDRESS,
   getTransferSolInstruction,
 } from '@solana-program/system';
-import {
-  pipe,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  address,
-  type Address,
-  type TransactionSigner,
-} from '@solana/kit';
+import { generateKeyPairSigner } from '@solana/kit';
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
@@ -45,164 +32,31 @@ import {
   initializer,
   cpmmMigrator,
 } from '../src/solana/index.js';
+
 import {
-  assertTransactionFits,
-  assertSolanaExampleNetwork,
+  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  DEFAULT_SWAP_FEE_BPS,
+  DEFAULT_TEST_METADATA,
+  WSOL_MINT,
+  assertCosignerRegistered,
+  assertMigrationQuoteThreshold,
   assertSimulationRejected,
-  createLookupTableForInstruction,
+  assertSolanaExampleNetwork,
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
-  getMetadataByteLength,
+  getCosignerHookRemainingAccounts,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
+  getSwapFeeAmount,
   getTokenAccountRentLamports,
+  loadCosigner,
   loadKeypairSignerFromEnv,
+  loadLaunchBeneficiaries,
+  parseDecimalTokenAmount,
+  sendInitializeLaunchWithLookupTable,
   sendInstructions,
   simulateInstructions,
 } from './solanaExampleHelpers.js';
-
-type SolanaClients = ReturnType<typeof createSolanaClientsFromEnv>;
-type LaunchBeneficiaryConfig = {
-  recipients: { wallet: Address; amount: bigint }[];
-  feeBeneficiaries: { wallet: Address; shareBps: number }[];
-};
-
-const WSOL_MINT: Address =
-  'So11111111111111111111111111111111111111112' as Address;
-
-async function loadCosigner(): Promise<TransactionSigner> {
-  if (!process.env.COSIGNER_KEYPAIR_PATH && !process.env.COSIGNER_KEYPAIR) {
-    throw new Error(
-      'COSIGNER_KEYPAIR_PATH or COSIGNER_KEYPAIR is required to sign cosigner-gated swaps.',
-    );
-  }
-
-  return loadKeypairSignerFromEnv({
-    pathEnv: 'COSIGNER_KEYPAIR_PATH',
-    jsonEnv: 'COSIGNER_KEYPAIR',
-    label: 'COSIGNER_KEYPAIR',
-  });
-}
-
-async function fetchActiveCosigners({
-  rpc,
-  cosignerHookProgram,
-  cosignerConfig,
-}: {
-  rpc: SolanaClients['rpc'];
-  cosignerHookProgram: Address;
-  cosignerConfig: Address;
-}): Promise<Address[]> {
-  const existingConfig = await cosignerHook.fetchMaybeCosignerConfig(
-    rpc,
-    cosignerConfig,
-    { commitment: 'confirmed' },
-  );
-
-  if (!existingConfig.exists) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} does not exist. The integrator/admin must initialize it before running this flow.`,
-    );
-  }
-
-  if (existingConfig.programAddress !== cosignerHookProgram) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} is owned by ${existingConfig.programAddress}, expected ${cosignerHookProgram}`,
-    );
-  }
-
-  const activeCosigners = existingConfig.data.cosigners.slice(
-    0,
-    existingConfig.data.cosignerCount,
-  );
-  if (activeCosigners.length === 0) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} does not include any active cosigners`,
-    );
-  }
-
-  return activeCosigners;
-}
-
-function requiredEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (!value) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
-
-function parseShareBps(name: string): number {
-  const value = Number(requiredEnv(name));
-  if (!Number.isInteger(value) || value <= 0 || value > 10_000) {
-    throw new Error(`${name} must be an integer from 1 to 10000`);
-  }
-  return value;
-}
-
-function parseDecimalTokenAmount(name: string, decimals: number): bigint {
-  const value = requiredEnv(name);
-  if (!/^\d+(\.\d+)?$/.test(value)) {
-    throw new Error(`${name} must be a non-negative decimal token amount`);
-  }
-
-  const [whole, fractional = ''] = value.split('.');
-  if (fractional.length > decimals) {
-    throw new Error(`${name} has more than ${decimals} decimal places`);
-  }
-
-  return (
-    BigInt(whole) * 10n ** BigInt(decimals) +
-    BigInt(fractional.padEnd(decimals, '0'))
-  );
-}
-
-function loadLaunchBeneficiaries({
-  baseDecimals,
-  expectedDistributionAmount,
-}: {
-  baseDecimals: number;
-  expectedDistributionAmount: bigint;
-}): LaunchBeneficiaryConfig {
-  const recipients: LaunchBeneficiaryConfig['recipients'] = [];
-  const feeBeneficiaries: LaunchBeneficiaryConfig['feeBeneficiaries'] = [];
-
-  for (let i = 1; i <= 2; i++) {
-    const prefix = `SOLANA_FEE_BENEFICIARY_${i}`;
-    const wallet = address(requiredEnv(`${prefix}_WALLET`));
-    const amount = parseDecimalTokenAmount(
-      `${prefix}_BASE_AMOUNT`,
-      baseDecimals,
-    );
-    const shareBps = parseShareBps(`${prefix}_SHARE_BPS`);
-
-    if (amount === 0n) {
-      throw new Error(`${prefix}_BASE_AMOUNT must be greater than zero`);
-    }
-
-    recipients.push({ wallet, amount });
-    feeBeneficiaries.push({ wallet, shareBps });
-  }
-
-  const totalAmount = recipients.reduce((sum, entry) => sum + entry.amount, 0n);
-  if (totalAmount !== expectedDistributionAmount) {
-    throw new Error(
-      `SOLANA_FEE_BENEFICIARY_*_BASE_AMOUNT values must sum to ${expectedDistributionAmount} base atoms`,
-    );
-  }
-
-  const totalShareBps = feeBeneficiaries.reduce(
-    (sum, entry) => sum + entry.shareBps,
-    0,
-  );
-  if (totalShareBps !== 10_000) {
-    throw new Error(
-      'SOLANA_FEE_BENEFICIARY_*_SHARE_BPS values must sum to 10000',
-    );
-  }
-
-  return { recipients, feeBeneficiaries };
-}
 
 async function main() {
   const payer = await loadKeypairSignerFromEnv();
@@ -215,16 +69,12 @@ async function main() {
   );
 
   console.log('Checking cosigner hook config...');
-  const activeCosigners = await fetchActiveCosigners({
+  await assertCosignerRegistered({
     rpc,
     cosignerHookProgram: deployment.cosignerHookProgram,
     cosignerConfig,
+    cosigner,
   });
-  if (!activeCosigners.includes(cosigner.address)) {
-    throw new Error(
-      `COSIGNER_KEYPAIR resolves to ${cosigner.address}, which is not registered in cosigner hook config ${cosignerConfig}`,
-    );
-  }
 
   const BASE_DECIMALS = 6;
   const BASE_TOTAL_SUPPLY = 1_000_000_000n * 10n ** BigInt(BASE_DECIMALS);
@@ -233,8 +83,8 @@ async function main() {
   const BASE_FOR_CURVE =
     BASE_TOTAL_SUPPLY - BASE_FOR_DISTRIBUTION - BASE_FOR_LIQUIDITY;
   const QUOTE_DECIMALS = 9;
-  const SWAP_FEE_BPS = 200;
-  const CPMM_SWAP_FEE_SPLIT_BPS = 10_000;
+  const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
+  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS;
   const BUY_AMOUNT_IN = parseDecimalTokenAmount(
     'SOLANA_COSIGNER_BUY_AMOUNT_SOL',
     QUOTE_DECIMALS,
@@ -315,12 +165,11 @@ async function main() {
       cpmmMigratorProgram: deployment.cpmmMigratorProgram,
     });
 
-  const signedHookRemainingAccounts = [namespace, cosigner];
-  const unsignedHookRemainingAccounts = [namespace, cosigner.address];
-  const hookRemainingAccountsHash = initializer.computeRemainingAccountsHash([
-    namespace,
-    cosigner.address,
-  ]);
+  const {
+    signedHookRemainingAccounts,
+    unsignedHookRemainingAccounts,
+    hookRemainingAccountsHash,
+  } = getCosignerHookRemainingAccounts({ namespace, cosigner });
 
   console.log('Creating cosigner-gated launch...');
   console.log('  Launch:            ', launch);
@@ -354,11 +203,7 @@ async function main() {
     baseForLiquidity: BASE_FOR_LIQUIDITY,
   });
 
-  const metadata = {
-    metadataName: 'TEST',
-    metadataSymbol: 'TEST',
-    metadataUri: 'https://example.com/metadata/test-token.json',
-  };
+  const metadata = DEFAULT_TEST_METADATA;
   const initializeLaunchIx =
     await initializer.createInitializeLaunchInstruction(
       {
@@ -412,38 +257,14 @@ async function main() {
       deployment.initializerProgram,
     );
 
-  const lookupTable = await createLookupTableForInstruction({
+  const launchSignature = await sendInitializeLaunchWithLookupTable({
     rpc,
     rpcSubscriptions,
     payer,
     instruction: initializeLaunchIx,
-    label: 'initialize_launch lookup table',
+    metadata,
   });
-  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-  const launchMessage = initializer.compressTransactionMessageWithLookupTable(
-    pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) => appendTransactionMessageInstructions([initializeLaunchIx], tx),
-    ),
-    lookupTable,
-  );
-  assertTransactionFits(launchMessage, {
-    label: 'initialize_launch',
-    metadataBytes: getMetadataByteLength(metadata),
-  });
-  const signedLaunch = await signTransactionMessageWithSigners(launchMessage);
-  await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-    signedLaunch as Parameters<
-      ReturnType<typeof sendAndConfirmTransactionFactory>
-    >[0],
-    { commitment: 'confirmed' },
-  );
-  console.log(
-    '  Launch tx:         ',
-    getSignatureFromTransaction(signedLaunch),
-  );
+  console.log('  Launch tx:         ', launchSignature);
 
   const [userBaseAta] = await findAssociatedTokenPda({
     owner: payer.address,
@@ -536,20 +357,15 @@ async function main() {
     initializer.phaseLabel(launchAccount.phase),
   );
 
-  const quoteVaultBalance = await rpc
-    .getTokenAccountBalance(quoteVault.address, { commitment: 'confirmed' })
-    .send();
-  const quoteVaultAmount = BigInt(quoteVaultBalance.value.amount);
-  const pendingQuoteFees =
-    (BUY_AMOUNT_IN * BigInt(SWAP_FEE_BPS) + 9_999n) / 10_000n;
-  const migrationQuoteAmount = quoteVaultAmount - pendingQuoteFees;
+  const { quoteVaultAmount, pendingQuoteFees } =
+    await assertMigrationQuoteThreshold({
+      rpc,
+      quoteVault: quoteVault.address,
+      pendingQuoteFees: getSwapFeeAmount(BUY_AMOUNT_IN, SWAP_FEE_BPS),
+      minRaiseQuote,
+    });
   console.log('  Quote vault amount:', quoteVaultAmount.toString());
   console.log('  Pending quote fees:', pendingQuoteFees.toString());
-  if (migrationQuoteAmount < minRaiseQuote) {
-    throw new Error(
-      `Migration quote amount ${migrationQuoteAmount} is below threshold ${minRaiseQuote}`,
-    );
-  }
   console.log('');
 
   const createRecipientAtaIxs = recipientAtas.map((ata, index) =>

--- a/examples/solana-cosigner-gated-buy.ts
+++ b/examples/solana-cosigner-gated-buy.ts
@@ -44,10 +44,8 @@ import {
   assertSolanaExampleNetwork,
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
-  getCosignerHookRemainingAccounts,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
-  getSwapFeeAmount,
   getTokenAccountRentLamports,
   loadCosigner,
   loadKeypairSignerFromEnv,
@@ -169,7 +167,7 @@ async function main() {
     signedHookRemainingAccounts,
     unsignedHookRemainingAccounts,
     hookRemainingAccountsHash,
-  } = getCosignerHookRemainingAccounts({ namespace, cosigner });
+  } = cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
 
   console.log('Creating cosigner-gated launch...');
   console.log('  Launch:            ', launch);
@@ -361,7 +359,10 @@ async function main() {
     await assertMigrationQuoteThreshold({
       rpc,
       quoteVault: quoteVault.address,
-      pendingQuoteFees: getSwapFeeAmount(BUY_AMOUNT_IN, SWAP_FEE_BPS),
+      pendingQuoteFees: initializer.getCurveSwapFeeAmount(
+        BUY_AMOUNT_IN,
+        SWAP_FEE_BPS,
+      ),
       minRaiseQuote,
     });
   console.log('  Quote vault amount:', quoteVaultAmount.toString());

--- a/examples/solana-cosigner-gated-buy.ts
+++ b/examples/solana-cosigner-gated-buy.ts
@@ -29,12 +29,11 @@ import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import {
   cosignerHook,
   cpmm,
+  createLaunch,
   initializer,
-  cpmmMigrator,
 } from '../src/solana/index.js';
 
 import {
-  DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
@@ -82,7 +81,6 @@ async function main() {
     BASE_TOTAL_SUPPLY - BASE_FOR_DISTRIBUTION - BASE_FOR_LIQUIDITY;
   const QUOTE_DECIMALS = 9;
   const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS;
   const BUY_AMOUNT_IN = parseDecimalTokenAmount(
     'SOLANA_COSIGNER_BUY_AMOUNT_SOL',
     QUOTE_DECIMALS,
@@ -110,64 +108,21 @@ async function main() {
   const baseMint = await generateKeyPairSigner();
   const baseVault = await generateKeyPairSigner();
   const quoteVault = await generateKeyPairSigner();
-  const metadataAccount = await initializer.getTokenMetadataAddress(
-    baseMint.address,
-  );
+  const metadata = DEFAULT_TEST_METADATA;
 
   const namespace = cosignerConfig;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-  const [launch] = await initializer.getLaunchAddress(
+  const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+    deployment,
     namespace,
     launchId,
-    deployment.initializerProgram,
-  );
-  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [payerBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    baseMint,
+    metadata,
   });
-  const [payerQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: WSOL_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const recipientAtas = await Promise.all(
-    launchBeneficiaries.recipients.map(async ({ wallet }) => {
-      const [ata] = await findAssociatedTokenPda({
-        owner: wallet,
-        mint: baseMint.address,
-        tokenProgram: TOKEN_PROGRAM_ADDRESS,
-      });
-      return ata;
-    }),
-  );
+  const { launch, launchAuthority, launchFeeState } = launchAddresses;
 
-  const migrationAccounts =
-    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
-      launch,
-      baseMint: baseMint.address,
-      quoteMint: WSOL_MINT,
-      launchAuthority,
-      adminBaseAta: payerBaseAta,
-      adminQuoteAta: payerQuoteAta,
-      recipientAtas,
-      cpmmProgram: deployment.cpmmProgram,
-      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
-    });
-
-  const {
-    signedHookRemainingAccounts,
-    unsignedHookRemainingAccounts,
-    hookRemainingAccountsHash,
-  } = cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
+  const { signedHookRemainingAccounts, unsignedHookRemainingAccounts } =
+    cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
 
   console.log('Creating cosigner-gated launch...');
   console.log('  Launch:            ', launch);
@@ -187,73 +142,44 @@ async function main() {
     );
   }
 
-  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
-    cpmmConfig: migrationAccounts.cpmmConfig,
-    initialSwapFeeBps: SWAP_FEE_BPS,
-    initialFeeSplitBps: CPMM_SWAP_FEE_SPLIT_BPS,
-    recipients: launchBeneficiaries.recipients,
-    minRaiseQuote,
-    minMigrationPriceQ64Opt: null,
-    migratedPoolHookConfig: null,
-  });
-  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
-    baseForDistribution: BASE_FOR_DISTRIBUTION,
-    baseForLiquidity: BASE_FOR_LIQUIDITY,
-  });
-
-  const metadata = DEFAULT_TEST_METADATA;
-  const initializeLaunchIx =
-    await initializer.createInitializeLaunchInstruction(
-      {
-        config: deployment.initializerConfig,
-        launch,
-        launchAuthority,
+  const { instruction: initializeLaunchIx, cpmmMigration } = await createLaunch(
+    {
+      deployment,
+      namespace,
+      launchId,
+      addresses: launchAddresses,
+      launchAccounts: {
         baseMint,
         quoteMint: WSOL_MINT,
         baseVault,
         quoteVault,
-        launchFeeState,
-        payer,
-        authority: payer,
-        hookProgram: deployment.cosignerHookProgram,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        cpmmConfig: migrationAccounts.cpmmConfig,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-        metadataAccount,
       },
-      {
-        namespace,
-        launchId,
+      payer,
+      authority: payer,
+      supply: {
         baseDecimals: BASE_DECIMALS,
         baseTotalSupply: BASE_TOTAL_SUPPLY,
         baseForDistribution: BASE_FOR_DISTRIBUTION,
         baseForLiquidity: BASE_FOR_LIQUIDITY,
+      },
+      curve: {
         curveVirtualBase: start.curveVirtualBase,
         curveVirtualQuote: start.curveVirtualQuote,
         swapFeeBps: SWAP_FEE_BPS,
-        curveKind: initializer.CURVE_KIND_XYK,
-        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
-        allowBuy: true,
-        allowSell: true,
-        hookFlags:
-          initializer.HF_BEFORE_SWAP | initializer.HF_FORWARD_READONLY_SIGNERS,
-        hookPayload: new Uint8Array(),
-        migratorInitPayload,
-        migratorMigratePayload,
-        hookRemainingAccountsHash,
-        migratorInitRemainingAccountsHash:
-          initializer.computeRemainingAccountsHash([
-            migrationAccounts.cpmmMigrationState,
-            migrationAccounts.cpmmConfig,
-          ]),
-        migratorRemainingAccountsHash: migrationAccounts.hash,
-        feeBeneficiaries: launchBeneficiaries.feeBeneficiaries,
-        ...metadata,
       },
-      deployment.initializerProgram,
-    );
+      cosigner,
+      migration: {
+        recipients: launchBeneficiaries.recipients,
+        minRaiseQuote,
+      },
+      metadata,
+      feeBeneficiaries: launchBeneficiaries.feeBeneficiaries,
+    },
+  );
+  if (!cpmmMigration) {
+    throw new Error('CPMM migration accounts were not prepared');
+  }
+  const migrationAccounts = cpmmMigration;
 
   const launchSignature = await sendInitializeLaunchWithLookupTable({
     rpc,
@@ -369,13 +295,14 @@ async function main() {
   console.log('  Pending quote fees:', pendingQuoteFees.toString());
   console.log('');
 
-  const createRecipientAtaIxs = recipientAtas.map((ata, index) =>
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata,
-      owner: launchBeneficiaries.recipients[index].wallet,
-      mint: baseMint.address,
-    }),
+  const createRecipientAtaIxs = migrationAccounts.recipientAtas.map(
+    (ata, index) =>
+      getCreateAssociatedTokenIdempotentInstruction({
+        payer,
+        ata,
+        owner: launchBeneficiaries.recipients[index].wallet,
+        mint: baseMint.address,
+      }),
   );
 
   const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(

--- a/examples/solana-cosigner-gated-launch.ts
+++ b/examples/solana-cosigner-gated-launch.ts
@@ -47,7 +47,6 @@ import {
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
   fetchActiveCosigners,
-  getCosignerHookRemainingAccounts,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
   getTokenAccountRentLamports,
@@ -142,7 +141,7 @@ async function main() {
     signedHookRemainingAccounts,
     unsignedHookRemainingAccounts,
     hookRemainingAccountsHash,
-  } = getCosignerHookRemainingAccounts({ namespace, cosigner });
+  } = cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
   const cosignGateExpiresAt = BigInt(
     Math.floor(Date.now() / 1_000) + COSIGN_GATE_SECONDS,
   );

--- a/examples/solana-cosigner-gated-launch.ts
+++ b/examples/solana-cosigner-gated-launch.ts
@@ -35,10 +35,10 @@ import {
   cosignerHook,
   cpmm,
   cpmmMigrator,
+  createLaunch,
   initializer,
 } from '../src/solana/index.js';
 import {
-  DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
@@ -103,10 +103,6 @@ async function main() {
 
   // ── Fee configuration ───────────────────────────────────────────────────
   const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_BPS = SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
-  const INITIALIZER_HOOK_FLAGS =
-    initializer.HF_BEFORE_SWAP | initializer.HF_FORWARD_READONLY_SIGNERS;
   const COSIGN_GATE_SECONDS = Number(process.env.COSIGN_GATE_SECONDS ?? 300);
   // ── Graduation threshold and price floor ────────────────────────────────
   const MIN_SOL_RAISE = 0.1; // low example threshold
@@ -131,156 +127,92 @@ async function main() {
   const baseMint = await generateKeyPairSigner();
   const baseVault = await generateKeyPairSigner();
   const quoteVault = await generateKeyPairSigner();
-  const metadataAccount = await initializer.getTokenMetadataAddress(
-    baseMint.address,
-  );
+  const metadata = DEFAULT_TEST_METADATA;
 
   const namespace = cosignerConfig;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-  const {
-    signedHookRemainingAccounts,
-    unsignedHookRemainingAccounts,
-    hookRemainingAccountsHash,
-  } = cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
+  const { signedHookRemainingAccounts, unsignedHookRemainingAccounts } =
+    cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
   const cosignGateExpiresAt = BigInt(
     Math.floor(Date.now() / 1_000) + COSIGN_GATE_SECONDS,
   );
-  const hookPayload = cosignerHook.encodeCosignerGateExpiryPayload({
-    mode: cosignerHook.GATE_EXPIRY_UNIX_TIMESTAMP,
-    value: cosignGateExpiresAt,
-    cosigner: cosigner.address,
-  });
 
-  const [launch] = await initializer.getLaunchAddress(
+  const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+    deployment,
     namespace,
     launchId,
-    deployment.initializerProgram,
-  );
-  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const initializerConfig = deployment.initializerConfig;
-  const [payerBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    baseMint,
+    metadata,
   });
-  const [payerQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: WSOL_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-
-  const migrationAccounts =
-    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
-      launch,
-      baseMint: baseMint.address,
-      quoteMint: WSOL_MINT,
-      launchAuthority,
-      adminBaseAta: payerBaseAta,
-      adminQuoteAta: payerQuoteAta,
-      recipientAtas: [payerBaseAta, payerBaseAta],
-      cpmmProgram: deployment.cpmmProgram,
-      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
-    });
-  const cpmmConfig = migrationAccounts.cpmmConfig;
-  const cpmmMigrationState = migrationAccounts.cpmmMigrationState;
-
-  console.log('Derived addresses:');
-  console.log('  Launch:          ', launch);
-  console.log('  Launch authority:', launchAuthority);
-  console.log('  Initializer config:', initializerConfig);
-  console.log('  CPMM config:     ', cpmmConfig);
-  console.log('  CPMM migrator state:', cpmmMigrationState);
-  console.log('  Initializer program:', deployment.initializerProgram);
-  console.log('  CPMM program:       ', deployment.cpmmProgram);
-  console.log('  CPMM migrator:      ', deployment.cpmmMigratorProgram);
-  console.log('  Cosigner hook:      ', deployment.cosignerHookProgram);
-  console.log('  Cosigner config:    ', cosignerConfig);
-  console.log('  Active cosigners:   ', Array.from(activeCosigners).join(', '));
-  console.log('  Signing cosigner:   ', cosigner.address);
-  console.log('  Cosign gate expiry: ', cosignGateExpiresAt.toString());
-  console.log('');
-
-  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
-    cpmmConfig: cpmmConfig,
-    initialSwapFeeBps: CPMM_SWAP_FEE_BPS,
-    initialFeeSplitBps: CPMM_SWAP_FEE_SPLIT_BPS,
-    recipients: [
-      { wallet: payer.address, amount: CREATOR_SHARE },
-      { wallet: payer.address, amount: TEAM_SHARE }, // use payer as team wallet in this example
-    ],
-    minRaiseQuote,
-    minMigrationPriceQ64Opt: null,
-    migratedPoolHookConfig: null,
-  });
-
-  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
-    baseForDistribution: BASE_FOR_DISTRIBUTION,
-    baseForLiquidity: BASE_FOR_LIQUIDITY,
-  });
+  const { launch, launchAuthority, launchFeeState } = launchAddresses;
+  const initializerConfig = launchAddresses.config;
+  const recipients = [
+    { wallet: payer.address, amount: CREATOR_SHARE },
+    { wallet: payer.address, amount: TEAM_SHARE },
+  ];
 
   // ── Build, sign, and send ────────────────────────────────────────────────
   console.log('Building launch instruction...');
   try {
-    const metadata = DEFAULT_TEST_METADATA;
-
-    const ix = await initializer.createInitializeLaunchInstruction(
-      {
-        config: initializerConfig,
-        launch,
-        launchAuthority,
+    const { instruction: ix, cpmmMigration } = await createLaunch({
+      deployment,
+      namespace,
+      launchId,
+      addresses: launchAddresses,
+      launchAccounts: {
         baseMint,
         quoteMint: WSOL_MINT,
         baseVault,
         quoteVault,
-        launchFeeState,
-        payer,
-        authority: payer,
-        hookProgram: deployment.cosignerHookProgram,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        cpmmConfig,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-        metadataAccount,
       },
-      {
-        namespace,
-        launchId,
+      payer,
+      authority: payer,
+      supply: {
         baseDecimals: BASE_DECIMALS,
         baseTotalSupply: BASE_TOTAL_SUPPLY,
         baseForDistribution: BASE_FOR_DISTRIBUTION,
         baseForLiquidity: BASE_FOR_LIQUIDITY,
+      },
+      curve: {
         curveVirtualBase: start.curveVirtualBase,
         curveVirtualQuote: start.curveVirtualQuote,
         swapFeeBps: SWAP_FEE_BPS,
-        curveKind: initializer.CURVE_KIND_XYK,
-        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
-        allowBuy: true,
-        allowSell: true,
-        hookFlags: INITIALIZER_HOOK_FLAGS,
-        hookPayload,
-        migratorInitPayload,
-        migratorMigratePayload,
-        hookRemainingAccountsHash,
-        migratorInitRemainingAccountsHash:
-          initializer.computeRemainingAccountsHash([
-            cpmmMigrationState,
-            cpmmConfig,
-          ]),
-        migratorRemainingAccountsHash: migrationAccounts.hash,
-        feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
-        ...metadata,
       },
-      deployment.initializerProgram,
+      cosigner,
+      cosignGateExpiresAt,
+      migration: {
+        recipients,
+        minRaiseQuote,
+      },
+      metadata,
+      feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
+    });
+    if (!cpmmMigration) {
+      throw new Error('CPMM migration accounts were not prepared');
+    }
+    const migrationAccounts = cpmmMigration;
+    const cpmmConfig = migrationAccounts.cpmmConfig;
+    const cpmmMigrationState = migrationAccounts.cpmmMigrationState;
+
+    console.log('Derived addresses:');
+    console.log('  Launch:          ', launch);
+    console.log('  Launch authority:', launchAuthority);
+    console.log('  Initializer config:', initializerConfig);
+    console.log('  CPMM config:     ', cpmmConfig);
+    console.log('  CPMM migrator state:', cpmmMigrationState);
+    console.log('  Initializer program:', deployment.initializerProgram);
+    console.log('  CPMM program:       ', deployment.cpmmProgram);
+    console.log('  CPMM migrator:      ', deployment.cpmmMigratorProgram);
+    console.log('  Cosigner hook:      ', deployment.cosignerHookProgram);
+    console.log('  Cosigner config:    ', cosignerConfig);
+    console.log(
+      '  Active cosigners:   ',
+      Array.from(activeCosigners).join(', '),
     );
+    console.log('  Signing cosigner:   ', cosigner.address);
+    console.log('  Cosign gate expiry: ', cosignGateExpiresAt.toString());
+    console.log('');
+
     const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,

--- a/examples/solana-cosigner-gated-launch.ts
+++ b/examples/solana-cosigner-gated-launch.ts
@@ -28,103 +28,35 @@ import {
   SYSTEM_PROGRAM_ADDRESS,
   getTransferSolInstruction,
 } from '@solana-program/system';
-import {
-  pipe,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  type Address,
-  type TransactionSigner,
-} from '@solana/kit';
+import { generateKeyPairSigner } from '@solana/kit';
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
   cosignerHook,
   cpmm,
-  initializer,
   cpmmMigrator,
+  initializer,
 } from '../src/solana/index.js';
 import {
-  assertTransactionFits,
-  assertSolanaExampleNetwork,
+  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  DEFAULT_SWAP_FEE_BPS,
+  DEFAULT_TEST_METADATA,
+  WSOL_MINT,
   assertSimulationRejected,
-  createLookupTableForInstruction,
+  assertSolanaExampleNetwork,
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
-  getMetadataByteLength,
+  fetchActiveCosigners,
+  getCosignerHookRemainingAccounts,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
   getTokenAccountRentLamports,
+  loadCosigner,
   loadKeypairSignerFromEnv,
+  sendInitializeLaunchWithLookupTable,
   sendInstructions,
   simulateInstructions,
 } from './solanaExampleHelpers.js';
-
-async function loadCosigner(): Promise<TransactionSigner> {
-  if (!process.env.COSIGNER_KEYPAIR_PATH && !process.env.COSIGNER_KEYPAIR) {
-    throw new Error(
-      'COSIGNER_KEYPAIR_PATH or COSIGNER_KEYPAIR is required to sign cosigner-gated swaps.',
-    );
-  }
-
-  const cosigner = await loadKeypairSignerFromEnv({
-    pathEnv: 'COSIGNER_KEYPAIR_PATH',
-    jsonEnv: 'COSIGNER_KEYPAIR',
-    label: 'COSIGNER_KEYPAIR',
-  });
-  return cosigner;
-}
-
-type SolanaClients = ReturnType<typeof createSolanaClientsFromEnv>;
-
-async function fetchActiveCosigners({
-  rpc,
-  cosignerHookProgram,
-  cosignerConfig,
-}: {
-  rpc: SolanaClients['rpc'];
-  cosignerHookProgram: Address;
-  cosignerConfig: Address;
-}): Promise<Address[]> {
-  const existingConfig = await cosignerHook.fetchMaybeCosignerConfig(
-    rpc,
-    cosignerConfig,
-    { commitment: 'confirmed' },
-  );
-
-  if (!existingConfig.exists) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} does not exist. The integrator/admin must initialize it before running this flow.`,
-    );
-  }
-
-  if (existingConfig.programAddress !== cosignerHookProgram) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} is owned by ${existingConfig.programAddress}, expected ${cosignerHookProgram}`,
-    );
-  }
-
-  const activeCosigners = existingConfig.data.cosigners.slice(
-    0,
-    existingConfig.data.cosignerCount,
-  );
-  if (activeCosigners.length === 0) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} does not include any active cosigners`,
-    );
-  }
-
-  return activeCosigners;
-}
-
-// WSOL mint — pools use the wrapped SPL mint since native SOL can't live in token vaults.
-const WSOL_MINT: Address =
-  'So11111111111111111111111111111111111111112' as Address;
 
 // ============================================================================
 // Main
@@ -146,7 +78,7 @@ async function main() {
     cosignerHookProgram: deployment.cosignerHookProgram,
     cosignerConfig,
   });
-  if (!activeCosigners.includes(cosigner.address)) {
+  if (!activeCosigners.has(cosigner.address.toString())) {
     throw new Error(
       `COSIGNER_KEYPAIR resolves to ${cosigner.address}, which is not registered in cosigner hook config ${cosignerConfig}`,
     );
@@ -171,9 +103,9 @@ async function main() {
   const END_MARKET_CAP_USD = 10_000_000;
 
   // ── Fee configuration ───────────────────────────────────────────────────
-  const SWAP_FEE_BPS = 200; // 2%; must fit this deployment's configured fee bounds
+  const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
   const CPMM_SWAP_FEE_BPS = SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = 10_000; // migrated launch fees route through LaunchFeeState
+  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
   const INITIALIZER_HOOK_FLAGS =
     initializer.HF_BEFORE_SWAP | initializer.HF_FORWARD_READONLY_SIGNERS;
   const COSIGN_GATE_SECONDS = Number(process.env.COSIGN_GATE_SECONDS ?? 300);
@@ -206,14 +138,11 @@ async function main() {
 
   const namespace = cosignerConfig;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-  const signedHookRemainingAccounts = [namespace, cosigner];
-  // Same keys as the signed path, but the cosigner is only an address here.
-  // The hook should reject it because the runtime will not mark it as signed.
-  const unsignedHookRemainingAccounts = [namespace, cosigner.address];
-  const hookRemainingAccountsHash = initializer.computeRemainingAccountsHash([
-    namespace,
-    cosigner.address,
-  ]);
+  const {
+    signedHookRemainingAccounts,
+    unsignedHookRemainingAccounts,
+    hookRemainingAccountsHash,
+  } = getCosignerHookRemainingAccounts({ namespace, cosigner });
   const cosignGateExpiresAt = BigInt(
     Math.floor(Date.now() / 1_000) + COSIGN_GATE_SECONDS,
   );
@@ -274,7 +203,7 @@ async function main() {
   console.log('  CPMM migrator:      ', deployment.cpmmMigratorProgram);
   console.log('  Cosigner hook:      ', deployment.cosignerHookProgram);
   console.log('  Cosigner config:    ', cosignerConfig);
-  console.log('  Active cosigners:   ', activeCosigners.join(', '));
+  console.log('  Active cosigners:   ', Array.from(activeCosigners).join(', '));
   console.log('  Signing cosigner:   ', cosigner.address);
   console.log('  Cosign gate expiry: ', cosignGateExpiresAt.toString());
   console.log('');
@@ -300,11 +229,7 @@ async function main() {
   // ── Build, sign, and send ────────────────────────────────────────────────
   console.log('Building launch instruction...');
   try {
-    const metadata = {
-      metadataName: 'TEST',
-      metadataSymbol: 'TEST',
-      metadataUri: 'https://example.com/metadata/test-token.json',
-    };
+    const metadata = DEFAULT_TEST_METADATA;
 
     const ix = await initializer.createInitializeLaunchInstruction(
       {
@@ -357,54 +282,18 @@ async function main() {
       },
       deployment.initializerProgram,
     );
-    const lookupTable = await createLookupTableForInstruction({
+    const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,
       payer,
       instruction: ix,
-      label: 'initialize_launch lookup table',
+      metadata,
     });
-
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const transactionMessage =
-      initializer.compressTransactionMessageWithLookupTable(
-        pipe(
-          createTransactionMessage({ version: 0 }),
-          (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-          (tx) =>
-            setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-          (tx) => appendTransactionMessageInstructions([ix], tx),
-        ),
-        lookupTable,
-      );
-    assertTransactionFits(transactionMessage, {
-      label: 'initialize_launch',
-      metadataBytes: getMetadataByteLength(metadata),
-    });
-
-    const signedTransaction =
-      await signTransactionMessageWithSigners(transactionMessage);
-
-    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-      rpc,
-      rpcSubscriptions,
-    });
-    await sendAndConfirmTransaction(
-      signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-      {
-        commitment: 'confirmed',
-      },
-    );
-
     console.log('');
     console.log('Token launch created successfully!');
     console.log('  Launch address:', launch);
     console.log('  Base mint:     ', baseMint.address);
-    console.log(
-      '  Transaction:   ',
-      getSignatureFromTransaction(signedTransaction),
-    );
+    console.log('  Transaction:   ', launchSignature);
 
     // ── Step 2: Preview a curve buy without executing ────────────────────────
     console.log(
@@ -583,7 +472,8 @@ async function main() {
 
     // ── Step 4: Migrate launch to CPMM pool ─────────────────────────────────
     //
-    // Anyone can call migrate_launch once quoteDeposited >= minRaiseQuote.
+    // Anyone can call migrate_launch once quote_vault_amount - pending_quote_fees
+    // is at least minRaiseQuote.
     // The migrator creates the canonical CPMM pool graph inline, then seeds
     // liquidity into it. The remaining accounts must match the hash committed
     // at launch creation.
@@ -618,34 +508,17 @@ async function main() {
     };
 
     {
-      const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+      const signature = await sendInstructions({
+        rpc,
+        rpcSubscriptions,
+        payer,
+        instructions: [
+          createSetComputeUnitLimitInstruction(400_000),
+          migrateLaunchIx,
+        ],
+      });
 
-      const transactionMessage = pipe(
-        createTransactionMessage({ version: 0 }),
-        (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-        (tx) =>
-          setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-        (tx) =>
-          appendTransactionMessageInstructions(
-            [createSetComputeUnitLimitInstruction(400_000), migrateLaunchIx],
-            tx,
-          ),
-      );
-
-      const signedTransaction =
-        await signTransactionMessageWithSigners(transactionMessage);
-
-      await sendAndConfirmTransaction(
-        signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-        {
-          commitment: 'confirmed',
-        },
-      );
-
-      console.log(
-        '  Migration confirmed:',
-        getSignatureFromTransaction(signedTransaction),
-      );
+      console.log('  Migration confirmed:', signature);
     }
     console.log('');
 

--- a/examples/solana-launch-by-marketcap.ts
+++ b/examples/solana-launch-by-marketcap.ts
@@ -9,6 +9,15 @@
 import './env.js';
 
 import {
+  TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda,
+} from '@solana-program/token';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import { generateKeyPairSigner } from '@solana/kit';
+import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
+
+import { cpmm, cpmmMigrator, initializer } from '../src/solana/index.js';
+import {
   DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,

--- a/examples/solana-launch-by-marketcap.ts
+++ b/examples/solana-launch-by-marketcap.ts
@@ -9,39 +9,17 @@
 import './env.js';
 
 import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-} from '@solana-program/token';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
-import {
-  generateKeyPairSigner,
-  pipe,
-  createTransactionMessage,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  type Address,
-} from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
-
-import { cpmm, initializer, cpmmMigrator } from '../src/solana/index.js';
-import {
-  assertTransactionFits,
+  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  DEFAULT_SWAP_FEE_BPS,
+  DEFAULT_TEST_METADATA,
+  WSOL_MINT,
   assertSolanaExampleNetwork,
-  createLookupTableForInstruction,
   createSolanaClientsFromEnv,
-  getMetadataByteLength,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
   loadKeypairSignerFromEnv,
+  sendInitializeLaunchWithLookupTable,
 } from './solanaExampleHelpers.js';
-
-// WSOL mint — pools use the wrapped SPL mint since native SOL can't live in token vaults.
-const WSOL_MINT: Address =
-  'So11111111111111111111111111111111111111112' as Address;
 
 async function main() {
   const payer = await loadKeypairSignerFromEnv();
@@ -59,8 +37,8 @@ async function main() {
   const QUOTE_DECIMALS = 9; // WSOL
   const START_MARKET_CAP_USD = 100_000;
   const END_MARKET_CAP_USD = 10_000_000;
-  const SWAP_FEE_BPS = 200; // 2%; must fit this deployment's configured fee bounds
-  const CPMM_FEE_SPLIT_BPS = 10_000; // migrated launch fees route through LaunchFeeState
+  const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
+  const CPMM_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
 
   // ── Graduation threshold and price floor ────────────────────────────────
   const MIN_SOL_RAISE = 50;
@@ -188,11 +166,7 @@ async function main() {
   // PDA and cpmmConfig as remaining accounts.
   console.log('Building launch instruction...');
   try {
-    const metadata = {
-      metadataName: 'TEST',
-      metadataSymbol: 'TEST',
-      metadataUri: 'https://example.com/metadata/test-token.json',
-    };
+    const metadata = DEFAULT_TEST_METADATA;
 
     const ix = await initializer.createInitializeLaunchInstruction(
       {
@@ -246,54 +220,19 @@ async function main() {
       },
       deployment.initializerProgram,
     );
-    const lookupTable = await createLookupTableForInstruction({
+    const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,
       payer,
       instruction: ix,
-      label: 'initialize_launch lookup table',
+      metadata,
     });
-
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const transactionMessage =
-      initializer.compressTransactionMessageWithLookupTable(
-        pipe(
-          createTransactionMessage({ version: 0 }),
-          (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-          (tx) =>
-            setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-          (tx) => appendTransactionMessageInstructions([ix], tx),
-        ),
-        lookupTable,
-      );
-    assertTransactionFits(transactionMessage, {
-      label: 'initialize_launch',
-      metadataBytes: getMetadataByteLength(metadata),
-    });
-
-    const signedTransaction =
-      await signTransactionMessageWithSigners(transactionMessage);
-
-    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-      rpc,
-      rpcSubscriptions,
-    });
-    await sendAndConfirmTransaction(
-      signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-      {
-        commitment: 'confirmed',
-      },
-    );
 
     console.log('');
     console.log('Token launch created successfully!');
     console.log('  Launch address:', launch);
     console.log('  Base mint:     ', baseMint.address);
-    console.log(
-      '  Transaction:   ',
-      getSignatureFromTransaction(signedTransaction),
-    );
+    console.log('  Transaction:   ', launchSignature);
 
     // ── Verify launch state ──────────────────────────────────────
     const launchAccount = await initializer.fetchLaunch(rpc, launch, {

--- a/examples/solana-launch-by-marketcap.ts
+++ b/examples/solana-launch-by-marketcap.ts
@@ -8,17 +8,10 @@
  */
 import './env.js';
 
-import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-} from '@solana-program/token';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
-import { cpmm, cpmmMigrator, initializer } from '../src/solana/index.js';
+import { cpmm, createLaunch, initializer } from '../src/solana/index.js';
 import {
-  DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
@@ -47,7 +40,6 @@ async function main() {
   const START_MARKET_CAP_USD = 100_000;
   const END_MARKET_CAP_USD = 10_000_000;
   const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
-  const CPMM_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
 
   // ── Graduation threshold and price floor ────────────────────────────────
   const MIN_SOL_RAISE = 50;
@@ -94,141 +86,69 @@ async function main() {
   const baseMint = await generateKeyPairSigner();
   const baseVault = await generateKeyPairSigner();
   const quoteVault = await generateKeyPairSigner();
-  const metadataAccount = await initializer.getTokenMetadataAddress(
-    baseMint.address,
-  );
+  const metadata = DEFAULT_TEST_METADATA;
 
-  // ── Derive PDAs ─────────────────────────────────────────────────────────────
+  // ── Derive launch addresses ─────────────────────────────────────────────────
   // Date.now() as launchId ensures each run creates a distinct launch.
   const namespace = payer.address;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-
-  const [launch] = await initializer.getLaunchAddress(
+  const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+    deployment,
     namespace,
     launchId,
-    deployment.initializerProgram,
-  );
-  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const initializerConfig = deployment.initializerConfig;
-  // Admin ATAs receive unsold curve tokens and residual migration dust.
-  const [payerBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    baseMint,
+    metadata,
   });
-  const [payerQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: WSOL_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-
-  const migrationAccounts =
-    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
-      launch,
-      baseMint: baseMint.address,
-      quoteMint: WSOL_MINT,
-      launchAuthority,
-      adminBaseAta: payerBaseAta,
-      adminQuoteAta: payerQuoteAta,
-      recipientAtas: [],
-      cpmmProgram: deployment.cpmmProgram,
-      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
-    });
-  const cpmmConfig = migrationAccounts.cpmmConfig;
-  const cpmmMigrationState = migrationAccounts.cpmmMigrationState;
-
-  console.log('Derived addresses:');
-  console.log('  Launch:          ', launch);
-  console.log('  Launch authority:', launchAuthority);
-  console.log('  Initializer config:', initializerConfig);
-  console.log('  CPMM config:     ', cpmmConfig);
-  console.log('  CPMM migrator state:', cpmmMigrationState);
-  console.log('');
-
-  // ── Encode CPMM migrator payload ──────────────────────────────────────────
-  // migratorInitPayload registers graduation params; migratorMigratePayload
-  // is forwarded at migration. minRaiseQuote is the graduation threshold.
-  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
-    cpmmConfig: cpmmConfig,
-    initialSwapFeeBps: SWAP_FEE_BPS,
-    initialFeeSplitBps: CPMM_FEE_SPLIT_BPS,
-    recipients: [],
-    minRaiseQuote,
-    minMigrationPriceQ64Opt: null, // no minimum graduation price floor
-    migratedPoolHookConfig: null,
-  });
-
-  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
-    baseForDistribution: 0n,
-    baseForLiquidity: 0n,
-  });
+  const { launch, launchAuthority } = launchAddresses;
+  const initializerConfig = launchAddresses.config;
 
   // ── Build, sign, and send ────────────────────────────────────────────────
-  // The CPMM migrator register_launch CPI consumes both the cpmmMigrationState
-  // PDA and cpmmConfig as remaining accounts.
   console.log('Building launch instruction...');
   try {
-    const metadata = DEFAULT_TEST_METADATA;
-
-    const ix = await initializer.createInitializeLaunchInstruction(
-      {
-        config: initializerConfig,
-        launch,
-        launchAuthority,
+    const { instruction: ix, cpmmMigration } = await createLaunch({
+      deployment,
+      namespace,
+      launchId,
+      addresses: launchAddresses,
+      launchAccounts: {
         baseMint,
         quoteMint: WSOL_MINT,
         baseVault,
         quoteVault,
-        launchFeeState,
-        payer,
-        authority: payer,
-        hookProgram: deployment.cpmmHookProgram,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        cpmmConfig,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-        metadataAccount,
       },
-      {
-        namespace,
-        launchId,
+      payer,
+      authority: payer,
+      supply: {
         baseDecimals: BASE_DECIMALS,
         baseTotalSupply: BASE_TOTAL_SUPPLY,
         baseForDistribution: 0n,
         baseForLiquidity: 0n,
-        // Opening price: virtualQuote / (baseForCurve + virtualBase)
+      },
+      curve: {
         curveVirtualBase: start.curveVirtualBase,
         curveVirtualQuote: start.curveVirtualQuote,
         swapFeeBps: SWAP_FEE_BPS,
-        curveKind: initializer.CURVE_KIND_XYK,
-        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
-        allowBuy: true,
-        allowSell: true,
-        hookFlags: initializer.HF_BEFORE_SWAP,
-        hookPayload: new Uint8Array(),
-        migratorInitPayload,
-        migratorMigratePayload,
-        hookRemainingAccountsHash: initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
-        migratorInitRemainingAccountsHash:
-          initializer.computeRemainingAccountsHash([
-            cpmmMigrationState,
-            cpmmConfig,
-          ]),
-        migratorRemainingAccountsHash: migrationAccounts.hash,
-        feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
-        ...metadata,
       },
-      deployment.initializerProgram,
-    );
+      migration: {
+        minRaiseQuote,
+      },
+      metadata,
+      feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
+    });
+    if (!cpmmMigration) {
+      throw new Error('CPMM migration accounts were not prepared');
+    }
+    const cpmmConfig = cpmmMigration.cpmmConfig;
+    const cpmmMigrationState = cpmmMigration.cpmmMigrationState;
+
+    console.log('Derived addresses:');
+    console.log('  Launch:          ', launch);
+    console.log('  Launch authority:', launchAuthority);
+    console.log('  Initializer config:', initializerConfig);
+    console.log('  CPMM config:     ', cpmmConfig);
+    console.log('  CPMM migrator state:', cpmmMigrationState);
+    console.log('');
+
     const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,

--- a/examples/solana-minimal-launch.ts
+++ b/examples/solana-minimal-launch.ts
@@ -1,0 +1,114 @@
+/**
+ * Example: Minimal XYK Token Launch (Solana)
+ *
+ * Demonstrates the smallest practical createLaunch flow: fixed curve numbers,
+ * default CPMM hook, default CPMM migrator, derived launch addresses, and no
+ * token metadata.
+ */
+import './env.js';
+
+import { generateKeyPairSigner } from '@solana/kit';
+
+import { createLaunch, initializer } from '../src/solana/index.js';
+import {
+  DEFAULT_SWAP_FEE_BPS,
+  WSOL_MINT,
+  assertSolanaExampleNetwork,
+  createSolanaClientsFromEnv,
+  getSolanaCpmmDeploymentFromEnv,
+  loadKeypairSignerFromEnv,
+  sendInitializeLaunchWithLookupTable,
+} from './solanaExampleHelpers.js';
+
+const BASE_DECIMALS = 6;
+const BASE_TOTAL_SUPPLY = 1_000_000_000n * 10n ** BigInt(BASE_DECIMALS);
+const LAMPORTS_PER_SOL = 1_000_000_000n;
+
+async function main(): Promise<void> {
+  const payer = await loadKeypairSignerFromEnv();
+  const { rpc, rpcSubscriptions, network } = createSolanaClientsFromEnv();
+  assertSolanaExampleNetwork(network, ['devnet', 'custom']);
+  const deployment = await getSolanaCpmmDeploymentFromEnv(network);
+
+  const baseMint = await generateKeyPairSigner();
+  const baseVault = await generateKeyPairSigner();
+  const quoteVault = await generateKeyPairSigner();
+
+  const { instruction, addresses, cpmmMigration } = await createLaunch({
+    deployment,
+    launchAccounts: {
+      baseMint,
+      quoteMint: WSOL_MINT,
+      baseVault,
+      quoteVault,
+    },
+    payer,
+    supply: {
+      baseDecimals: BASE_DECIMALS,
+      baseTotalSupply: BASE_TOTAL_SUPPLY,
+      baseForDistribution: 0n,
+      baseForLiquidity: 0n,
+    },
+    curve: {
+      curveVirtualBase: BASE_TOTAL_SUPPLY,
+      curveVirtualQuote: 10n * LAMPORTS_PER_SOL,
+      swapFeeBps: DEFAULT_SWAP_FEE_BPS,
+    },
+    migration: {
+      minRaiseQuote: LAMPORTS_PER_SOL,
+    },
+  });
+
+  if (!cpmmMigration) {
+    throw new Error('CPMM migration accounts were not prepared');
+  }
+
+  console.log('Creating minimal XYK token launch...');
+  console.log('  Launch:              ', addresses.launch);
+  console.log('  Base mint:           ', baseMint.address);
+  console.log('  Launch authority:    ', addresses.launchAuthority);
+  console.log('  CPMM migrator state: ', cpmmMigration.cpmmMigrationState);
+
+  const signature = await sendInitializeLaunchWithLookupTable({
+    rpc,
+    rpcSubscriptions,
+    payer,
+    instruction,
+  });
+
+  console.log('');
+  console.log('Token launch created successfully!');
+  console.log('  Transaction:', signature);
+
+  const launchAccount = await initializer.fetchLaunch(rpc, addresses.launch, {
+    programId: deployment.initializerProgram,
+  });
+
+  if (!launchAccount) {
+    throw new Error('Launch account was not found after initialization');
+  }
+
+  console.log('');
+  console.log('Launch account verified:');
+  console.log(
+    '  Phase:              ',
+    initializer.phaseLabel(launchAccount.phase),
+  );
+  console.log(
+    '  Quote deposited:    ',
+    launchAccount.quoteDeposited.toString(),
+  );
+  console.log(
+    '  Curve virtual base: ',
+    launchAccount.curveVirtualBase.toString(),
+  );
+  console.log(
+    '  Curve virtual quote:',
+    launchAccount.curveVirtualQuote.toString(),
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error('Error creating minimal launch:', error);
+  process.exit(1);
+});

--- a/examples/solana-prediction-market.ts
+++ b/examples/solana-prediction-market.ts
@@ -16,38 +16,15 @@
  */
 import './env.js';
 
-import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import {
-  generateKeyPairSigner,
-  pipe,
-  createTransactionMessage,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  type Address,
-} from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
-
-import {
-  initializer,
-  predictionMigrator,
-  trustedOracle,
-} from '../src/solana/index.js';
-import {
+  WSOL_MINT,
   assertSolanaExampleNetwork,
-  createLookupTableForInstruction,
   createSolanaClientsFromEnv,
   getSolanaCpmmDeploymentFromEnv,
   loadKeypairSignerFromEnv,
+  sendInitializeLaunchWithLookupTable,
+  sendInstructions,
 } from './solanaExampleHelpers.js';
-
-// WSOL mint — the quote token (SOL wrapped as SPL token so it can live in vaults).
-const WSOL_MINT: Address =
-  'So11111111111111111111111111111111111111112' as Address;
 
 // ============================================================================
 // Main
@@ -108,33 +85,13 @@ async function main() {
       quoteMint: WSOL_MINT,
     });
 
-    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
+    const oracleSignature = await sendInstructions({
       rpc,
       rpcSubscriptions,
+      payer,
+      instructions: [initOracleIx],
     });
-
-    {
-      const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-      const transactionMessage = pipe(
-        createTransactionMessage({ version: 0 }),
-        (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-        (tx) =>
-          setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-        (tx) => appendTransactionMessageInstructions([initOracleIx], tx),
-      );
-      const signedTransaction =
-        await signTransactionMessageWithSigners(transactionMessage);
-      await sendAndConfirmTransaction(
-        signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-        {
-          commitment: 'confirmed',
-        },
-      );
-      console.log(
-        '  Oracle created:',
-        getSignatureFromTransaction(signedTransaction),
-      );
-    }
+    console.log('  Oracle created:', oracleSignature);
 
     // ── Step 2: Create per-outcome launches ───────────────────────────────
     // YES and NO launches are independent of each other and sent in parallel.
@@ -208,6 +165,12 @@ async function main() {
         // ── Build the initializeLaunch instruction ───────────────────────────
         // The instruction builder automatically appends the 6 register_entry
         // remaining accounts for the prediction migrator.
+        const metadata = {
+          metadataName: `${outcome.label} Token`,
+          metadataSymbol: outcome.label,
+          metadataUri: `https://example.com/${outcome.label.toLowerCase()}.json`,
+        };
+
         const ix = await initializer.createInitializeLaunchInstruction(
           {
             config,
@@ -271,54 +234,22 @@ async function main() {
                 entryAddress,
                 entryByMint,
               ]),
-            // ALTs compress account keys but not instruction data; keep
-            // metadata strings short enough to fit the 1232-byte tx limit.
-            metadataName: `${outcome.label} Token`,
-            metadataSymbol: outcome.label,
-            metadataUri: `https://example.com/${outcome.label.toLowerCase()}.json`,
+            ...metadata,
             feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
           },
           deployment.initializerProgram,
         );
-        const lookupTable = await createLookupTableForInstruction({
+        const launchSignature = await sendInitializeLaunchWithLookupTable({
           rpc,
           rpcSubscriptions,
           payer,
           instruction: ix,
-          label: `${outcome.label} initialize_launch lookup table`,
+          metadata,
+          label: `${outcome.label} initialize_launch`,
         });
 
-        const { value: latestBlockhash } = await rpc
-          .getLatestBlockhash()
-          .send();
-        const transactionMessage =
-          initializer.compressTransactionMessageWithLookupTable(
-            pipe(
-              createTransactionMessage({ version: 0 }),
-              (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-              (tx) =>
-                setTransactionMessageLifetimeUsingBlockhash(
-                  latestBlockhash,
-                  tx,
-                ),
-              (tx) => appendTransactionMessageInstructions([ix], tx),
-            ),
-            lookupTable,
-          );
-        const signedTransaction =
-          await signTransactionMessageWithSigners(transactionMessage);
-        await sendAndConfirmTransaction(
-          signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-          {
-            commitment: 'confirmed',
-          },
-        );
-
-        console.log(`  ${outcome.label} launch created!`);
-        console.log(
-          '  Transaction:',
-          getSignatureFromTransaction(signedTransaction),
-        );
+        console.log(`${outcome.label} launch created!`);
+        console.log('  Transaction:', launchSignature);
 
         // Verify launch state
         const launchAccount = await initializer.fetchLaunch(rpc, launch, {

--- a/examples/solana-prediction-market.ts
+++ b/examples/solana-prediction-market.ts
@@ -16,8 +16,8 @@
  */
 import './env.js';
 
-import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 import { generateKeyPairSigner } from '@solana/kit';
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
@@ -82,7 +82,6 @@ async function main() {
   // namespace must equal oracleStateAddress (validated by register_entry:
   // require_keys_eq!(launch.namespace, oracle.key()))
   const namespace = oracleStateAddress;
-  const config = deployment.initializerConfig;
 
   console.log('Creating trusted oracle...');
   console.log('  Oracle state:', oracleStateAddress);
@@ -117,35 +116,31 @@ async function main() {
         // launchId must equal entryId (validated by register_entry:
         // require!(launch.launch_id == args.entry_id))
         const launchId = entryId;
-        const [launch] = await initializer.getLaunchAddress(
-          namespace,
-          launchId,
-          deployment.initializerProgram,
-        );
-        const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-          launch,
-          deployment.initializerProgram,
-        );
-        const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-          launch,
-          deployment.initializerProgram,
-        );
-
         const baseMint = await generateKeyPairSigner();
         const baseVault = await generateKeyPairSigner();
         const quoteVault = await generateKeyPairSigner();
-        const metadataAccount = await initializer.getTokenMetadataAddress(
-          baseMint.address,
-        );
+        const metadata = {
+          metadataName: `${outcome.label} Token`,
+          metadataSymbol: outcome.label,
+          metadataUri: `https://example.com/${outcome.label.toLowerCase()}.json`,
+        };
+        const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+          deployment,
+          namespace,
+          launchId,
+          baseMint,
+          metadata,
+        });
+        const { launch, launchAuthority } = launchAddresses;
 
         console.log('  Launch:           ', launch);
         console.log('  Launch authority: ', launchAuthority);
         console.log('  Base mint:        ', baseMint.address);
 
         // ── Derive prediction market PDAs for remaining-accounts hash ────────
-        // These are the accounts the migrator will receive during migration.
-        // The instruction builder auto-appends them; we derive them here only
-        // to compute migratorRemainingAccountsHash.
+        // These are the accounts the migrator will receive during launch
+        // registration and migration. The launch helper commits their hashes;
+        // the low-level instruction builder appends the register_entry accounts.
         const [market] = await predictionMigrator.getPredictionMarketAddress(
           oracleStateAddress,
           WSOL_MINT,
@@ -161,6 +156,14 @@ async function main() {
             market,
             baseMint.address,
           );
+        const predictionRemainingAccounts = [
+          oracleStateAddress,
+          market,
+          potVault,
+          marketAuthority,
+          entryAddress,
+          entryByMint,
+        ];
 
         // ── Encode migrator payloads ────────────────────────────────────────
         // Init payload → registerEntry; migrate payload → migrateEntry.
@@ -172,25 +175,16 @@ async function main() {
           .getMigrateEntryInstructionDataEncoder()
           .encode({ entryId });
 
-        // ── Build the initializeLaunch instruction ───────────────────────────
-        // The instruction builder automatically appends the 6 register_entry
-        // remaining accounts for the prediction migrator.
-        const metadata = {
-          metadataName: `${outcome.label} Token`,
-          metadataSymbol: outcome.label,
-          metadataUri: `https://example.com/${outcome.label.toLowerCase()}.json`,
-        };
-
         const ix = await initializer.createInitializeLaunchInstruction(
           {
-            config,
+            config: launchAddresses.config,
             launch,
             launchAuthority,
             baseMint,
             quoteMint: WSOL_MINT,
             baseVault,
             quoteVault,
-            launchFeeState,
+            launchFeeState: launchAddresses.launchFeeState,
             payer,
             authority: payer,
             hookProgram: initializer.PREDICTION_HOOK_PROGRAM_ID,
@@ -200,7 +194,7 @@ async function main() {
             quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
             systemProgram: SYSTEM_PROGRAM_ADDRESS,
             rent: SYSVAR_RENT_ADDRESS,
-            metadataAccount,
+            metadataAccount: launchAddresses.metadataAccount,
           },
           {
             namespace,
@@ -211,7 +205,7 @@ async function main() {
             baseForLiquidity: BASE_FOR_LIQUIDITY,
             curveVirtualBase: CURVE_VIRTUAL_BASE,
             curveVirtualQuote: CURVE_VIRTUAL_QUOTE,
-            swapFeeBps: 100, // 1% swap fee
+            swapFeeBps: 100,
             curveKind: initializer.CURVE_KIND_XYK,
             curveParams: new Uint8Array([
               initializer.CURVE_PARAMS_FORMAT_XYK_V0,
@@ -222,30 +216,21 @@ async function main() {
             hookPayload: new Uint8Array(),
             migratorInitPayload,
             migratorMigratePayload,
-            // Prediction hook reads oracle_state to check is_finalized.
             hookRemainingAccountsHash: initializer.computeRemainingAccountsHash(
               [oracleStateAddress],
             ),
             migratorInitRemainingAccountsHash:
-              initializer.computeRemainingAccountsHash([
-                oracleStateAddress,
-                market,
-                potVault,
-                marketAuthority,
-                entryAddress,
-                entryByMint,
-              ]),
+              initializer.computeRemainingAccountsHash(
+                predictionRemainingAccounts,
+              ),
             migratorRemainingAccountsHash:
-              initializer.computeRemainingAccountsHash([
-                oracleStateAddress,
-                market,
-                potVault,
-                marketAuthority,
-                entryAddress,
-                entryByMint,
-              ]),
-            ...metadata,
+              initializer.computeRemainingAccountsHash(
+                predictionRemainingAccounts,
+              ),
             feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
+            metadataName: metadata.metadataName,
+            metadataSymbol: metadata.metadataSymbol,
+            metadataUri: metadata.metadataUri,
           },
           deployment.initializerProgram,
         );

--- a/examples/solana-prediction-market.ts
+++ b/examples/solana-prediction-market.ts
@@ -16,6 +16,16 @@
  */
 import './env.js';
 
+import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import { generateKeyPairSigner } from '@solana/kit';
+import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
+
+import {
+  initializer,
+  predictionMigrator,
+  trustedOracle,
+} from '../src/solana/index.js';
 import {
   WSOL_MINT,
   assertSolanaExampleNetwork,

--- a/examples/solana-swap.ts
+++ b/examples/solana-swap.ts
@@ -7,6 +7,14 @@
  */
 import './env.js';
 
+import { address, type Address } from '@solana/kit';
+import {
+  TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+} from '@solana-program/token';
+
+import { cpmm } from '../src/solana/index.js';
 import {
   assertSolanaExampleNetwork,
   createSolanaClientsFromEnv,

--- a/examples/solana-swap.ts
+++ b/examples/solana-swap.ts
@@ -8,30 +8,11 @@
 import './env.js';
 
 import {
-  address,
-  pipe,
-  createTransactionMessage,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  type Address,
-} from '@solana/kit';
-
-import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
-} from '@solana-program/token';
-
-import { cpmm } from '../src/solana/index.js';
-import {
   assertSolanaExampleNetwork,
   createSolanaClientsFromEnv,
   getSolanaCpmmDeploymentFromEnv,
   loadKeypairSignerFromEnv,
+  sendInstructions,
 } from './solanaExampleHelpers.js';
 
 if (!process.env.MINT_0 || !process.env.MINT_1) {
@@ -155,39 +136,16 @@ async function main() {
       mint: pool.token1Mint,
     });
 
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const transactionMessage = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) =>
-        appendTransactionMessageInstructions(
-          [createUserInAtaIx, createUserOutAtaIx, ix],
-          tx,
-        ),
-    );
-
-    const signedTransaction =
-      await signTransactionMessageWithSigners(transactionMessage);
-
-    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
+    const signature = await sendInstructions({
       rpc,
       rpcSubscriptions,
+      payer,
+      instructions: [createUserInAtaIx, createUserOutAtaIx, ix],
     });
-    await sendAndConfirmTransaction(
-      signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-      {
-        commitment: 'confirmed',
-      },
-    );
 
     console.log('');
     console.log('Swap confirmed!');
-    console.log(
-      '  Transaction:',
-      getSignatureFromTransaction(signedTransaction),
-    );
+    console.log('  Transaction:', signature);
     console.log('  Sent:       ', AMOUNT_IN.toString(), 'input token atoms');
     console.log(
       '  Received:   ~',

--- a/examples/solana-usdc-cosigner-gated-buy.ts
+++ b/examples/solana-usdc-cosigner-gated-buy.ts
@@ -41,9 +41,7 @@ import {
   assertTokenBalance,
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
-  getCosignerHookRemainingAccounts,
   getSolanaCpmmDeploymentFromEnv,
-  getSwapFeeAmount,
   loadCosigner,
   loadKeypairSignerFromEnv,
   loadLaunchBeneficiaries,
@@ -173,7 +171,7 @@ async function main() {
     signedHookRemainingAccounts,
     unsignedHookRemainingAccounts,
     hookRemainingAccountsHash,
-  } = getCosignerHookRemainingAccounts({ namespace, cosigner });
+  } = cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
 
   console.log('Creating cosigner-gated launch...');
   console.log('  Launch:            ', launch);
@@ -359,7 +357,10 @@ async function main() {
     await assertMigrationQuoteThreshold({
       rpc,
       quoteVault: quoteVault.address,
-      pendingQuoteFees: getSwapFeeAmount(BUY_AMOUNT_IN, SWAP_FEE_BPS),
+      pendingQuoteFees: initializer.getCurveSwapFeeAmount(
+        BUY_AMOUNT_IN,
+        SWAP_FEE_BPS,
+      ),
       minRaiseQuote,
     });
   console.log('  Quote vault amount:', quoteVaultAmount.toString());

--- a/examples/solana-usdc-cosigner-gated-buy.ts
+++ b/examples/solana-usdc-cosigner-gated-buy.ts
@@ -19,20 +19,7 @@ import {
   getCreateAssociatedTokenIdempotentInstruction,
 } from '@solana-program/token';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
-import {
-  pipe,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  address,
-  type Address,
-  type TransactionSigner,
-} from '@solana/kit';
+import { generateKeyPairSigner } from '@solana/kit';
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
@@ -41,213 +28,30 @@ import {
   initializer,
   cpmmMigrator,
 } from '../src/solana/index.js';
+
 import {
-  assertTransactionFits,
-  assertSolanaExampleNetwork,
+  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  DEFAULT_SWAP_FEE_BPS,
+  DEFAULT_TEST_METADATA,
+  DEVNET_USDC_MINT as USDC_MINT,
+  assertCosignerRegistered,
+  assertMigrationQuoteThreshold,
   assertSimulationRejected,
-  createLookupTableForInstruction,
+  assertSolanaExampleNetwork,
+  assertTokenBalance,
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
-  getMetadataByteLength,
+  getCosignerHookRemainingAccounts,
   getSolanaCpmmDeploymentFromEnv,
+  getSwapFeeAmount,
+  loadCosigner,
   loadKeypairSignerFromEnv,
+  loadLaunchBeneficiaries,
+  parseDecimalTokenAmount,
+  sendInitializeLaunchWithLookupTable,
   sendInstructions,
   simulateInstructions,
 } from './solanaExampleHelpers.js';
-
-type SolanaClients = ReturnType<typeof createSolanaClientsFromEnv>;
-type LaunchBeneficiaryConfig = {
-  recipients: { wallet: Address; amount: bigint }[];
-  feeBeneficiaries: { wallet: Address; shareBps: number }[];
-};
-
-async function fetchOwnedTokenAmount({
-  rpc,
-  owner,
-  mint,
-  tokenAccount,
-}: {
-  rpc: SolanaClients['rpc'];
-  owner: Address;
-  mint: Address;
-  tokenAccount: Address;
-}): Promise<bigint | null> {
-  const result = await rpc
-    .getTokenAccountsByOwner(
-      owner,
-      { mint },
-      { encoding: 'jsonParsed', commitment: 'confirmed' },
-    )
-    .send();
-  const account = result.value.find(({ pubkey }) => pubkey === tokenAccount);
-  return account
-    ? BigInt(account.account.data.parsed.info.tokenAmount.amount)
-    : null;
-}
-
-async function assertTokenBalance({
-  rpc,
-  owner,
-  mint,
-  tokenAccount,
-  amount,
-}: {
-  rpc: SolanaClients['rpc'];
-  owner: Address;
-  mint: Address;
-  tokenAccount: Address;
-  amount: bigint;
-}): Promise<void> {
-  const balance = await fetchOwnedTokenAmount({
-    rpc,
-    owner,
-    mint,
-    tokenAccount,
-  });
-  if (balance === null || balance < amount) {
-    throw new Error(
-      `USDC token account ${tokenAccount} needs at least ${amount} atoms; current balance is ${balance ?? 0n}`,
-    );
-  }
-}
-
-// Standard devnet USDC mint.
-const USDC_MINT: Address =
-  '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU' as Address;
-
-async function loadCosigner(): Promise<TransactionSigner> {
-  if (!process.env.COSIGNER_KEYPAIR_PATH && !process.env.COSIGNER_KEYPAIR) {
-    throw new Error(
-      'COSIGNER_KEYPAIR_PATH or COSIGNER_KEYPAIR is required to sign cosigner-gated swaps.',
-    );
-  }
-
-  return loadKeypairSignerFromEnv({
-    pathEnv: 'COSIGNER_KEYPAIR_PATH',
-    jsonEnv: 'COSIGNER_KEYPAIR',
-    label: 'COSIGNER_KEYPAIR',
-  });
-}
-
-async function fetchActiveCosigners({
-  rpc,
-  cosignerHookProgram,
-  cosignerConfig,
-}: {
-  rpc: SolanaClients['rpc'];
-  cosignerHookProgram: Address;
-  cosignerConfig: Address;
-}): Promise<Address[]> {
-  const existingConfig = await cosignerHook.fetchMaybeCosignerConfig(
-    rpc,
-    cosignerConfig,
-    { commitment: 'confirmed' },
-  );
-
-  if (!existingConfig.exists) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} does not exist. The integrator/admin must initialize it before running this flow.`,
-    );
-  }
-
-  if (existingConfig.programAddress !== cosignerHookProgram) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} is owned by ${existingConfig.programAddress}, expected ${cosignerHookProgram}`,
-    );
-  }
-
-  const activeCosigners = existingConfig.data.cosigners.slice(
-    0,
-    existingConfig.data.cosignerCount,
-  );
-  if (activeCosigners.length === 0) {
-    throw new Error(
-      `Cosigner hook config ${cosignerConfig} does not include any active cosigners`,
-    );
-  }
-
-  return activeCosigners;
-}
-
-function requiredEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (!value) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
-
-function parseShareBps(name: string): number {
-  const value = Number(requiredEnv(name));
-  if (!Number.isInteger(value) || value <= 0 || value > 10_000) {
-    throw new Error(`${name} must be an integer from 1 to 10000`);
-  }
-  return value;
-}
-
-function parseDecimalTokenAmount(name: string, decimals: number): bigint {
-  const value = requiredEnv(name);
-  if (!/^\d+(\.\d+)?$/.test(value)) {
-    throw new Error(`${name} must be a non-negative decimal token amount`);
-  }
-
-  const [whole, fractional = ''] = value.split('.');
-  if (fractional.length > decimals) {
-    throw new Error(`${name} has more than ${decimals} decimal places`);
-  }
-
-  return (
-    BigInt(whole) * 10n ** BigInt(decimals) +
-    BigInt(fractional.padEnd(decimals, '0'))
-  );
-}
-
-function loadLaunchBeneficiaries({
-  baseDecimals,
-  expectedDistributionAmount,
-}: {
-  baseDecimals: number;
-  expectedDistributionAmount: bigint;
-}): LaunchBeneficiaryConfig {
-  const recipients: LaunchBeneficiaryConfig['recipients'] = [];
-  const feeBeneficiaries: LaunchBeneficiaryConfig['feeBeneficiaries'] = [];
-
-  for (let i = 1; i <= 2; i++) {
-    const prefix = `SOLANA_FEE_BENEFICIARY_${i}`;
-    const wallet = address(requiredEnv(`${prefix}_WALLET`));
-    const amount = parseDecimalTokenAmount(
-      `${prefix}_BASE_AMOUNT`,
-      baseDecimals,
-    );
-    const shareBps = parseShareBps(`${prefix}_SHARE_BPS`);
-
-    if (amount === 0n) {
-      throw new Error(`${prefix}_BASE_AMOUNT must be greater than zero`);
-    }
-
-    recipients.push({ wallet, amount });
-    feeBeneficiaries.push({ wallet, shareBps });
-  }
-
-  const totalAmount = recipients.reduce((sum, entry) => sum + entry.amount, 0n);
-  if (totalAmount !== expectedDistributionAmount) {
-    throw new Error(
-      `SOLANA_FEE_BENEFICIARY_*_BASE_AMOUNT values must sum to ${expectedDistributionAmount} base atoms`,
-    );
-  }
-
-  const totalShareBps = feeBeneficiaries.reduce(
-    (sum, entry) => sum + entry.shareBps,
-    0,
-  );
-  if (totalShareBps !== 10_000) {
-    throw new Error(
-      'SOLANA_FEE_BENEFICIARY_*_SHARE_BPS values must sum to 10000',
-    );
-  }
-
-  return { recipients, feeBeneficiaries };
-}
 
 async function main() {
   const payer = await loadKeypairSignerFromEnv();
@@ -260,16 +64,12 @@ async function main() {
   );
 
   console.log('Checking cosigner hook config...');
-  const activeCosigners = await fetchActiveCosigners({
+  await assertCosignerRegistered({
     rpc,
     cosignerHookProgram: deployment.cosignerHookProgram,
     cosignerConfig,
+    cosigner,
   });
-  if (!activeCosigners.includes(cosigner.address)) {
-    throw new Error(
-      `COSIGNER_KEYPAIR resolves to ${cosigner.address}, which is not registered in cosigner hook config ${cosignerConfig}`,
-    );
-  }
 
   const BASE_DECIMALS = 6;
   const BASE_TOTAL_SUPPLY = 1_000_000_000n * 10n ** BigInt(BASE_DECIMALS);
@@ -278,8 +78,8 @@ async function main() {
   const BASE_FOR_CURVE =
     BASE_TOTAL_SUPPLY - BASE_FOR_DISTRIBUTION - BASE_FOR_LIQUIDITY;
   const QUOTE_DECIMALS = 6;
-  const SWAP_FEE_BPS = 200;
-  const CPMM_SWAP_FEE_SPLIT_BPS = 10_000;
+  const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
+  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS;
   const BUY_AMOUNT_IN = parseDecimalTokenAmount(
     'SOLANA_COSIGNER_BUY_AMOUNT_USDC',
     QUOTE_DECIMALS,
@@ -369,12 +169,11 @@ async function main() {
       cpmmMigratorProgram: deployment.cpmmMigratorProgram,
     });
 
-  const signedHookRemainingAccounts = [namespace, cosigner];
-  const unsignedHookRemainingAccounts = [namespace, cosigner.address];
-  const hookRemainingAccountsHash = initializer.computeRemainingAccountsHash([
-    namespace,
-    cosigner.address,
-  ]);
+  const {
+    signedHookRemainingAccounts,
+    unsignedHookRemainingAccounts,
+    hookRemainingAccountsHash,
+  } = getCosignerHookRemainingAccounts({ namespace, cosigner });
 
   console.log('Creating cosigner-gated launch...');
   console.log('  Launch:            ', launch);
@@ -408,11 +207,7 @@ async function main() {
     baseForLiquidity: BASE_FOR_LIQUIDITY,
   });
 
-  const metadata = {
-    metadataName: 'TEST',
-    metadataSymbol: 'TEST',
-    metadataUri: 'https://example.com/metadata/test-token.json',
-  };
+  const metadata = DEFAULT_TEST_METADATA;
   const initializeLaunchIx =
     await initializer.createInitializeLaunchInstruction(
       {
@@ -466,38 +261,14 @@ async function main() {
       deployment.initializerProgram,
     );
 
-  const lookupTable = await createLookupTableForInstruction({
+  const launchSignature = await sendInitializeLaunchWithLookupTable({
     rpc,
     rpcSubscriptions,
     payer,
     instruction: initializeLaunchIx,
-    label: 'initialize_launch lookup table',
+    metadata,
   });
-  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-  const launchMessage = initializer.compressTransactionMessageWithLookupTable(
-    pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) => appendTransactionMessageInstructions([initializeLaunchIx], tx),
-    ),
-    lookupTable,
-  );
-  assertTransactionFits(launchMessage, {
-    label: 'initialize_launch',
-    metadataBytes: getMetadataByteLength(metadata),
-  });
-  const signedLaunch = await signTransactionMessageWithSigners(launchMessage);
-  await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-    signedLaunch as Parameters<
-      ReturnType<typeof sendAndConfirmTransactionFactory>
-    >[0],
-    { commitment: 'confirmed' },
-  );
-  console.log(
-    '  Launch tx:         ',
-    getSignatureFromTransaction(signedLaunch),
-  );
+  console.log('  Launch tx:         ', launchSignature);
 
   const [userBaseAta] = await findAssociatedTokenPda({
     owner: payer.address,
@@ -584,20 +355,15 @@ async function main() {
     initializer.phaseLabel(launchAccount.phase),
   );
 
-  const quoteVaultBalance = await rpc
-    .getTokenAccountBalance(quoteVault.address, { commitment: 'confirmed' })
-    .send();
-  const quoteVaultAmount = BigInt(quoteVaultBalance.value.amount);
-  const pendingQuoteFees =
-    (BUY_AMOUNT_IN * BigInt(SWAP_FEE_BPS) + 9_999n) / 10_000n;
-  const migrationQuoteAmount = quoteVaultAmount - pendingQuoteFees;
+  const { quoteVaultAmount, pendingQuoteFees } =
+    await assertMigrationQuoteThreshold({
+      rpc,
+      quoteVault: quoteVault.address,
+      pendingQuoteFees: getSwapFeeAmount(BUY_AMOUNT_IN, SWAP_FEE_BPS),
+      minRaiseQuote,
+    });
   console.log('  Quote vault amount:', quoteVaultAmount.toString());
   console.log('  Pending quote fees:', pendingQuoteFees.toString());
-  if (migrationQuoteAmount < minRaiseQuote) {
-    throw new Error(
-      `Migration quote amount ${migrationQuoteAmount} is below threshold ${minRaiseQuote}`,
-    );
-  }
   console.log('');
 
   const createRecipientAtaIxs = recipientAtas.map((ata, index) =>

--- a/examples/solana-usdc-cosigner-gated-buy.ts
+++ b/examples/solana-usdc-cosigner-gated-buy.ts
@@ -25,12 +25,11 @@ import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import {
   cosignerHook,
   cpmm,
+  createLaunch,
   initializer,
-  cpmmMigrator,
 } from '../src/solana/index.js';
 
 import {
-  DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   DEVNET_USDC_MINT as USDC_MINT,
@@ -77,7 +76,6 @@ async function main() {
     BASE_TOTAL_SUPPLY - BASE_FOR_DISTRIBUTION - BASE_FOR_LIQUIDITY;
   const QUOTE_DECIMALS = 6;
   const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS;
   const BUY_AMOUNT_IN = parseDecimalTokenAmount(
     'SOLANA_COSIGNER_BUY_AMOUNT_USDC',
     QUOTE_DECIMALS,
@@ -107,30 +105,18 @@ async function main() {
   const baseMint = await generateKeyPairSigner();
   const baseVault = await generateKeyPairSigner();
   const quoteVault = await generateKeyPairSigner();
-  const metadataAccount = await initializer.getTokenMetadataAddress(
-    baseMint.address,
-  );
+  const metadata = DEFAULT_TEST_METADATA;
 
   const namespace = cosignerConfig;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-  const [launch] = await initializer.getLaunchAddress(
+  const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+    deployment,
     namespace,
     launchId,
-    deployment.initializerProgram,
-  );
-  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [payerBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    baseMint,
+    metadata,
   });
+  const { launch, launchAuthority, launchFeeState } = launchAddresses;
   const [payerQuoteAta] = await findAssociatedTokenPda({
     owner: payer.address,
     mint: USDC_MINT,
@@ -143,35 +129,9 @@ async function main() {
     tokenAccount: payerQuoteAta,
     amount: BUY_AMOUNT_IN,
   });
-  const recipientAtas = await Promise.all(
-    launchBeneficiaries.recipients.map(async ({ wallet }) => {
-      const [ata] = await findAssociatedTokenPda({
-        owner: wallet,
-        mint: baseMint.address,
-        tokenProgram: TOKEN_PROGRAM_ADDRESS,
-      });
-      return ata;
-    }),
-  );
 
-  const migrationAccounts =
-    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
-      launch,
-      baseMint: baseMint.address,
-      quoteMint: USDC_MINT,
-      launchAuthority,
-      adminBaseAta: payerBaseAta,
-      adminQuoteAta: payerQuoteAta,
-      recipientAtas,
-      cpmmProgram: deployment.cpmmProgram,
-      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
-    });
-
-  const {
-    signedHookRemainingAccounts,
-    unsignedHookRemainingAccounts,
-    hookRemainingAccountsHash,
-  } = cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
+  const { signedHookRemainingAccounts, unsignedHookRemainingAccounts } =
+    cosignerHook.getCosignerHookRemainingAccounts({ namespace, cosigner });
 
   console.log('Creating cosigner-gated launch...');
   console.log('  Launch:            ', launch);
@@ -191,73 +151,44 @@ async function main() {
     );
   }
 
-  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
-    cpmmConfig: migrationAccounts.cpmmConfig,
-    initialSwapFeeBps: SWAP_FEE_BPS,
-    initialFeeSplitBps: CPMM_SWAP_FEE_SPLIT_BPS,
-    recipients: launchBeneficiaries.recipients,
-    minRaiseQuote,
-    minMigrationPriceQ64Opt: null,
-    migratedPoolHookConfig: null,
-  });
-  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
-    baseForDistribution: BASE_FOR_DISTRIBUTION,
-    baseForLiquidity: BASE_FOR_LIQUIDITY,
-  });
-
-  const metadata = DEFAULT_TEST_METADATA;
-  const initializeLaunchIx =
-    await initializer.createInitializeLaunchInstruction(
-      {
-        config: deployment.initializerConfig,
-        launch,
-        launchAuthority,
+  const { instruction: initializeLaunchIx, cpmmMigration } = await createLaunch(
+    {
+      deployment,
+      namespace,
+      launchId,
+      addresses: launchAddresses,
+      launchAccounts: {
         baseMint,
         quoteMint: USDC_MINT,
         baseVault,
         quoteVault,
-        launchFeeState,
-        payer,
-        authority: payer,
-        hookProgram: deployment.cosignerHookProgram,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        cpmmConfig: migrationAccounts.cpmmConfig,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-        metadataAccount,
       },
-      {
-        namespace,
-        launchId,
+      payer,
+      authority: payer,
+      supply: {
         baseDecimals: BASE_DECIMALS,
         baseTotalSupply: BASE_TOTAL_SUPPLY,
         baseForDistribution: BASE_FOR_DISTRIBUTION,
         baseForLiquidity: BASE_FOR_LIQUIDITY,
+      },
+      curve: {
         curveVirtualBase: start.curveVirtualBase,
         curveVirtualQuote: start.curveVirtualQuote,
         swapFeeBps: SWAP_FEE_BPS,
-        curveKind: initializer.CURVE_KIND_XYK,
-        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
-        allowBuy: true,
-        allowSell: true,
-        hookFlags:
-          initializer.HF_BEFORE_SWAP | initializer.HF_FORWARD_READONLY_SIGNERS,
-        hookPayload: new Uint8Array(),
-        migratorInitPayload,
-        migratorMigratePayload,
-        hookRemainingAccountsHash,
-        migratorInitRemainingAccountsHash:
-          initializer.computeRemainingAccountsHash([
-            migrationAccounts.cpmmMigrationState,
-            migrationAccounts.cpmmConfig,
-          ]),
-        migratorRemainingAccountsHash: migrationAccounts.hash,
-        feeBeneficiaries: launchBeneficiaries.feeBeneficiaries,
-        ...metadata,
       },
-      deployment.initializerProgram,
-    );
+      cosigner,
+      migration: {
+        recipients: launchBeneficiaries.recipients,
+        minRaiseQuote,
+      },
+      metadata,
+      feeBeneficiaries: launchBeneficiaries.feeBeneficiaries,
+    },
+  );
+  if (!cpmmMigration) {
+    throw new Error('CPMM migration accounts were not prepared');
+  }
+  const migrationAccounts = cpmmMigration;
 
   const launchSignature = await sendInitializeLaunchWithLookupTable({
     rpc,
@@ -367,13 +298,14 @@ async function main() {
   console.log('  Pending quote fees:', pendingQuoteFees.toString());
   console.log('');
 
-  const createRecipientAtaIxs = recipientAtas.map((ata, index) =>
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata,
-      owner: launchBeneficiaries.recipients[index].wallet,
-      mint: baseMint.address,
-    }),
+  const createRecipientAtaIxs = migrationAccounts.recipientAtas.map(
+    (ata, index) =>
+      getCreateAssociatedTokenIdempotentInstruction({
+        payer,
+        ata,
+        owner: launchBeneficiaries.recipients[index].wallet,
+        mint: baseMint.address,
+      }),
   );
 
   const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(

--- a/examples/solana-usdc-e2e-launch.ts
+++ b/examples/solana-usdc-e2e-launch.ts
@@ -38,7 +38,6 @@ import {
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
   getSolanaCpmmDeploymentFromEnv,
-  getSwapFeeAmount,
   loadKeypairSignerFromEnv,
   sendInitializeLaunchWithLookupTable,
   sendInstructions,
@@ -374,7 +373,10 @@ async function main() {
       console.log('  Curve buy confirmed:', signature);
     }
 
-    const expectedQuoteFee = getSwapFeeAmount(BUY_AMOUNT_IN, SWAP_FEE_BPS);
+    const expectedQuoteFee = initializer.getCurveSwapFeeAmount(
+      BUY_AMOUNT_IN,
+      SWAP_FEE_BPS,
+    );
     const feeStateAccount = await fetchLaunchFeeState(rpc, launchFeeState, {
       commitment: 'confirmed',
     });

--- a/examples/solana-usdc-e2e-launch.ts
+++ b/examples/solana-usdc-e2e-launch.ts
@@ -23,11 +23,15 @@ import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
-import { cpmm, initializer, cpmmMigrator } from '../src/solana/index.js';
+import {
+  cpmm,
+  initializer,
+  cpmmMigrator,
+  createLaunch,
+} from '../src/solana/index.js';
 import { fetchLaunchFeeState } from '../src/solana/generated/initializer/accounts/launchFeeState.js';
 
 import {
-  DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   DEVNET_USDC_MINT as USDC_MINT,
@@ -72,8 +76,6 @@ async function main() {
 
   // ── Fee configuration ───────────────────────────────────────────────────
   const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_BPS = SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
 
   // ── Graduation threshold and price floor ────────────────────────────────
   const minRaiseQuote = 100_000n; // 0.1 USDC
@@ -96,33 +98,20 @@ async function main() {
   const baseMint = await generateKeyPairSigner();
   const baseVault = await generateKeyPairSigner();
   const quoteVault = await generateKeyPairSigner();
-  const metadataAccount = await initializer.getTokenMetadataAddress(
-    baseMint.address,
-  );
+  const metadata = DEFAULT_TEST_METADATA;
 
   const namespace = payer.address;
   const launchId = initializer.launchIdFromU64(BigInt(Date.now()));
-
-  const [launch] = await initializer.getLaunchAddress(
+  const launchAddresses = await initializer.deriveCreateLaunchAddresses({
+    deployment,
     namespace,
     launchId,
-    deployment.initializerProgram,
-  );
-  const [launchAuthority] = await initializer.getLaunchAuthorityAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const [launchFeeState] = await initializer.getLaunchFeeStateAddress(
-    launch,
-    deployment.initializerProgram,
-  );
-  const initializerConfig = deployment.initializerConfig;
-
-  const [payerBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    baseMint,
+    metadata,
   });
+  const { launch, launchAuthority, launchFeeState } = launchAddresses;
+  const initializerConfig = launchAddresses.config;
+
   const [payerQuoteAta] = await findAssociatedTokenPda({
     owner: payer.address,
     mint: USDC_MINT,
@@ -135,104 +124,60 @@ async function main() {
     tokenAccount: payerQuoteAta,
     amount: BUY_AMOUNT_IN,
   });
-
-  const migrationAccounts =
-    await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
-      launch,
-      baseMint: baseMint.address,
-      quoteMint: USDC_MINT,
-      launchAuthority,
-      adminBaseAta: payerBaseAta,
-      adminQuoteAta: payerQuoteAta,
-      recipientAtas: [payerBaseAta, payerBaseAta],
-      cpmmProgram: deployment.cpmmProgram,
-      cpmmMigratorProgram: deployment.cpmmMigratorProgram,
-    });
-  const cpmmConfig = migrationAccounts.cpmmConfig;
-  const cpmmMigrationState = migrationAccounts.cpmmMigrationState;
-
-  console.log('Derived addresses:');
-  console.log('  Launch:          ', launch);
-  console.log('  Launch authority:', launchAuthority);
-  console.log('  Initializer config:', initializerConfig);
-  console.log('  CPMM config:     ', cpmmConfig);
-  console.log('  CPMM migrator state:', cpmmMigrationState);
-  console.log('');
-
-  const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
-    cpmmConfig: cpmmConfig,
-    initialSwapFeeBps: CPMM_SWAP_FEE_BPS,
-    initialFeeSplitBps: CPMM_SWAP_FEE_SPLIT_BPS,
-    recipients: [
-      { wallet: payer.address, amount: CREATOR_SHARE },
-      { wallet: payer.address, amount: TEAM_SHARE }, // use payer as team wallet in this example
-    ],
-    minRaiseQuote,
-    minMigrationPriceQ64Opt: null,
-    migratedPoolHookConfig: null,
-  });
-
-  const migratorMigratePayload = cpmmMigrator.encodeMigratePayload({
-    baseForDistribution: BASE_FOR_DISTRIBUTION,
-    baseForLiquidity: BASE_FOR_LIQUIDITY,
-  });
+  const recipients = [
+    { wallet: payer.address, amount: CREATOR_SHARE },
+    { wallet: payer.address, amount: TEAM_SHARE },
+  ];
 
   // ── Build, sign, and send ────────────────────────────────────────────────
   console.log('Building launch instruction...');
   try {
-    const metadata = DEFAULT_TEST_METADATA;
-
-    const ix = await initializer.createInitializeLaunchInstruction(
-      {
-        config: initializerConfig,
-        launch,
-        launchAuthority,
+    const { instruction: ix, cpmmMigration } = await createLaunch({
+      deployment,
+      namespace,
+      launchId,
+      addresses: launchAddresses,
+      launchAccounts: {
         baseMint,
         quoteMint: USDC_MINT,
         baseVault,
         quoteVault,
-        launchFeeState,
-        payer,
-        authority: payer,
-        hookProgram: deployment.cpmmHookProgram,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        cpmmConfig,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-        metadataAccount,
       },
-      {
-        namespace,
-        launchId,
+      payer,
+      authority: payer,
+      supply: {
         baseDecimals: BASE_DECIMALS,
         baseTotalSupply: BASE_TOTAL_SUPPLY,
         baseForDistribution: BASE_FOR_DISTRIBUTION,
         baseForLiquidity: BASE_FOR_LIQUIDITY,
+      },
+      curve: {
         curveVirtualBase: start.curveVirtualBase,
         curveVirtualQuote: start.curveVirtualQuote,
         swapFeeBps: SWAP_FEE_BPS,
-        curveKind: initializer.CURVE_KIND_XYK,
-        curveParams: new Uint8Array([initializer.CURVE_PARAMS_FORMAT_XYK_V0]),
-        allowBuy: true,
-        allowSell: true,
-        hookFlags: initializer.HF_BEFORE_SWAP,
-        hookPayload: new Uint8Array(),
-        migratorInitPayload,
-        migratorMigratePayload,
-        hookRemainingAccountsHash: initializer.EMPTY_REMAINING_ACCOUNTS_HASH,
-        migratorInitRemainingAccountsHash:
-          initializer.computeRemainingAccountsHash([
-            cpmmMigrationState,
-            cpmmConfig,
-          ]),
-        migratorRemainingAccountsHash: migrationAccounts.hash,
-        feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
-        ...metadata,
       },
-      deployment.initializerProgram,
-    );
+      migration: {
+        recipients,
+        minRaiseQuote,
+      },
+      metadata,
+      feeBeneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
+    });
+    if (!cpmmMigration) {
+      throw new Error('CPMM migration accounts were not prepared');
+    }
+    const migrationAccounts = cpmmMigration;
+    const cpmmConfig = migrationAccounts.cpmmConfig;
+    const cpmmMigrationState = migrationAccounts.cpmmMigrationState;
+
+    console.log('Derived addresses:');
+    console.log('  Launch:          ', launch);
+    console.log('  Launch authority:', launchAuthority);
+    console.log('  Initializer config:', initializerConfig);
+    console.log('  CPMM config:     ', cpmmConfig);
+    console.log('  CPMM migrator state:', cpmmMigrationState);
+    console.log('');
+
     const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,

--- a/examples/solana-usdc-e2e-launch.ts
+++ b/examples/solana-usdc-e2e-launch.ts
@@ -15,102 +15,23 @@
 import './env.js';
 
 import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
-} from '@solana-program/token';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
-import {
-  generateKeyPairSigner,
-  getBase64EncodedWireTransaction,
-  pipe,
-  createTransactionMessage,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-  signTransactionMessageWithSigners,
-  sendAndConfirmTransactionFactory,
-  getSignatureFromTransaction,
-  type Address,
-} from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
-
-import { cpmm, initializer, cpmmMigrator } from '../src/solana/index.js';
-import { fetchLaunchFeeState } from '../src/solana/generated/initializer/accounts/launchFeeState.js';
-import {
-  assertTransactionFits,
+  DEFAULT_CPMM_FEE_SPLIT_BPS,
+  DEFAULT_SWAP_FEE_BPS,
+  DEFAULT_TEST_METADATA,
+  DEVNET_USDC_MINT as USDC_MINT,
+  assertBigintEqual,
+  assertMigrationQuoteThreshold,
   assertSolanaExampleNetwork,
-  createLookupTableForInstruction,
+  assertTokenBalance,
   createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
-  getMetadataByteLength,
   getSolanaCpmmDeploymentFromEnv,
+  getSwapFeeAmount,
   loadKeypairSignerFromEnv,
+  sendInitializeLaunchWithLookupTable,
+  sendInstructions,
+  simulateInstructions,
 } from './solanaExampleHelpers.js';
-
-// Standard devnet USDC mint.
-const USDC_MINT: Address =
-  '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU' as Address;
-
-async function fetchOwnedTokenAmount({
-  rpc,
-  owner,
-  mint,
-  tokenAccount,
-}: {
-  rpc: ReturnType<typeof createSolanaClientsFromEnv>['rpc'];
-  owner: Address;
-  mint: Address;
-  tokenAccount: Address;
-}): Promise<bigint | null> {
-  const result = await rpc
-    .getTokenAccountsByOwner(
-      owner,
-      { mint },
-      { encoding: 'jsonParsed', commitment: 'confirmed' },
-    )
-    .send();
-  const account = result.value.find(({ pubkey }) => pubkey === tokenAccount);
-  return account
-    ? BigInt(account.account.data.parsed.info.tokenAmount.amount)
-    : null;
-}
-
-async function assertTokenBalance({
-  rpc,
-  owner,
-  mint,
-  tokenAccount,
-  amount,
-}: {
-  rpc: ReturnType<typeof createSolanaClientsFromEnv>['rpc'];
-  owner: Address;
-  mint: Address;
-  tokenAccount: Address;
-  amount: bigint;
-}): Promise<void> {
-  const balance = await fetchOwnedTokenAmount({
-    rpc,
-    owner,
-    mint,
-    tokenAccount,
-  });
-  if (balance === null || balance < amount) {
-    throw new Error(
-      `USDC token account ${tokenAccount} needs at least ${amount} atoms; current balance is ${balance ?? 0n}`,
-    );
-  }
-}
-
-function ceilDiv(numerator: bigint, denominator: bigint): bigint {
-  return (numerator + denominator - 1n) / denominator;
-}
-
-function assertEqual(label: string, actual: bigint, expected: bigint): void {
-  if (actual !== expected) {
-    throw new Error(`${label}: expected ${expected}, got ${actual}`);
-  }
-}
 
 // ============================================================================
 // Main
@@ -139,9 +60,9 @@ async function main() {
   const END_MARKET_CAP_USD = 10_000_000;
 
   // ── Fee configuration ───────────────────────────────────────────────────
-  const SWAP_FEE_BPS = 200; // 2%; must fit this deployment's configured fee bounds
+  const SWAP_FEE_BPS = DEFAULT_SWAP_FEE_BPS;
   const CPMM_SWAP_FEE_BPS = SWAP_FEE_BPS;
-  const CPMM_SWAP_FEE_SPLIT_BPS = 10_000; // migrated launch fees route through LaunchFeeState
+  const CPMM_SWAP_FEE_SPLIT_BPS = DEFAULT_CPMM_FEE_SPLIT_BPS; // migrated launch fees route through LaunchFeeState
 
   // ── Graduation threshold and price floor ────────────────────────────────
   const minRaiseQuote = 100_000n; // 0.1 USDC
@@ -248,11 +169,7 @@ async function main() {
   // ── Build, sign, and send ────────────────────────────────────────────────
   console.log('Building launch instruction...');
   try {
-    const metadata = {
-      metadataName: 'TEST',
-      metadataSymbol: 'TEST',
-      metadataUri: 'https://example.com/metadata/test-token.json',
-    };
+    const metadata = DEFAULT_TEST_METADATA;
 
     const ix = await initializer.createInitializeLaunchInstruction(
       {
@@ -305,54 +222,18 @@ async function main() {
       },
       deployment.initializerProgram,
     );
-    const lookupTable = await createLookupTableForInstruction({
+    const launchSignature = await sendInitializeLaunchWithLookupTable({
       rpc,
       rpcSubscriptions,
       payer,
       instruction: ix,
-      label: 'initialize_launch lookup table',
+      metadata,
     });
-
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const transactionMessage =
-      initializer.compressTransactionMessageWithLookupTable(
-        pipe(
-          createTransactionMessage({ version: 0 }),
-          (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-          (tx) =>
-            setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-          (tx) => appendTransactionMessageInstructions([ix], tx),
-        ),
-        lookupTable,
-      );
-    assertTransactionFits(transactionMessage, {
-      label: 'initialize_launch',
-      metadataBytes: getMetadataByteLength(metadata),
-    });
-
-    const signedTransaction =
-      await signTransactionMessageWithSigners(transactionMessage);
-
-    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-      rpc,
-      rpcSubscriptions,
-    });
-    await sendAndConfirmTransaction(
-      signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-      {
-        commitment: 'confirmed',
-      },
-    );
-
     console.log('');
     console.log('Token launch created successfully!');
     console.log('  Launch address:', launch);
     console.log('  Base mint:     ', baseMint.address);
-    console.log(
-      '  Transaction:   ',
-      getSignatureFromTransaction(signedTransaction),
-    );
+    console.log('  Transaction:   ', launchSignature);
 
     // ── Step 2: Enumerate launches by this wallet (indexer-style) ───────────
     console.log('Step 2: Listing launches owned by this wallet...');
@@ -388,25 +269,11 @@ async function main() {
       deployment.initializerProgram,
     );
 
-    // simulateTransaction is the idiomatic way to run a read-only instruction.
-    const { value: previewBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const previewMessage = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(previewBlockhash, tx),
-      (tx) => appendTransactionMessageInstructions([previewIx], tx),
-    );
-
-    const signedPreview =
-      await signTransactionMessageWithSigners(previewMessage);
-
-    const { value: simulateResult } = await rpc
-      .simulateTransaction(getBase64EncodedWireTransaction(signedPreview), {
-        encoding: 'base64',
-        replaceRecentBlockhash: true,
-      })
-      .send();
+    const simulateResult = await simulateInstructions({
+      rpc,
+      payer,
+      instructions: [previewIx],
+    });
 
     if (simulateResult.returnData?.data) {
       const returnBytes = Uint8Array.from(
@@ -485,59 +352,38 @@ async function main() {
     );
 
     {
-      const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+      const signature = await sendInstructions({
+        rpc,
+        rpcSubscriptions,
+        payer,
+        instructions: [createBaseAtaIx, createQuoteAtaIx, swapIx],
+      });
 
-      const transactionMessage = pipe(
-        createTransactionMessage({ version: 0 }),
-        (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-        (tx) =>
-          setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-        (tx) =>
-          appendTransactionMessageInstructions(
-            [createBaseAtaIx, createQuoteAtaIx, swapIx],
-            tx,
-          ),
-      );
-
-      const signedTransaction =
-        await signTransactionMessageWithSigners(transactionMessage);
-
-      await sendAndConfirmTransaction(
-        signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-        {
-          commitment: 'confirmed',
-        },
-      );
-
-      console.log(
-        '  Curve buy confirmed:',
-        getSignatureFromTransaction(signedTransaction),
-      );
+      console.log('  Curve buy confirmed:', signature);
     }
 
-    const expectedQuoteFee = ceilDiv(
-      BUY_AMOUNT_IN * BigInt(SWAP_FEE_BPS),
-      10_000n,
-    );
+    const expectedQuoteFee = getSwapFeeAmount(BUY_AMOUNT_IN, SWAP_FEE_BPS);
     const feeStateAccount = await fetchLaunchFeeState(rpc, launchFeeState, {
       commitment: 'confirmed',
     });
     const feeState = feeStateAccount.data;
-    assertEqual(
+    assertBigintEqual(
       'cumulatedQuoteFees',
       feeState.cumulatedQuoteFees,
       expectedQuoteFee,
     );
-    assertEqual('cumulatedBaseFees', feeState.cumulatedBaseFees, 0n);
+    assertBigintEqual('cumulatedBaseFees', feeState.cumulatedBaseFees, 0n);
     const protocolQuoteFees =
       (expectedQuoteFee * BigInt(feeState.protocolFeeBps)) / 10_000n;
     const beneficiaryQuoteFees = expectedQuoteFee - protocolQuoteFees;
-    const quoteVaultBalance = await rpc
-      .getTokenAccountBalance(quoteVault.address, { commitment: 'confirmed' })
-      .send();
-    const quoteVaultAmount = BigInt(quoteVaultBalance.value.amount);
     const pendingQuoteFees = feeState.cumulatedQuoteFees;
-    const migrationQuoteAmount = quoteVaultAmount - pendingQuoteFees;
+    const { quoteVaultAmount, migrationQuoteAmount } =
+      await assertMigrationQuoteThreshold({
+        rpc,
+        quoteVault: quoteVault.address,
+        pendingQuoteFees,
+        minRaiseQuote,
+      });
 
     console.log('  Fee arithmetic verified:');
     console.log('    cumulated quote fees:', expectedQuoteFee.toString());
@@ -545,11 +391,6 @@ async function main() {
     console.log('    beneficiary fees:    ', beneficiaryQuoteFees.toString());
     console.log('    quote vault amount:  ', quoteVaultAmount.toString());
     console.log('    migration quote:     ', migrationQuoteAmount.toString());
-    if (migrationQuoteAmount < minRaiseQuote) {
-      throw new Error(
-        `Migration quote amount ${migrationQuoteAmount} is below threshold ${minRaiseQuote}`,
-      );
-    }
     console.log('');
 
     // ── Step 5: Migrate launch to CPMM pool ─────────────────────────────────
@@ -590,34 +431,17 @@ async function main() {
     };
 
     {
-      const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+      const signature = await sendInstructions({
+        rpc,
+        rpcSubscriptions,
+        payer,
+        instructions: [
+          createSetComputeUnitLimitInstruction(400_000),
+          migrateLaunchIx,
+        ],
+      });
 
-      const transactionMessage = pipe(
-        createTransactionMessage({ version: 0 }),
-        (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-        (tx) =>
-          setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-        (tx) =>
-          appendTransactionMessageInstructions(
-            [createSetComputeUnitLimitInstruction(400_000), migrateLaunchIx],
-            tx,
-          ),
-      );
-
-      const signedTransaction =
-        await signTransactionMessageWithSigners(transactionMessage);
-
-      await sendAndConfirmTransaction(
-        signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
-        {
-          commitment: 'confirmed',
-        },
-      );
-
-      console.log(
-        '  Migration confirmed:',
-        getSignatureFromTransaction(signedTransaction),
-      );
+      console.log('  Migration confirmed:', signature);
     }
     console.log('');
 

--- a/examples/solana-usdc-e2e-launch.ts
+++ b/examples/solana-usdc-e2e-launch.ts
@@ -15,6 +15,18 @@
 import './env.js';
 
 import {
+  TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+} from '@solana-program/token';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import { generateKeyPairSigner } from '@solana/kit';
+import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
+
+import { cpmm, initializer, cpmmMigrator } from '../src/solana/index.js';
+import { fetchLaunchFeeState } from '../src/solana/generated/initializer/accounts/launchFeeState.js';
+
+import {
   DEFAULT_CPMM_FEE_SPLIT_BPS,
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,

--- a/examples/solanaExampleHelpers.ts
+++ b/examples/solanaExampleHelpers.ts
@@ -535,19 +535,29 @@ export async function fetchActiveCosigners({
   cosignerHookProgram: Address;
   cosignerConfig: Address;
 }): Promise<Set<string>> {
-  const configAccount = await cosignerHook.accounts.fetchMaybeCosignerConfig(
+  const configAccount = await cosignerHook.fetchMaybeCosignerConfig(
     rpc,
     cosignerConfig,
-    cosignerHookProgram,
+    { commitment: 'confirmed' },
   );
   if (!configAccount.exists) {
     throw new Error('Cosigner config does not exist: ' + cosignerConfig);
   }
+  if (configAccount.programAddress !== cosignerHookProgram) {
+    throw new Error(
+      'Cosigner config ' +
+        cosignerConfig +
+        ' is owned by ' +
+        configAccount.programAddress +
+        ', expected ' +
+        cosignerHookProgram,
+    );
+  }
 
   return new Set(
     configAccount.data.cosigners
-      .filter((entry) => entry.isActive)
-      .map((entry) => entry.authority.toString()),
+      .slice(0, configAccount.data.cosignerCount)
+      .map((authority) => authority.toString()),
   );
 }
 

--- a/examples/solanaExampleHelpers.ts
+++ b/examples/solanaExampleHelpers.ts
@@ -431,7 +431,12 @@ export function parseDecimalTokenAmount(
   decimals: number,
 ): bigint {
   const raw = requiredEnv(name);
-  const [whole, fraction = ''] = raw.split('.');
+  const parts = raw.split('.');
+  if (parts.length > 2) {
+    throw new Error(name + ' must be a non-negative decimal amount');
+  }
+
+  const [whole, fraction = ''] = parts;
   if (!whole || !/^\d+$/.test(whole) || !/^\d*$/.test(fraction)) {
     throw new Error(name + ' must be a non-negative decimal amount');
   }
@@ -498,14 +503,6 @@ export function loadLaunchBeneficiaries({
   }
 
   return { recipients, feeBeneficiaries };
-}
-
-export function ceilDiv(numerator: bigint, denominator: bigint): bigint {
-  return (numerator + denominator - 1n) / denominator;
-}
-
-export function getSwapFeeAmount(amountIn: bigint, swapFeeBps: number): bigint {
-  return ceilDiv(amountIn * BigInt(swapFeeBps), 10_000n);
 }
 
 export function assertBigintEqual(
@@ -585,24 +582,6 @@ export async function assertCosignerRegistered({
         cosignerConfig,
     );
   }
-}
-
-export function getCosignerHookRemainingAccounts({
-  namespace,
-  cosigner,
-}: {
-  namespace: Address;
-  cosigner: TransactionSigner;
-}) {
-  const unsignedHookRemainingAccounts = [namespace, cosigner.address];
-
-  return {
-    signedHookRemainingAccounts: [namespace, cosigner],
-    unsignedHookRemainingAccounts,
-    hookRemainingAccountsHash: initializer.computeRemainingAccountsHash(
-      unsignedHookRemainingAccounts,
-    ),
-  };
 }
 
 async function fetchOwnedTokenAmount({
@@ -738,6 +717,15 @@ export async function getMigrationQuoteProgress({
     .getTokenAccountBalance(quoteVault, { commitment: 'confirmed' })
     .send();
   const quoteVaultAmount = BigInt(vaultBalance.value.amount);
+  if (pendingQuoteFees > quoteVaultAmount) {
+    throw new Error(
+      'Pending quote fees ' +
+        pendingQuoteFees +
+        ' exceed quote vault balance ' +
+        quoteVaultAmount,
+    );
+  }
+
   const migrationQuoteAmount = quoteVaultAmount - pendingQuoteFees;
 
   return {

--- a/examples/solanaExampleHelpers.ts
+++ b/examples/solanaExampleHelpers.ts
@@ -734,8 +734,10 @@ export async function getMigrationQuoteProgress({
   quoteVault: Address;
   pendingQuoteFees: bigint;
 }) {
-  const vaultBalance = await rpc.getBalance(quoteVault).send();
-  const quoteVaultAmount = vaultBalance.value;
+  const vaultBalance = await rpc
+    .getTokenAccountBalance(quoteVault, { commitment: 'confirmed' })
+    .send();
+  const quoteVaultAmount = BigInt(vaultBalance.value.amount);
   const migrationQuoteAmount = quoteVaultAmount - pendingQuoteFees;
 
   return {

--- a/examples/solanaExampleHelpers.ts
+++ b/examples/solanaExampleHelpers.ts
@@ -27,6 +27,7 @@ import {
 
 import {
   DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
+  cosignerHook,
   deriveSolanaCpmmDeployment,
   initializer,
   type SolanaCpmmDeployment,
@@ -45,6 +46,17 @@ export type SolanaExampleNetwork =
 export const DEFAULT_SOLANA_EXAMPLE_NETWORK: SolanaExampleNetwork = 'devnet';
 export const TOKEN_ACCOUNT_SPACE = 165n;
 export const SOLANA_TRANSACTION_SIZE_LIMIT = 1232;
+export const WSOL_MINT = address('So11111111111111111111111111111111111111112');
+export const DEVNET_USDC_MINT = address(
+  '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+);
+export const DEFAULT_TEST_METADATA = {
+  metadataName: 'TEST',
+  metadataSymbol: 'TEST',
+  metadataUri: 'https://example.com/metadata/test-token.json',
+} as const;
+export const DEFAULT_SWAP_FEE_BPS = 200;
+export const DEFAULT_CPMM_FEE_SPLIT_BPS = 10_000;
 
 const COMPUTE_BUDGET_PROGRAM_ID = address(
   'ComputeBudget111111111111111111111111111111',
@@ -106,7 +118,7 @@ const CUSTOM_CPMM_PROGRAM_ENV = {
 } as const satisfies Record<keyof SolanaCpmmProgramAddresses, string>;
 
 function requiredAddressFromEnv(name: string): Address {
-  const value = process.env[name];
+  const value = process.env[name]?.trim();
   if (!value) {
     throw new Error(`${name} is required when SOLANA_NETWORK=custom`);
   }
@@ -391,6 +403,365 @@ export async function createLookupTableForInstruction({
   );
 
   return lookupTable;
+}
+
+export type LaunchBeneficiaryConfig = {
+  recipients: { wallet: Address; amount: bigint }[];
+  feeBeneficiaries: { wallet: Address; shareBps: number }[];
+};
+
+export function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(name + ' is required');
+  }
+  return value;
+}
+
+export function parseShareBps(name: string): number {
+  const value = Number(requiredEnv(name));
+  if (!Number.isInteger(value) || value <= 0 || value > 10_000) {
+    throw new Error(name + ' must be an integer from 1 to 10000');
+  }
+  return value;
+}
+
+export function parseDecimalTokenAmount(
+  name: string,
+  decimals: number,
+): bigint {
+  const raw = requiredEnv(name);
+  const [whole, fraction = ''] = raw.split('.');
+  if (!whole || !/^\d+$/.test(whole) || !/^\d*$/.test(fraction)) {
+    throw new Error(name + ' must be a non-negative decimal amount');
+  }
+  if (fraction.length > decimals) {
+    throw new Error(name + ' supports at most ' + decimals + ' decimal places');
+  }
+
+  const paddedFraction = fraction.padEnd(decimals, '0');
+  return BigInt(whole + paddedFraction);
+}
+
+export function loadLaunchBeneficiaries({
+  baseDecimals,
+  expectedDistributionAmount,
+  count = 2,
+}: {
+  baseDecimals: number;
+  expectedDistributionAmount: bigint;
+  count?: number;
+}): LaunchBeneficiaryConfig {
+  const recipients: LaunchBeneficiaryConfig['recipients'] = [];
+  const feeBeneficiaries: LaunchBeneficiaryConfig['feeBeneficiaries'] = [];
+
+  for (let index = 0; index < count; index++) {
+    const suffix = index + 1;
+    const prefix = 'SOLANA_FEE_BENEFICIARY_' + suffix;
+    const wallet = address(requiredEnv(prefix + '_WALLET'));
+    const amount = parseDecimalTokenAmount(
+      prefix + '_BASE_AMOUNT',
+      baseDecimals,
+    );
+    const shareBps = parseShareBps(prefix + '_SHARE_BPS');
+
+    if (amount === 0n) {
+      throw new Error(prefix + '_BASE_AMOUNT must be greater than zero');
+    }
+
+    recipients.push({ wallet, amount });
+    feeBeneficiaries.push({ wallet, shareBps });
+  }
+
+  const distributionTotal = recipients.reduce(
+    (total, recipient) => total + recipient.amount,
+    0n,
+  );
+  if (distributionTotal !== expectedDistributionAmount) {
+    throw new Error(
+      'SOLANA_FEE_BENEFICIARY_*_BASE_AMOUNT values must sum to ' +
+        expectedDistributionAmount +
+        ' base atoms; got ' +
+        distributionTotal,
+    );
+  }
+
+  const feeShareTotal = feeBeneficiaries.reduce(
+    (total, recipient) => total + recipient.shareBps,
+    0,
+  );
+  if (feeShareTotal !== 10_000) {
+    throw new Error(
+      'SOLANA_FEE_BENEFICIARY_*_SHARE_BPS values must sum to 10000; got ' +
+        feeShareTotal,
+    );
+  }
+
+  return { recipients, feeBeneficiaries };
+}
+
+export function ceilDiv(numerator: bigint, denominator: bigint): bigint {
+  return (numerator + denominator - 1n) / denominator;
+}
+
+export function getSwapFeeAmount(amountIn: bigint, swapFeeBps: number): bigint {
+  return ceilDiv(amountIn * BigInt(swapFeeBps), 10_000n);
+}
+
+export function assertBigintEqual(
+  label: string,
+  actual: bigint,
+  expected: bigint,
+): void {
+  if (actual !== expected) {
+    throw new Error(label + ': expected ' + expected + ', got ' + actual);
+  }
+}
+
+export async function loadCosigner(): Promise<TransactionSigner> {
+  return loadKeypairSignerFromEnv({
+    pathEnv: 'COSIGNER_KEYPAIR_PATH',
+    jsonEnv: 'COSIGNER_KEYPAIR',
+    label: 'COSIGNER_KEYPAIR',
+  });
+}
+
+export async function fetchActiveCosigners({
+  rpc,
+  cosignerHookProgram,
+  cosignerConfig,
+}: {
+  rpc: SolanaClients['rpc'];
+  cosignerHookProgram: Address;
+  cosignerConfig: Address;
+}): Promise<Set<string>> {
+  const configAccount = await cosignerHook.accounts.fetchMaybeCosignerConfig(
+    rpc,
+    cosignerConfig,
+    cosignerHookProgram,
+  );
+  if (!configAccount.exists) {
+    throw new Error('Cosigner config does not exist: ' + cosignerConfig);
+  }
+
+  return new Set(
+    configAccount.data.cosigners
+      .filter((entry) => entry.isActive)
+      .map((entry) => entry.authority.toString()),
+  );
+}
+
+export async function assertCosignerRegistered({
+  rpc,
+  cosignerHookProgram,
+  cosignerConfig,
+  cosigner,
+}: {
+  rpc: SolanaClients['rpc'];
+  cosignerHookProgram: Address;
+  cosignerConfig: Address;
+  cosigner: TransactionSigner;
+}): Promise<void> {
+  const activeCosigners = await fetchActiveCosigners({
+    rpc,
+    cosignerHookProgram,
+    cosignerConfig,
+  });
+  if (!activeCosigners.has(cosigner.address.toString())) {
+    throw new Error(
+      'Cosigner ' +
+        cosigner.address +
+        ' is not active in config ' +
+        cosignerConfig,
+    );
+  }
+}
+
+export function getCosignerHookRemainingAccounts({
+  namespace,
+  cosigner,
+}: {
+  namespace: Address;
+  cosigner: TransactionSigner;
+}) {
+  const unsignedHookRemainingAccounts = [namespace, cosigner.address];
+
+  return {
+    signedHookRemainingAccounts: [namespace, cosigner],
+    unsignedHookRemainingAccounts,
+    hookRemainingAccountsHash: initializer.computeRemainingAccountsHash(
+      unsignedHookRemainingAccounts,
+    ),
+  };
+}
+
+async function fetchOwnedTokenAmount({
+  rpc,
+  owner,
+  mint,
+  tokenAccount,
+}: {
+  rpc: SolanaClients['rpc'];
+  owner: Address;
+  mint: Address;
+  tokenAccount: Address;
+}): Promise<bigint> {
+  const account = await rpc
+    .getTokenAccountsByOwner(
+      owner,
+      { mint },
+      { commitment: 'confirmed', encoding: 'jsonParsed' },
+    )
+    .send();
+  const match = account.value.find(({ pubkey }) => pubkey === tokenAccount);
+  if (!match) {
+    return 0n;
+  }
+
+  const amount = match.account.data.parsed.info.tokenAmount.amount;
+  return BigInt(amount);
+}
+
+export async function assertTokenBalance({
+  rpc,
+  owner,
+  mint,
+  tokenAccount,
+  amount,
+  label = 'token',
+}: {
+  rpc: SolanaClients['rpc'];
+  owner: Address;
+  mint: Address;
+  tokenAccount: Address;
+  amount: bigint;
+  label?: string;
+}): Promise<void> {
+  const balance = await fetchOwnedTokenAmount({
+    rpc,
+    owner,
+    mint,
+    tokenAccount,
+  });
+  if (balance < amount) {
+    throw new Error(
+      'Payer ' +
+        owner +
+        ' needs at least ' +
+        amount +
+        ' ' +
+        label +
+        ' atoms; found ' +
+        balance +
+        '. Fund ' +
+        tokenAccount +
+        ' and retry.',
+    );
+  }
+}
+
+export async function sendInitializeLaunchWithLookupTable({
+  rpc,
+  rpcSubscriptions,
+  payer,
+  instruction,
+  metadata,
+  label = 'initialize_launch',
+}: {
+  rpc: SolanaClients['rpc'];
+  rpcSubscriptions: SolanaClients['rpcSubscriptions'];
+  payer: TransactionSigner;
+  instruction: Instruction;
+  metadata?: {
+    metadataName?: string;
+    metadataSymbol?: string;
+    metadataUri?: string;
+  };
+  label?: string;
+}): Promise<string> {
+  const lookupTable = await createLookupTableForInstruction({
+    rpc,
+    rpcSubscriptions,
+    payer,
+    instruction,
+    label: 'initialize_launch ALT',
+  });
+  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+  const message = initializer.compressTransactionMessageWithLookupTable(
+    pipe(
+      createTransactionMessage({ version: 0 }),
+      (tx) => setTransactionMessageFeePayerSigner(payer, tx),
+      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+      (tx) => appendTransactionMessageInstructions([instruction], tx),
+    ),
+    lookupTable,
+  );
+
+  assertTransactionFits(message, {
+    label,
+    metadataBytes: metadata ? getMetadataByteLength(metadata) : undefined,
+  });
+
+  const signedTransaction = await signTransactionMessageWithSigners(message);
+  const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
+    rpc,
+    rpcSubscriptions,
+  });
+  await sendAndConfirmTransaction(
+    signedTransaction as Parameters<typeof sendAndConfirmTransaction>[0],
+    { commitment: 'confirmed' },
+  );
+
+  return getSignatureFromTransaction(signedTransaction);
+}
+
+export async function getMigrationQuoteProgress({
+  rpc,
+  quoteVault,
+  pendingQuoteFees,
+}: {
+  rpc: SolanaClients['rpc'];
+  quoteVault: Address;
+  pendingQuoteFees: bigint;
+}) {
+  const vaultBalance = await rpc.getBalance(quoteVault).send();
+  const quoteVaultAmount = vaultBalance.value;
+  const migrationQuoteAmount = quoteVaultAmount - pendingQuoteFees;
+
+  return {
+    quoteVaultAmount,
+    pendingQuoteFees,
+    migrationQuoteAmount,
+  };
+}
+
+export async function assertMigrationQuoteThreshold({
+  rpc,
+  quoteVault,
+  pendingQuoteFees,
+  minRaiseQuote,
+}: {
+  rpc: SolanaClients['rpc'];
+  quoteVault: Address;
+  pendingQuoteFees: bigint;
+  minRaiseQuote: bigint;
+}) {
+  const progress = await getMigrationQuoteProgress({
+    rpc,
+    quoteVault,
+    pendingQuoteFees,
+  });
+
+  if (progress.migrationQuoteAmount < minRaiseQuote) {
+    throw new Error(
+      'Quote available for migration ' +
+        progress.migrationQuoteAmount +
+        ' is below minRaiseQuote ' +
+        minRaiseQuote,
+    );
+  }
+
+  return progress;
 }
 
 export async function getSolPriceUsd(): Promise<number> {

--- a/scripts/benchmark-solana-metadata-size.ts
+++ b/scripts/benchmark-solana-metadata-size.ts
@@ -34,9 +34,9 @@ const SAMPLE_METADATA = {
   metadataUri: 'https://example.com/metadata/test-token.json',
 };
 const REQUESTED_METADATA = {
-  metadataName: METADATA_NAME,
-  metadataSymbol: METADATA_SYMBOL,
-  metadataUri: SAMPLE_METADATA.metadataUri,
+  metadataName: 'Frenzy Devnet Cosigner',
+  metadataSymbol: 'FDC',
+  metadataUri: 'https://example.com/frenzy-devnet-cosigner.json',
 };
 const DUMMY_BLOCKHASH = {
   blockhash: '11111111111111111111111111111111',
@@ -241,6 +241,7 @@ async function buildMessage(
           context.cpmmConfig,
         ]),
       migratorRemainingAccountsHash: context.migrationHash,
+      feeBeneficiaries: [{ wallet: context.payer.address, shareBps: 10_000 }],
       ...metadata,
     },
   );
@@ -534,13 +535,23 @@ async function benchmark(
     sampleRemainingBytes: sample.remaining,
     requestedMetadataBytes: requested.metadataBytes,
     requestedSize: requested.size,
+    requestedFits: requested.fits,
     requestedRemainingBytes: requested.remaining,
+    requestedOverflowBytes: Math.max(0, -requested.remaining),
+    requestedExtraMetadataBytes: max.metadataBytes - requested.metadataBytes,
     launchAltMaxUriBytes,
     launchAltMaxMetadataBytes: launchAltMax.metadataBytes,
     launchAltSampleSize: launchAltSample.size,
     launchAltSampleRemainingBytes: launchAltSample.remaining,
     launchAltRequestedSize: launchAltRequested.size,
+    launchAltRequestedFits: launchAltRequested.fits,
     launchAltRequestedRemainingBytes: launchAltRequested.remaining,
+    launchAltRequestedOverflowBytes: Math.max(
+      0,
+      -launchAltRequested.remaining,
+    ),
+    launchAltRequestedExtraMetadataBytes:
+      launchAltMax.metadataBytes - launchAltRequested.metadataBytes,
   };
 }
 
@@ -562,6 +573,7 @@ async function benchmarkPrediction() {
     metadataUri: 'u'.repeat(maxUriBytes),
   });
   const sample = await measurePrediction(SAMPLE_METADATA);
+  const requested = await measurePrediction(REQUESTED_METADATA);
 
   return {
     shape: 'prediction',
@@ -576,6 +588,12 @@ async function benchmarkPrediction() {
     sampleMetadataBytes: sample.metadataBytes,
     sampleSize: sample.size,
     sampleRemainingBytes: sample.remaining,
+    requestedMetadataBytes: requested.metadataBytes,
+    requestedSize: requested.size,
+    requestedFits: requested.fits,
+    requestedRemainingBytes: requested.remaining,
+    requestedOverflowBytes: Math.max(0, -requested.remaining),
+    requestedExtraMetadataBytes: max.metadataBytes - requested.metadataBytes,
   };
 }
 

--- a/src/solana/core/constants.ts
+++ b/src/solana/core/constants.ts
@@ -5,6 +5,10 @@ export {
 } from '@solana-program/token';
 export { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 export { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
+
+export const TOKEN_2022_PROGRAM_ADDRESS: Address = address(
+  'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+);
 export const SYSVAR_INSTRUCTIONS_ADDRESS: Address = address(
   'Sysvar1nstructions1111111111111111111111111',
 );

--- a/src/solana/cosignerHook/constants.ts
+++ b/src/solana/cosignerHook/constants.ts
@@ -1,6 +1,17 @@
-import { COSIGNER_HOOK_PROGRAM_ADDRESS } from '../generated/cosignerHook/programs/index.js';
+import { address, type Address } from '@solana/kit';
 
-export const COSIGNER_HOOK_PROGRAM_ID = COSIGNER_HOOK_PROGRAM_ADDRESS;
+/**
+ * Default Doppler native cosigner hook program for devnet deployments.
+ *
+ * The generated COSIGNER_HOOK_PROGRAM_ADDRESS reflects the IDL's generic
+ * cosigner hook deployment. Pass an explicit programAddress to generated
+ * instructions when targeting a custom/integrator hook deployment.
+ */
+export const DOPPLER_NATIVE_COSIGNER_HOOK_PROGRAM_ID: Address = address(
+  '5iWYdN9SEDeF3FTjKB48XYyCFAcVDuYHsz31Z4Wmq7Ch',
+);
+
+export const COSIGNER_HOOK_PROGRAM_ID = DOPPLER_NATIVE_COSIGNER_HOOK_PROGRAM_ID;
 
 export const SEED_COSIGNER_HOOK_CONFIG = 'cosigner_hook_config';
 export const MAX_COSIGNERS = 32;

--- a/src/solana/cosignerHook/gate.ts
+++ b/src/solana/cosignerHook/gate.ts
@@ -3,8 +3,10 @@ import {
   getAddressEncoder,
   type Address,
   type ReadonlyUint8Array,
+  type TransactionSigner,
 } from '@solana/kit';
 
+import { computeRemainingAccountsHash } from '../initializer/helpers.js';
 import {
   GATE_EXPIRY_DISABLED,
   GATE_EXPIRY_HEADER_LEN,
@@ -52,6 +54,12 @@ export type CosignerGateStatus = {
     | 'slot_unavailable'
     | 'invalid_expiry_payload'
     | 'invalid_expiry_mode';
+};
+
+export type CosignerHookRemainingAccounts = {
+  signedHookRemainingAccounts: [Address, TransactionSigner];
+  unsignedHookRemainingAccounts: [Address, Address];
+  hookRemainingAccountsHash: Uint8Array;
 };
 
 function toBigInt(value: bigint | number): bigint {
@@ -204,4 +212,25 @@ export function isCosignerGateEnforced(
   clock: CosignerGateClock = {},
 ): boolean {
   return getCosignerGateStatus(hookPayload, clock).gateEnforced;
+}
+
+export function getCosignerHookRemainingAccounts({
+  namespace,
+  cosigner,
+}: {
+  namespace: Address;
+  cosigner: TransactionSigner;
+}): CosignerHookRemainingAccounts {
+  const unsignedHookRemainingAccounts: [Address, Address] = [
+    namespace,
+    cosigner.address,
+  ];
+
+  return {
+    signedHookRemainingAccounts: [namespace, cosigner],
+    unsignedHookRemainingAccounts,
+    hookRemainingAccountsHash: computeRemainingAccountsHash(
+      unsignedHookRemainingAccounts,
+    ),
+  };
 }

--- a/src/solana/deployment.ts
+++ b/src/solana/deployment.ts
@@ -9,7 +9,7 @@ import {
   INITIALIZER_PROGRAM_ID,
   getConfigAddress as getInitializerConfigAddress,
 } from './initializer/index.js';
-import { COSIGNER_HOOK_PROGRAM_ID } from './cosignerHook/index.js';
+import { DOPPLER_NATIVE_COSIGNER_HOOK_PROGRAM_ID } from './cosignerHook/index.js';
 import { CPMM_MIGRATOR_PROGRAM_ID } from './migrators/cpmmMigrator/index.js';
 
 export interface SolanaCpmmProgramAddresses {
@@ -31,7 +31,7 @@ export const DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES: SolanaCpmmProgramAddresses
     initializerProgram: INITIALIZER_PROGRAM_ID,
     cpmmMigratorProgram: CPMM_MIGRATOR_PROGRAM_ID,
     cpmmHookProgram: CPMM_HOOK_PROGRAM_ID,
-    cosignerHookProgram: COSIGNER_HOOK_PROGRAM_ID,
+    cosignerHookProgram: DOPPLER_NATIVE_COSIGNER_HOOK_PROGRAM_ID,
   };
 
 export async function deriveSolanaCpmmDeployment(

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -11,6 +11,23 @@ export * as cpmmMigrator from './migrators/cpmmMigrator/index.js';
 export * as predictionMigrator from './migrators/predictionMigrator/index.js';
 export * as trustedOracle from './trustedOracle/index.js';
 
+export { createLaunch } from './initializer/createLaunch.js';
+export type {
+  CreateLaunchAccountSigners,
+  CreateLaunchAddresses,
+  CreateLaunchCpmmMigrationConfig,
+  CreateLaunchCustomMigrationConfig,
+  CreateLaunchHookMode,
+  CreateLaunchInput,
+  CreateLaunchMigrationConfig,
+  CreateLaunchResult,
+  DeriveCreateLaunchAddressesInput,
+  LaunchMetadata,
+  LaunchSupply,
+  LaunchTokenPrograms,
+  XykCurveConfig,
+} from './initializer/createLaunch.js';
+
 export {
   DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
   deriveSolanaCpmmDeployment,

--- a/src/solana/initializer/createLaunch.ts
+++ b/src/solana/initializer/createLaunch.ts
@@ -1,0 +1,720 @@
+import {
+  AccountRole,
+  type AccountMeta,
+  type AccountSignerMeta,
+  type Address,
+  type Instruction,
+  type ReadonlyUint8Array,
+  type TransactionSigner,
+} from '@solana/kit';
+import { findAssociatedTokenPda } from '@solana-program/token';
+import {
+  SYSVAR_RENT_ADDRESS,
+  SYSTEM_PROGRAM_ADDRESS,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
+  TOKEN_METADATA_PROGRAM_ID,
+} from '../core/constants.js';
+import {
+  DOPPLER_NATIVE_COSIGNER_HOOK_PROGRAM_ID,
+  GATE_EXPIRY_UNIX_TIMESTAMP,
+  encodeCosignerGateExpiryPayload,
+  getCosignerHookConfigAddress,
+} from '../cosignerHook/index.js';
+import type { SolanaCpmmDeployment } from '../deployment.js';
+import {
+  buildCpmmMigrationRemainingAccounts,
+  encodeMigratePayload,
+  encodeRegisterLaunchPayload,
+  type CpmmMigrationRemainingAccounts,
+  type MigratedPoolHookConfigArgs,
+  type RecipientArgs,
+} from '../migrators/cpmmMigrator/index.js';
+import { CPMM_MIGRATOR_PROGRAM_ID } from '../migrators/cpmmMigrator/constants.js';
+import { getCpmmMigratorStateAddress } from '../migrators/cpmmMigrator/pda.js';
+import {
+  CPMM_HOOK_PROGRAM_ID,
+  CURVE_KIND_XYK,
+  CURVE_PARAMS_FORMAT_XYK_V0,
+  EMPTY_REMAINING_ACCOUNTS_HASH,
+  HF_BEFORE_SWAP,
+  HF_FORWARD_READONLY_SIGNERS,
+  INITIALIZER_PROGRAM_ID,
+} from './constants.js';
+import {
+  createInitializeLaunchInstruction,
+  getTokenMetadataAddress,
+  type InitializeLaunchAccounts,
+  type InitializeLaunchParams,
+} from './instructions/initializeLaunch.js';
+import {
+  getConfigAddress,
+  getLaunchAddress,
+  getLaunchAuthorityAddress,
+  getLaunchFeeStateAddress,
+} from './pda.js';
+import { computeRemainingAccountsHash } from './helpers.js';
+
+type AddressOrSigner = InitializeLaunchAccounts['baseMint'];
+type RemainingAccount =
+  | Address
+  | AccountMeta
+  | AccountSignerMeta
+  | TransactionSigner;
+
+const DEFAULT_CPMM_MIGRATION_FEE_SPLIT_BPS = 10_000;
+
+export type LaunchTokenPrograms = {
+  baseTokenProgram: Address;
+  quoteTokenProgram: Address;
+};
+
+export type LaunchSupply = {
+  baseDecimals: number;
+  baseTotalSupply: bigint;
+  baseForDistribution: bigint;
+  baseForLiquidity: bigint;
+};
+
+export type XykCurveConfig = {
+  curveVirtualBase: bigint;
+  curveVirtualQuote: bigint;
+  swapFeeBps: number;
+};
+
+export type LaunchMetadata = {
+  metadataName: string;
+  metadataSymbol: string;
+  metadataUri: string;
+};
+
+export type CreateLaunchAccountSigners = {
+  baseMint: AddressOrSigner;
+  quoteMint: Address;
+  baseVault: AddressOrSigner;
+  quoteVault: AddressOrSigner;
+};
+
+export type CreateLaunchHookMode = 'cpmm' | 'cosigner' | false;
+
+export type CreateLaunchCpmmMigrationConfig = {
+  enabled?: true;
+  kind?: 'cpmm';
+  program?: Address;
+  cpmmProgram?: Address;
+  admin?: Address;
+  adminBaseAta?: Address;
+  adminQuoteAta?: Address;
+  recipientAtas?: ReadonlyArray<Address>;
+  recipients?: ReadonlyArray<RecipientArgs>;
+  minRaiseQuote?: number | bigint;
+  minMigrationPriceQ64Opt?: number | bigint | null;
+  migratedPoolHookConfig?: MigratedPoolHookConfigArgs | null;
+  initialSwapFeeBps?: number;
+  initialFeeSplitBps?: number;
+  baseForDistribution?: number | bigint;
+  baseForLiquidity?: number | bigint;
+};
+
+export type CreateLaunchCustomMigrationConfig = {
+  enabled?: true;
+  kind: 'custom';
+  program: Address;
+  initPayload?: ReadonlyUint8Array;
+  migratePayload?: ReadonlyUint8Array;
+  cpmmConfig?: Address;
+  initRemainingAccounts?: ReadonlyArray<RemainingAccount>;
+  initRemainingAccountsHash?: ReadonlyUint8Array;
+  remainingAccounts?: ReadonlyArray<RemainingAccount>;
+  remainingAccountsHash?: ReadonlyUint8Array;
+};
+
+export type CreateLaunchMigrationConfig =
+  | CreateLaunchCpmmMigrationConfig
+  | CreateLaunchCustomMigrationConfig;
+
+export type CreateLaunchAddresses = {
+  config: Address;
+  launch: Address;
+  launchAuthority: Address;
+  launchFeeState: Address;
+  metadataAccount?: Address;
+};
+
+export type DeriveCreateLaunchAddressesInput = {
+  deployment?: Pick<
+    SolanaCpmmDeployment,
+    'initializerConfig' | 'initializerProgram'
+  >;
+  programId?: Address;
+  config?: Address;
+  namespace: Address;
+  launchId: Uint8Array;
+  baseMint: AddressOrSigner;
+  metadata?: LaunchMetadata | null;
+  metadataAccount?: Address;
+};
+
+export type CreateLaunchInput = {
+  deployment?: Pick<
+    SolanaCpmmDeployment,
+    'initializerConfig' | 'initializerProgram'
+  > &
+    Partial<
+      Pick<
+        SolanaCpmmDeployment,
+        | 'cpmmMigratorProgram'
+        | 'cpmmProgram'
+        | 'cpmmHookProgram'
+        | 'cosignerHookProgram'
+      >
+    >;
+  programId?: Address;
+  config?: Address;
+  namespace?: Address;
+  launchId?: Uint8Array;
+  addresses?: CreateLaunchAddresses;
+  launchAccounts: CreateLaunchAccountSigners;
+  payer: AddressOrSigner;
+  authority?: AddressOrSigner;
+  supply: LaunchSupply;
+  curve: XykCurveConfig;
+  tokenPrograms?: Partial<LaunchTokenPrograms>;
+  hook?: CreateLaunchHookMode | null;
+  cosigner?: AddressOrSigner;
+  cosignGateExpiresAt?: bigint | number | null;
+  migration?: boolean | CreateLaunchMigrationConfig | null;
+  metadata?: LaunchMetadata | null;
+  feeBeneficiaries?: InitializeLaunchParams['feeBeneficiaries'];
+  allowBuy?: boolean;
+  allowSell?: boolean;
+  systemProgram?: Address;
+  rent?: Address;
+  metadataProgram?: Address;
+};
+
+export type CreateLaunchResult = {
+  namespace: Address;
+  launchId: Uint8Array;
+  addresses: CreateLaunchAddresses;
+  instruction: Instruction;
+  cpmmMigration?: CpmmMigrationRemainingAccounts;
+};
+
+type ResolvedCreateLaunchMigration = {
+  program: Address;
+  initPayload?: ReadonlyUint8Array;
+  migratePayload?: ReadonlyUint8Array;
+  cpmmConfig?: Address;
+  initRemainingAccounts?: ReadonlyArray<RemainingAccount>;
+  initRemainingAccountsHash?: ReadonlyUint8Array;
+  remainingAccounts?: ReadonlyArray<RemainingAccount>;
+  remainingAccountsHash?: ReadonlyUint8Array;
+  cpmmMigration?: CpmmMigrationRemainingAccounts;
+};
+
+type CreateLaunchHookContext = {
+  mode: CreateLaunchHookMode;
+  cosignerConfig?: Address;
+};
+
+type ResolvedCreateLaunchHook = {
+  program?: Address;
+  flags: number;
+  payload?: ReadonlyUint8Array;
+  remainingAccounts?: ReadonlyArray<RemainingAccount>;
+  remainingAccountsHash: ReadonlyUint8Array;
+};
+
+let launchIdCounter = 0n;
+
+export const launchTokenPrograms = {
+  splToken(): LaunchTokenPrograms {
+    return {
+      baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
+      quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
+    };
+  },
+  token2022Base(): LaunchTokenPrograms {
+    return {
+      baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+      quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
+    };
+  },
+} as const;
+
+export function createLaunchId(): Uint8Array {
+  const bytes = new Uint8Array(32);
+  const view = new DataView(bytes.buffer);
+  view.setBigUint64(0, BigInt(Date.now()), true);
+  view.setBigUint64(8, launchIdCounter, true);
+  launchIdCounter += 1n;
+  bytes.set([0x44, 0x4f, 0x50, 0x4c], 28);
+  return bytes;
+}
+
+function isTransactionSigner(value: unknown): value is TransactionSigner {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'address' in value &&
+    'signTransactions' in value
+  );
+}
+
+function getAccountAddress(account: RemainingAccount): Address {
+  if (typeof account === 'string') {
+    return account;
+  }
+  return account.address;
+}
+
+function getSignerAddress(value: AddressOrSigner): Address {
+  return isTransactionSigner(value) ? value.address : value;
+}
+
+function getRemainingAccountMeta(
+  account: RemainingAccount,
+): AccountMeta | AccountSignerMeta {
+  if (typeof account === 'string') {
+    return { address: account, role: AccountRole.READONLY };
+  }
+  if (isTransactionSigner(account)) {
+    return {
+      address: account.address,
+      role: AccountRole.READONLY_SIGNER,
+      signer: account,
+    };
+  }
+  return account;
+}
+
+function hasMetadata(metadata: LaunchMetadata | null | undefined): boolean {
+  return Boolean(metadata?.metadataName);
+}
+
+function getInitializerProgramId(
+  input: Pick<CreateLaunchInput, 'deployment' | 'programId'>,
+): Address {
+  return (
+    input.programId ??
+    input.deployment?.initializerProgram ??
+    INITIALIZER_PROGRAM_ID
+  );
+}
+
+function getInitializerConfig(
+  input: Pick<CreateLaunchInput, 'deployment' | 'config'>,
+): Address | undefined {
+  return input.config ?? input.deployment?.initializerConfig;
+}
+
+function hashRemainingAccounts(
+  accounts: ReadonlyArray<RemainingAccount> | undefined,
+): Uint8Array | undefined {
+  if (!accounts) {
+    return undefined;
+  }
+  return computeRemainingAccountsHash(accounts.map(getAccountAddress));
+}
+
+function isCustomMigrationConfig(
+  migration: CreateLaunchMigrationConfig,
+): migration is CreateLaunchCustomMigrationConfig {
+  return migration.kind === 'custom';
+}
+
+function getCreateLaunchHookMode(
+  input: CreateLaunchInput,
+): CreateLaunchHookMode {
+  if (input.hook !== undefined && input.hook !== null) {
+    return input.hook;
+  }
+  return input.cosigner ? 'cosigner' : 'cpmm';
+}
+
+async function getCreateLaunchHookContext(
+  input: CreateLaunchInput,
+): Promise<CreateLaunchHookContext> {
+  const mode = getCreateLaunchHookMode(input);
+  if (mode !== 'cosigner') {
+    return { mode };
+  }
+  const [cosignerConfig] = await getCosignerHookConfigAddress(
+    input.deployment?.cosignerHookProgram ??
+      DOPPLER_NATIVE_COSIGNER_HOOK_PROGRAM_ID,
+  );
+  return { mode, cosignerConfig };
+}
+
+function getCosignerHookRemainingAccounts({
+  namespace,
+  cosigner,
+  cosignerConfig,
+}: {
+  namespace: Address;
+  cosigner: AddressOrSigner;
+  cosignerConfig: Address;
+}): RemainingAccount[] {
+  const accounts: RemainingAccount[] =
+    namespace === cosignerConfig
+      ? [cosignerConfig]
+      : [namespace, cosignerConfig];
+  accounts.push(cosigner);
+  return accounts;
+}
+
+function resolveCosignerHookPayload(
+  input: CreateLaunchInput,
+): ReadonlyUint8Array {
+  if (
+    input.cosignGateExpiresAt === undefined ||
+    input.cosignGateExpiresAt === null
+  ) {
+    return new Uint8Array();
+  }
+  if (!input.cosigner) {
+    throw new Error('cosigner is required when cosignGateExpiresAt is set');
+  }
+  return encodeCosignerGateExpiryPayload({
+    mode: GATE_EXPIRY_UNIX_TIMESTAMP,
+    value: input.cosignGateExpiresAt,
+    cosigner: getSignerAddress(input.cosigner),
+  });
+}
+
+function resolveCreateLaunchHook({
+  input,
+  namespace,
+  hookContext,
+}: {
+  input: CreateLaunchInput;
+  namespace: Address;
+  hookContext: CreateLaunchHookContext;
+}): ResolvedCreateLaunchHook {
+  if (hookContext.mode === false) {
+    return {
+      flags: 0,
+      remainingAccountsHash: EMPTY_REMAINING_ACCOUNTS_HASH,
+    };
+  }
+  if (hookContext.mode === 'cosigner') {
+    if (!input.cosigner) {
+      throw new Error('cosigner is required when hook is "cosigner"');
+    }
+    if (!hookContext.cosignerConfig) {
+      throw new Error('cosigner hook config could not be derived');
+    }
+    const remainingAccounts = getCosignerHookRemainingAccounts({
+      namespace,
+      cosigner: input.cosigner,
+      cosignerConfig: hookContext.cosignerConfig,
+    });
+    return {
+      program:
+        input.deployment?.cosignerHookProgram ??
+        DOPPLER_NATIVE_COSIGNER_HOOK_PROGRAM_ID,
+      flags: HF_BEFORE_SWAP | HF_FORWARD_READONLY_SIGNERS,
+      payload: resolveCosignerHookPayload(input),
+      remainingAccounts,
+      remainingAccountsHash:
+        hashRemainingAccounts(remainingAccounts) ??
+        EMPTY_REMAINING_ACCOUNTS_HASH,
+    };
+  }
+  return {
+    program: input.deployment?.cpmmHookProgram ?? CPMM_HOOK_PROGRAM_ID,
+    flags: HF_BEFORE_SWAP,
+    payload: new Uint8Array(),
+    remainingAccountsHash: EMPTY_REMAINING_ACCOUNTS_HASH,
+  };
+}
+
+async function getAssociatedTokenAddress({
+  owner,
+  mint,
+  tokenProgram,
+}: {
+  owner: Address;
+  mint: Address;
+  tokenProgram: Address;
+}): Promise<Address> {
+  const [ata] = await findAssociatedTokenPda({
+    owner,
+    mint,
+    tokenProgram,
+  });
+  return ata;
+}
+
+async function resolveCreateLaunchMigration({
+  addresses,
+  input,
+  tokenPrograms,
+}: {
+  addresses: CreateLaunchAddresses;
+  input: CreateLaunchInput;
+  tokenPrograms: LaunchTokenPrograms;
+}): Promise<ResolvedCreateLaunchMigration | null> {
+  const migration = input.migration === undefined ? true : input.migration;
+  if (migration === false || migration === null) {
+    return null;
+  }
+
+  const cpmmMigratorProgram =
+    input.deployment?.cpmmMigratorProgram ?? CPMM_MIGRATOR_PROGRAM_ID;
+  if (migration !== true && isCustomMigrationConfig(migration)) {
+    if (!migration.program) {
+      throw new Error('custom launch migration requires a migrator program');
+    }
+    return migration;
+  }
+
+  const cpmmMigration = migration === true ? {} : migration;
+  const admin = cpmmMigration.admin ?? getSignerAddress(input.payer);
+  const baseMint = getSignerAddress(input.launchAccounts.baseMint);
+  const adminBaseAta =
+    cpmmMigration.adminBaseAta ??
+    (await getAssociatedTokenAddress({
+      owner: admin,
+      mint: baseMint,
+      tokenProgram: tokenPrograms.baseTokenProgram,
+    }));
+  const adminQuoteAta =
+    cpmmMigration.adminQuoteAta ??
+    (await getAssociatedTokenAddress({
+      owner: admin,
+      mint: input.launchAccounts.quoteMint,
+      tokenProgram: tokenPrograms.quoteTokenProgram,
+    }));
+  const recipients = [...(cpmmMigration.recipients ?? [])];
+  const recipientAtas =
+    cpmmMigration.recipientAtas ??
+    (await Promise.all(
+      recipients.map(({ wallet }) =>
+        getAssociatedTokenAddress({
+          owner: wallet,
+          mint: baseMint,
+          tokenProgram: tokenPrograms.baseTokenProgram,
+        }),
+      ),
+    ));
+  const migrationAccounts = await buildCpmmMigrationRemainingAccounts({
+    launch: addresses.launch,
+    baseMint,
+    quoteMint: input.launchAccounts.quoteMint,
+    launchAuthority: addresses.launchAuthority,
+    adminBaseAta,
+    adminQuoteAta,
+    recipientAtas: [...recipientAtas],
+    cpmmProgram: cpmmMigration.cpmmProgram ?? input.deployment?.cpmmProgram,
+    cpmmMigratorProgram: cpmmMigration.program ?? cpmmMigratorProgram,
+  });
+  const initPayload = encodeRegisterLaunchPayload({
+    cpmmConfig: migrationAccounts.cpmmConfig,
+    initialSwapFeeBps:
+      cpmmMigration.initialSwapFeeBps ?? input.curve.swapFeeBps,
+    initialFeeSplitBps:
+      cpmmMigration.initialFeeSplitBps ?? DEFAULT_CPMM_MIGRATION_FEE_SPLIT_BPS,
+    recipients,
+    minRaiseQuote: cpmmMigration.minRaiseQuote ?? 0n,
+    minMigrationPriceQ64Opt: cpmmMigration.minMigrationPriceQ64Opt ?? null,
+    migratedPoolHookConfig: cpmmMigration.migratedPoolHookConfig ?? null,
+  });
+  const migratePayload = encodeMigratePayload({
+    baseForDistribution:
+      cpmmMigration.baseForDistribution ?? input.supply.baseForDistribution,
+    baseForLiquidity:
+      cpmmMigration.baseForLiquidity ?? input.supply.baseForLiquidity,
+  });
+
+  return {
+    program: cpmmMigration.program ?? cpmmMigratorProgram,
+    initPayload,
+    migratePayload,
+    cpmmConfig: migrationAccounts.cpmmConfig,
+    remainingAccounts: migrationAccounts.addresses,
+    remainingAccountsHash: migrationAccounts.hash,
+    cpmmMigration: migrationAccounts,
+  };
+}
+
+export async function deriveCreateLaunchAddresses(
+  input: DeriveCreateLaunchAddressesInput,
+): Promise<CreateLaunchAddresses> {
+  const programId =
+    input.programId ??
+    input.deployment?.initializerProgram ??
+    INITIALIZER_PROGRAM_ID;
+  const config =
+    input.config ??
+    input.deployment?.initializerConfig ??
+    (await getConfigAddress(programId))[0];
+  const [launch] = await getLaunchAddress(
+    input.namespace,
+    input.launchId,
+    programId,
+  );
+  const [launchAuthority] = await getLaunchAuthorityAddress(launch, programId);
+  const [launchFeeState] = await getLaunchFeeStateAddress(launch, programId);
+  const metadataAccount = hasMetadata(input.metadata)
+    ? (input.metadataAccount ??
+      (await getTokenMetadataAddress(getSignerAddress(input.baseMint))))
+    : input.metadataAccount;
+
+  return {
+    config,
+    launch,
+    launchAuthority,
+    launchFeeState,
+    metadataAccount,
+  };
+}
+
+async function getMigrationInitRemainingAccountsHash({
+  launch,
+  migration,
+}: {
+  launch: Address;
+  migration: ResolvedCreateLaunchMigration | null | undefined;
+}): Promise<ReadonlyUint8Array> {
+  if (!migration) {
+    return EMPTY_REMAINING_ACCOUNTS_HASH;
+  }
+  if (migration.initRemainingAccountsHash) {
+    return migration.initRemainingAccountsHash;
+  }
+  const initHash = hashRemainingAccounts(migration.initRemainingAccounts);
+  if (initHash) {
+    return initHash;
+  }
+  if (migration.cpmmConfig) {
+    const migratorProgram = migration.program ?? CPMM_MIGRATOR_PROGRAM_ID;
+    const [cpmmMigrationState] = await getCpmmMigratorStateAddress(
+      launch,
+      migratorProgram,
+    );
+    return computeRemainingAccountsHash([
+      cpmmMigrationState,
+      migration.cpmmConfig,
+    ]);
+  }
+  return EMPTY_REMAINING_ACCOUNTS_HASH;
+}
+
+export async function createLaunch(
+  input: CreateLaunchInput,
+): Promise<CreateLaunchResult> {
+  const programId = getInitializerProgramId(input);
+  const launchId = input.launchId ?? createLaunchId();
+  const hookContext = await getCreateLaunchHookContext(input);
+  const namespace =
+    input.namespace ??
+    hookContext.cosignerConfig ??
+    getSignerAddress(input.payer);
+  const tokenPrograms = {
+    ...launchTokenPrograms.splToken(),
+    ...input.tokenPrograms,
+  };
+  const addresses =
+    input.addresses ??
+    (await deriveCreateLaunchAddresses({
+      deployment: input.deployment,
+      programId,
+      config: getInitializerConfig(input),
+      namespace,
+      launchId,
+      baseMint: input.launchAccounts.baseMint,
+      metadata: input.metadata,
+    }));
+  const migration = await resolveCreateLaunchMigration({
+    addresses,
+    input,
+    tokenPrograms,
+  });
+  const hook = resolveCreateLaunchHook({
+    input,
+    namespace,
+    hookContext,
+  });
+  const migratorInitRemainingAccountsHash =
+    await getMigrationInitRemainingAccountsHash({
+      launch: addresses.launch,
+      migration,
+    });
+  const migratorRemainingAccountsHash =
+    migration?.remainingAccountsHash ??
+    hashRemainingAccounts(migration?.remainingAccounts) ??
+    EMPTY_REMAINING_ACCOUNTS_HASH;
+
+  const instruction = await createInitializeLaunchInstruction(
+    {
+      config: addresses.config,
+      launch: addresses.launch,
+      launchAuthority: addresses.launchAuthority,
+      baseMint: input.launchAccounts.baseMint,
+      quoteMint: input.launchAccounts.quoteMint,
+      baseVault: input.launchAccounts.baseVault,
+      quoteVault: input.launchAccounts.quoteVault,
+      launchFeeState: addresses.launchFeeState,
+      payer: input.payer,
+      authority: input.authority,
+      hookProgram: hook.program,
+      migratorProgram: migration?.program,
+      cpmmConfig: migration?.cpmmConfig,
+      baseTokenProgram: tokenPrograms.baseTokenProgram,
+      quoteTokenProgram: tokenPrograms.quoteTokenProgram,
+      systemProgram: input.systemProgram ?? SYSTEM_PROGRAM_ADDRESS,
+      rent: input.rent ?? SYSVAR_RENT_ADDRESS,
+      metadataAccount: addresses.metadataAccount,
+      metadataProgram: input.metadataProgram ?? TOKEN_METADATA_PROGRAM_ID,
+    },
+    {
+      namespace,
+      launchId,
+      baseDecimals: input.supply.baseDecimals,
+      baseTotalSupply: input.supply.baseTotalSupply,
+      baseForDistribution: input.supply.baseForDistribution,
+      baseForLiquidity: input.supply.baseForLiquidity,
+      curveVirtualBase: input.curve.curveVirtualBase,
+      curveVirtualQuote: input.curve.curveVirtualQuote,
+      swapFeeBps: input.curve.swapFeeBps,
+      curveKind: CURVE_KIND_XYK,
+      curveParams: new Uint8Array([CURVE_PARAMS_FORMAT_XYK_V0]),
+      allowBuy: input.allowBuy ?? true,
+      allowSell: input.allowSell ?? true,
+      hookFlags: hook.flags,
+      hookPayload: hook.payload ?? new Uint8Array(),
+      migratorInitPayload: migration?.initPayload ?? new Uint8Array(),
+      migratorMigratePayload: migration?.migratePayload ?? new Uint8Array(),
+      hookRemainingAccountsHash: hook.remainingAccountsHash,
+      migratorInitRemainingAccountsHash,
+      migratorRemainingAccountsHash,
+      feeBeneficiaries: input.feeBeneficiaries ?? [],
+      metadataName: input.metadata?.metadataName ?? '',
+      metadataSymbol: input.metadata?.metadataSymbol ?? '',
+      metadataUri: input.metadata?.metadataUri ?? '',
+    },
+    programId,
+  );
+
+  const preparedInstruction = migration?.initRemainingAccounts
+    ? {
+        ...instruction,
+        accounts: [
+          ...(instruction.accounts ?? []),
+          ...(migration?.initRemainingAccounts ?? []).map(
+            getRemainingAccountMeta,
+          ),
+        ],
+      }
+    : instruction;
+
+  return {
+    namespace,
+    launchId,
+    addresses,
+    instruction: preparedInstruction,
+    cpmmMigration: migration?.cpmmMigration,
+  };
+}

--- a/src/solana/initializer/helpers.ts
+++ b/src/solana/initializer/helpers.ts
@@ -1,5 +1,7 @@
 import { getAddressEncoder, type Address } from '@solana/kit';
 import { keccak_256 } from '@noble/hashes/sha3.js';
+import { BPS_DENOM } from '../core/constants.js';
+import { ceilDiv } from '../core/math.js';
 import { PHASE_TRADING, PHASE_MIGRATED, PHASE_ABORTED } from './constants.js';
 
 /**
@@ -25,6 +27,30 @@ export function computeRemainingAccountsHash(addresses: Address[]): Uint8Array {
     buf.set(addressEncoder.encode(addresses[i]), 4 + i * 32);
   }
   return keccak_256(buf);
+}
+
+/**
+ * Compute the fee charged by initializer bonding-curve exact-in swaps.
+ *
+ * The initializer program rounds swap fees up, so small non-zero trades with a
+ * non-zero fee rate still pay at least one atom.
+ */
+export function getCurveSwapFeeAmount(
+  amountIn: bigint,
+  swapFeeBps: number,
+): bigint {
+  if (amountIn < 0n) {
+    throw new Error('amountIn must be non-negative');
+  }
+  if (
+    !Number.isInteger(swapFeeBps) ||
+    swapFeeBps < 0 ||
+    swapFeeBps > Number(BPS_DENOM)
+  ) {
+    throw new Error('swapFeeBps must be an integer from 0 to 10000');
+  }
+
+  return ceilDiv(amountIn * BigInt(swapFeeBps), BPS_DENOM);
 }
 
 /**

--- a/src/solana/initializer/index.ts
+++ b/src/solana/initializer/index.ts
@@ -113,7 +113,11 @@ export {
 } from './instructions/index.js';
 
 // Helpers
-export { computeRemainingAccountsHash, phaseLabel } from './helpers.js';
+export {
+  computeRemainingAccountsHash,
+  getCurveSwapFeeAmount,
+  phaseLabel,
+} from './helpers.js';
 export {
   DEFAULT_LOOKUP_TABLE_ADDRESSES_PER_EXTEND,
   getInstructionLookupTableAddresses,

--- a/src/solana/initializer/index.ts
+++ b/src/solana/initializer/index.ts
@@ -112,6 +112,28 @@ export {
   type PreviewMigrationResult,
 } from './instructions/index.js';
 
+// High-level launch helpers
+export {
+  createLaunchId,
+  deriveCreateLaunchAddresses,
+  launchTokenPrograms,
+} from './createLaunch.js';
+export type {
+  CreateLaunchAccountSigners,
+  CreateLaunchAddresses,
+  CreateLaunchCpmmMigrationConfig,
+  CreateLaunchCustomMigrationConfig,
+  CreateLaunchHookMode,
+  CreateLaunchInput,
+  CreateLaunchMigrationConfig,
+  CreateLaunchResult,
+  DeriveCreateLaunchAddressesInput,
+  LaunchMetadata,
+  LaunchSupply,
+  LaunchTokenPrograms,
+  XykCurveConfig,
+} from './createLaunch.js';
+
 // Helpers
 export {
   computeRemainingAccountsHash,

--- a/src/solana/initializer/instructions/initializeLaunch.ts
+++ b/src/solana/initializer/instructions/initializeLaunch.ts
@@ -13,6 +13,8 @@ import {
 } from '@solana/kit';
 import {
   SYSTEM_PROGRAM_ADDRESS,
+  SYSVAR_INSTRUCTIONS_ADDRESS,
+  TOKEN_2022_PROGRAM_ADDRESS,
   TOKEN_PROGRAM_ADDRESS,
   TOKEN_METADATA_PROGRAM_ID,
 } from '../../core/constants.js';
@@ -191,6 +193,8 @@ export async function createInitializeLaunchInstruction(
   const withMetadata = Boolean(
     args.metadataName && args.metadataName.length > 0,
   );
+  const withToken2022Metadata =
+    withMetadata && baseTokenProgram === TOKEN_2022_PROGRAM_ADDRESS;
 
   if (withMetadata && !metadataAccount) {
     throw new Error(
@@ -273,6 +277,13 @@ export async function createInitializeLaunchInstruction(
   const data = new Uint8Array(
     getInitializeLaunchInstructionDataEncoder().encode(encoderArgs),
   );
+
+  if (withToken2022Metadata) {
+    keys.push({
+      address: SYSVAR_INSTRUCTIONS_ADDRESS,
+      role: AccountRole.READONLY,
+    });
+  }
 
   keys.push(
     ...hookCreateRemainingAccounts.map((account) =>

--- a/src/solana/migrators/cpmmMigrator/index.ts
+++ b/src/solana/migrators/cpmmMigrator/index.ts
@@ -21,6 +21,8 @@ export type {
   RecipientArgs,
   RegisterLaunchArgs,
   RegisterLaunchArgsArgs,
+  MigratedPoolHookConfig,
+  MigratedPoolHookConfigArgs,
   MigrateArgs,
   MigrateArgsArgs,
   CpmmMigratorState,

--- a/src/solana/migrators/cpmmMigrator/remainingAccounts.ts
+++ b/src/solana/migrators/cpmmMigrator/remainingAccounts.ts
@@ -30,6 +30,9 @@ export interface CpmmMigrationRemainingAccounts {
   hash: Uint8Array;
   cpmmMigrationState: Address;
   cpmmConfig: Address;
+  adminBaseAta: Address;
+  adminQuoteAta: Address;
+  recipientAtas: Address[];
   pool: Address;
   poolAuthority: Address;
   poolVault0: Address;
@@ -107,6 +110,9 @@ export async function buildCpmmMigrationRemainingAccounts({
     ],
     cpmmMigrationState,
     cpmmConfig: poolInit.config[0],
+    adminBaseAta,
+    adminQuoteAta,
+    recipientAtas,
     pool,
     poolAuthority: poolInit.authority[0],
     poolVault0: poolInit.vault0[0],

--- a/test/solana/deployment.test.ts
+++ b/test/solana/deployment.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { address } from '@solana/kit';
 
 import {
+  cosignerHook,
   cpmm,
   cpmmMigrator,
   DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
@@ -23,6 +24,9 @@ describe('Solana deployment helpers', () => {
     const deployment = await deriveSolanaCpmmDeployment();
 
     expect(deployment).toMatchObject(DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES);
+    expect(deployment.cosignerHookProgram).toBe(
+      cosignerHook.DOPPLER_NATIVE_COSIGNER_HOOK_PROGRAM_ID,
+    );
     expect(deployment.cpmmConfig).toBeDefined();
     expect(deployment.initializerConfig).toBeDefined();
   });

--- a/test/solana/unit/cosignerHook/gate.test.ts
+++ b/test/solana/unit/cosignerHook/gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Address } from '@solana/kit';
-import { cosignerHook } from '@/solana/index.js';
+import { generateKeyPairSigner } from '@solana/signers';
+import { cosignerHook, initializer } from '@/solana/index.js';
 
 describe('cosignerHook gate payload helpers', () => {
   const cosigner = 'So11111111111111111111111111111111111111112' as Address;
@@ -142,5 +143,25 @@ describe('cosignerHook gate payload helpers', () => {
         cosigner,
       }),
     ).toThrow(/Cosigner hint cannot be encoded/);
+  });
+
+  it('builds cosigner hook remaining accounts and commitment hash', async () => {
+    const signer = await generateKeyPairSigner();
+    const remainingAccounts = cosignerHook.getCosignerHookRemainingAccounts({
+      namespace: cosigner,
+      cosigner: signer,
+    });
+
+    expect(remainingAccounts.signedHookRemainingAccounts).toEqual([
+      cosigner,
+      signer,
+    ]);
+    expect(remainingAccounts.unsignedHookRemainingAccounts).toEqual([
+      cosigner,
+      signer.address,
+    ]);
+    expect(remainingAccounts.hookRemainingAccountsHash).toEqual(
+      initializer.computeRemainingAccountsHash([cosigner, signer.address]),
+    );
   });
 });

--- a/test/solana/unit/initializer/instruction.test.ts
+++ b/test/solana/unit/initializer/instruction.test.ts
@@ -4,7 +4,12 @@ import { generateKeyPairSigner } from '@solana/signers';
 import { AccountRole } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
-import { initializer, cpmmMigrator } from '@/solana/index.js';
+import {
+  createLaunch,
+  initializer,
+  cpmmMigrator,
+  cosignerHook,
+} from '@/solana/index.js';
 import {
   SYSVAR_INSTRUCTIONS_ADDRESS,
   TOKEN_2022_PROGRAM_ADDRESS,
@@ -256,6 +261,209 @@ describe('initializer instructions', () => {
     expect(ix.accounts![19].address).toBe(expectedCpmmMigratorState);
     expect(ix.accounts![20].address).toBe(cpmmConfig);
   });
+
+  it('prepares initializeLaunch from launch domain inputs', async () => {
+    const baseMint = await generateKeyPairSigner();
+    const baseVault = await generateKeyPairSigner();
+    const quoteVault = await generateKeyPairSigner();
+    const admin = await generateKeyPairSigner();
+
+    const quoteMint = address('DtCGbAhmf5R6Fjuo3zJqCS9Ep5wePTmxHzK8ri8E5nhb');
+    const namespace = admin.address;
+    const launchId = initializer.launchIdFromU64(4n);
+    const [config] = await initializer.getConfigAddress();
+    const [expectedLaunch] = await initializer.getLaunchAddress(
+      namespace,
+      launchId,
+    );
+    const [expectedLaunchAuthority] =
+      await initializer.getLaunchAuthorityAddress(expectedLaunch);
+    const [expectedLaunchFeeState] =
+      await initializer.getLaunchFeeStateAddress(expectedLaunch);
+    const expectedMetadataAccount = await initializer.getTokenMetadataAddress(
+      baseMint.address,
+    );
+    const [expectedCpmmMigratorState] =
+      await cpmmMigrator.getCpmmMigratorStateAddress(expectedLaunch);
+
+    const prepared = await createLaunch({
+      deployment: {
+        initializerConfig: config,
+        initializerProgram: initializer.INITIALIZER_PROGRAM_ID,
+      },
+      namespace,
+      launchId,
+      launchAccounts: {
+        baseMint,
+        quoteMint,
+        baseVault,
+        quoteVault,
+      },
+      payer: admin,
+      authority: admin,
+      supply: {
+        baseDecimals: 6,
+        baseTotalSupply: 1_000_000n,
+        baseForDistribution: 700_000n,
+        baseForLiquidity: 300_000n,
+      },
+      curve: {
+        curveVirtualBase: 200_000n,
+        curveVirtualQuote: 200_000n,
+        swapFeeBps: 100,
+      },
+      tokenPrograms: initializer.launchTokenPrograms.token2022Base(),
+      metadata: {
+        metadataName: 'Token',
+        metadataSymbol: 'TKN',
+        metadataUri: 'https://example.com/token.json',
+      },
+      feeBeneficiaries: [{ wallet: admin.address, shareBps: 10_000 }],
+    });
+
+    expect(prepared.namespace).toBe(namespace);
+    expect(prepared.launchId).toBe(launchId);
+    expect(prepared.addresses).toEqual({
+      config,
+      launch: expectedLaunch,
+      launchAuthority: expectedLaunchAuthority,
+      launchFeeState: expectedLaunchFeeState,
+      metadataAccount: expectedMetadataAccount,
+    });
+    expect(prepared.cpmmMigration).toBeDefined();
+
+    const ix = prepared.instruction;
+    expect(ix.programAddress).toBe(initializer.INITIALIZER_PROGRAM_ID);
+    expect(ix.accounts).toHaveLength(21);
+    expect(ix.accounts![0].address).toBe(config);
+    expect(ix.accounts![1].address).toBe(expectedLaunch);
+    expect(ix.accounts![2].address).toBe(expectedLaunchAuthority);
+    expect(ix.accounts![3].address).toBe(baseMint.address);
+    expect(ix.accounts![4].address).toBe(quoteMint);
+    expect(ix.accounts![5].address).toBe(baseVault.address);
+    expect(ix.accounts![6].address).toBe(quoteVault.address);
+    expect(ix.accounts![7].address).toBe(expectedLaunchFeeState);
+    expect(ix.accounts![10].address).toBe(initializer.CPMM_HOOK_PROGRAM_ID);
+    expect(ix.accounts![11].address).toBe(
+      cpmmMigrator.CPMM_MIGRATOR_PROGRAM_ID,
+    );
+    expect(ix.accounts![12].address).toBe(TOKEN_2022_PROGRAM_ADDRESS);
+    expect(ix.accounts![13].address).toBe(TOKEN_PROGRAM_ADDRESS);
+    expect(ix.accounts![16].address).toBe(expectedMetadataAccount);
+    expect(ix.accounts![17].address).toBe(TOKEN_METADATA_PROGRAM_ID);
+    expect(ix.accounts![18].address).toBe(SYSVAR_INSTRUCTIONS_ADDRESS);
+    expect(ix.accounts![19].address).toBe(expectedCpmmMigratorState);
+    expect(ix.accounts![20].address).toBe(prepared.cpmmMigration!.cpmmConfig);
+    expect(prepared.cpmmMigration!.cpmmMigrationState).toBe(
+      expectedCpmmMigratorState,
+    );
+    expect(prepared.cpmmMigration!.recipientAtas).toEqual([]);
+  });
+
+  it('uses the native cosigner hook when a cosigner is provided', async () => {
+    const baseMint = await generateKeyPairSigner();
+    const baseVault = await generateKeyPairSigner();
+    const quoteVault = await generateKeyPairSigner();
+    const admin = await generateKeyPairSigner();
+    const cosigner = await generateKeyPairSigner();
+
+    const quoteMint = address('DtCGbAhmf5R6Fjuo3zJqCS9Ep5wePTmxHzK8ri8E5nhb');
+    const launchId = initializer.launchIdFromU64(6n);
+    const [config] = await initializer.getConfigAddress();
+    const [cosignerConfig] = await cosignerHook.getCosignerHookConfigAddress();
+    const [expectedLaunch] = await initializer.getLaunchAddress(
+      cosignerConfig,
+      launchId,
+    );
+
+    const prepared = await createLaunch({
+      deployment: {
+        initializerConfig: config,
+        initializerProgram: initializer.INITIALIZER_PROGRAM_ID,
+      },
+      launchId,
+      launchAccounts: {
+        baseMint,
+        quoteMint,
+        baseVault,
+        quoteVault,
+      },
+      payer: admin,
+      authority: admin,
+      supply: {
+        baseDecimals: 6,
+        baseTotalSupply: 1_000_000n,
+        baseForDistribution: 0n,
+        baseForLiquidity: 0n,
+      },
+      curve: {
+        curveVirtualBase: 200_000n,
+        curveVirtualQuote: 200_000n,
+        swapFeeBps: 100,
+      },
+      cosigner,
+      metadata: null,
+    });
+
+    expect(prepared.namespace).toBe(cosignerConfig);
+    expect(prepared.addresses.launch).toBe(expectedLaunch);
+
+    const ix = prepared.instruction;
+    expect(ix.accounts).toHaveLength(20);
+    expect(ix.accounts![10].address).toBe(
+      cosignerHook.COSIGNER_HOOK_PROGRAM_ID,
+    );
+    expect(ix.accounts![11].address).toBe(
+      cpmmMigrator.CPMM_MIGRATOR_PROGRAM_ID,
+    );
+    expect(ix.accounts![18].address).toBe(
+      prepared.cpmmMigration!.cpmmMigrationState,
+    );
+    expect(ix.accounts![19].address).toBe(prepared.cpmmMigration!.cpmmConfig);
+  });
+
+  it('prepares initializeLaunch without a migrator when migration is disabled', async () => {
+    const baseMint = await generateKeyPairSigner();
+    const baseVault = await generateKeyPairSigner();
+    const quoteVault = await generateKeyPairSigner();
+    const admin = await generateKeyPairSigner();
+
+    const quoteMint = address('DtCGbAhmf5R6Fjuo3zJqCS9Ep5wePTmxHzK8ri8E5nhb');
+    const launchId = initializer.launchIdFromU64(5n);
+
+    const prepared = await createLaunch({
+      namespace: admin.address,
+      launchId,
+      launchAccounts: {
+        baseMint,
+        quoteMint,
+        baseVault,
+        quoteVault,
+      },
+      payer: admin,
+      authority: admin,
+      supply: {
+        baseDecimals: 6,
+        baseTotalSupply: 1_000_000n,
+        baseForDistribution: 0n,
+        baseForLiquidity: 0n,
+      },
+      curve: {
+        curveVirtualBase: 200_000n,
+        curveVirtualQuote: 200_000n,
+        swapFeeBps: 100,
+      },
+      hook: false,
+      migration: false,
+      metadata: null,
+    });
+
+    const ix = prepared.instruction;
+    expect(ix.accounts).toHaveLength(18);
+    expect(ix.accounts![10].address).toBe(initializer.INITIALIZER_PROGRAM_ID);
+    expect(ix.accounts![11].address).toBe(initializer.INITIALIZER_PROGRAM_ID);
+  });
+
   it('rejects initializeLaunch when curve kind is not currently enabled', async () => {
     const baseMint = await generateKeyPairSigner();
     const baseVault = await generateKeyPairSigner();

--- a/test/solana/unit/initializer/instruction.test.ts
+++ b/test/solana/unit/initializer/instruction.test.ts
@@ -208,6 +208,7 @@ describe('initializer instructions', () => {
         systemProgram: SYSTEM_PROGRAM_ADDRESS,
         rent: SYSVAR_RENT_PUBKEY,
         metadataAccount,
+        hookProgram: SYSTEM_PROGRAM_ADDRESS,
       },
       {
         namespace,
@@ -223,7 +224,6 @@ describe('initializer instructions', () => {
         curveParams: new Uint8Array([0]),
         allowBuy: true,
         allowSell: true,
-        hookProgram: SYSTEM_PROGRAM_ADDRESS,
         hookFlags: 0,
         hookPayload: new Uint8Array(),
         migratorInitPayload: cpmmMigrator.encodeRegisterLaunchPayload({
@@ -315,5 +315,18 @@ describe('initializer instructions', () => {
         },
       ),
     ).rejects.toThrow(/unsupported curve kind/);
+  });
+
+  it('computes initializer curve swap fees with ceil rounding', () => {
+    expect(initializer.getCurveSwapFeeAmount(0n, 30)).toBe(0n);
+    expect(initializer.getCurveSwapFeeAmount(1n, 30)).toBe(1n);
+    expect(initializer.getCurveSwapFeeAmount(333n, 30)).toBe(1n);
+    expect(initializer.getCurveSwapFeeAmount(10_001n, 30)).toBe(31n);
+    expect(() => initializer.getCurveSwapFeeAmount(-1n, 30)).toThrow(
+      /amountIn must be non-negative/,
+    );
+    expect(() => initializer.getCurveSwapFeeAmount(1n, 10_001)).toThrow(
+      /swapFeeBps must be an integer from 0 to 10000/,
+    );
   });
 });

--- a/test/solana/unit/initializer/instruction.test.ts
+++ b/test/solana/unit/initializer/instruction.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { address } from '@solana/addresses';
 import { generateKeyPairSigner } from '@solana/signers';
+import { AccountRole } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 import { initializer, cpmmMigrator } from '@/solana/index.js';
+import {
+  SYSVAR_INSTRUCTIONS_ADDRESS,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_METADATA_PROGRAM_ID,
+} from '@/solana/core/constants.js';
 
 const SYSVAR_RENT_PUBKEY = address(
   'SysvarRent111111111111111111111111111111111',
@@ -161,6 +167,95 @@ describe('initializer instructions', () => {
     }
   });
 
+  it('prepends the instructions sysvar for Token-2022 metadata without changing routed accounts', async () => {
+    const baseMint = await generateKeyPairSigner();
+    const baseVault = await generateKeyPairSigner();
+    const quoteVault = await generateKeyPairSigner();
+    const admin = await generateKeyPairSigner();
+
+    const quoteMint = address('DtCGbAhmf5R6Fjuo3zJqCS9Ep5wePTmxHzK8ri8E5nhb');
+    const metadataAccount = await initializer.getTokenMetadataAddress(
+      baseMint.address,
+    );
+    const namespace = admin.address;
+    const launchId = initializer.launchIdFromU64(3n);
+    const migratorProgram = cpmmMigrator.CPMM_MIGRATOR_PROGRAM_ID;
+    const cpmmConfig = address('E45nSdnfANtYhCy6qZXo2a7qAWCU6pYjpqsby1bbkaiL');
+
+    const [config] = await initializer.getConfigAddress();
+    const [launch] = await initializer.getLaunchAddress(namespace, launchId);
+    const [launchAuthority] =
+      await initializer.getLaunchAuthorityAddress(launch);
+    const [launchFeeState] = await initializer.getLaunchFeeStateAddress(launch);
+    const [expectedCpmmMigratorState] =
+      await cpmmMigrator.getCpmmMigratorStateAddress(launch);
+
+    const ix = await initializer.createInitializeLaunchInstruction(
+      {
+        config,
+        launch,
+        launchAuthority,
+        baseMint,
+        quoteMint,
+        baseVault,
+        quoteVault,
+        payer: admin,
+        authority: admin,
+        migratorProgram,
+        cpmmConfig,
+        baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
+        rent: SYSVAR_RENT_PUBKEY,
+        metadataAccount,
+      },
+      {
+        namespace,
+        launchId,
+        baseDecimals: 6,
+        baseTotalSupply: 1_000_000n,
+        baseForDistribution: 700_000n,
+        baseForLiquidity: 300_000n,
+        curveVirtualBase: 200_000n,
+        curveVirtualQuote: 200_000n,
+        curveFeeBps: 100,
+        curveKind: 0,
+        curveParams: new Uint8Array([0]),
+        allowBuy: true,
+        allowSell: true,
+        hookProgram: SYSTEM_PROGRAM_ADDRESS,
+        hookFlags: 0,
+        hookPayload: new Uint8Array(),
+        migratorInitPayload: cpmmMigrator.encodeRegisterLaunchPayload({
+          cpmmConfig,
+          initialSwapFeeBps: 30,
+          initialFeeSplitBps: 5000,
+          recipients: [],
+          minRaiseQuote: 500_000n,
+          minMigrationPriceQ64Opt: null,
+          migratedPoolHookConfig: null,
+        }),
+        migratorMigratePayload: cpmmMigrator.encodeMigratePayload({
+          baseForDistribution: 700_000n,
+          baseForLiquidity: 300_000n,
+        }),
+        hookRemainingAccountsHash: new Uint8Array(32),
+        migratorInitRemainingAccountsHash: new Uint8Array(32),
+        migratorRemainingAccountsHash: new Uint8Array(32),
+        metadataName: 'Token',
+        metadataSymbol: 'TKN',
+        metadataUri: 'https://example.com/token.json',
+      },
+    );
+
+    expect(ix.accounts).toHaveLength(21);
+    expect(ix.accounts![16].address).toBe(metadataAccount);
+    expect(ix.accounts![17].address).toBe(TOKEN_METADATA_PROGRAM_ID);
+    expect(ix.accounts![18].address).toBe(SYSVAR_INSTRUCTIONS_ADDRESS);
+    expect(ix.accounts![18].role).toBe(AccountRole.READONLY);
+    expect(ix.accounts![19].address).toBe(expectedCpmmMigratorState);
+    expect(ix.accounts![20].address).toBe(cpmmConfig);
+  });
   it('rejects initializeLaunch when curve kind is not currently enabled', async () => {
     const baseMint = await generateKeyPairSigner();
     const baseVault = await generateKeyPairSigner();


### PR DESCRIPTION
## Summary

- Centralize shared Solana example utilities for env parsing, signer loading, transaction sending/simulation, initialize-launch ALT setup, metadata size checks, cosigner validation, beneficiary parsing, token balance checks, and fee-aware migration threshold checks.
- Refactor tracked Solana examples to use the shared helpers, reducing duplicated transaction boilerplate while preserving existing flows and env names.
- Update Solana example docs and env comments to reflect the current WSOL, USDC, cosigner, prediction market, and swap examples.

## Tests

- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test:solana