### PR TITLE
feat: retrieve pending fees for multiple tokens for a beneficiary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Doppler SDK exposes network-specific entrypoints for creating, managing, and
 
 - **EVM Auctions**: Static auctions, dynamic auctions, and multicurve launches across Uniswap V3/V4 paths
 - **EVM Migration Paths**: Support for V2, V2 split, V4, V4 split, DopplerHook, and no-op migration
-- **EVM Multicurve Fees**: Pending-fee previews and beneficiary fee claiming for locked multicurve pools
+- **EVM Multicurve Fees**: Single-token and batched pending-fee previews plus beneficiary fee claiming for locked multicurve pools
 - **Solana Launches**: Initializer, CPMM, migrator, hook, oracle, and Token-2022-compatible instruction helpers
 - **Solana Clients and React**: Read clients, PDA helpers, generated codecs, and optional React bindings
 - **Token Management**: Built-in EVM support for DERC20 tokens with vesting
@@ -555,7 +555,7 @@ For decay pools, `pool.fee` is always the terminal fee (`endFee`) of the schedul
 When you want fee revenue to flow to specific addresses without migrating liquidity after the auction, use lockable beneficiaries with NoOp migration:
 
 ```typescript
-import { WAD } from '@whetstone-research/doppler-sdk/evm';
+import { MulticurveFees, WAD } from '@whetstone-research/doppler-sdk/evm';
 
 // Define beneficiaries with shares that sum to WAD (1e18 = 100%)
 // IMPORTANT: Protocol owner must be included with at least 5% shares
@@ -608,20 +608,26 @@ console.log('Asset address:', assetAddress);
 // const pool = await sdk.getMulticurvePool(assetAddress)
 // const pending = await pool.getPendingFees('0xBeneficiary...')
 // await pool.collectFees()
+//
+// To preview many locked multicurve tokens at once:
+// const fees = new MulticurveFees(publicClient, walletClient, tokenAddresses)
+// const pendingByToken = await fees.getPendingFees('0xBeneficiary...')
 ```
 
 **Important Notes:**
 
 - Set `fee` > 0 (e.g., 3000 for 0.3%) to accumulate trading fees for beneficiaries
 - **Save the asset address** (token address) returned from creation - you need it to collect fees later
-- Use `getPendingFees(beneficiary)` to preview a beneficiary's claimable token0/token1 fees
+- Use `MulticurvePool.getPendingFees(beneficiary)` to preview a beneficiary's claimable token0/token1 fees for one pool
+- Use `MulticurveFees.getPendingFees(beneficiary)` to preview pending fees for multiple tokens with one multicall by default
+- Pass `tokenBatchSize` to `MulticurveFees` when an RPC provider needs large pending-fee previews split into smaller token batches
 - `collectFees()` claims a payout for the calling account only when the caller is a configured beneficiary
 - Pool enters "Locked" status (status = 2) and liquidity cannot be migrated
 - Beneficiaries are immutable and set at pool creation time
 - The SDK automatically handles PoolKey construction and PoolId computation for you
 
 See [examples/multicurve-lockable-beneficiaries.ts](./examples/multicurve-lockable-beneficiaries.ts) for a complete example.
-See [docs/multicurve-fees.md](./docs/multicurve-fees.md) for pending-fee previews, claiming, and current migrated-launch limitations.
+See [docs/multicurve-fees.md](./docs/multicurve-fees.md) for single-token and multi-token pending-fee previews, claiming, batching, and current migrated-launch limitations.
 
 #### Transaction gas override
 
@@ -781,6 +787,8 @@ Multicurve pools support fee collection and beneficiary claims when configured
 with `pool.beneficiaries` and no-op migration.
 
 ```typescript
+import { MulticurveFees } from '@whetstone-research/doppler-sdk/evm';
+
 // Get a multicurve pool instance using the asset address (token address)
 const pool = await sdk.getMulticurvePool(assetAddress);
 
@@ -804,6 +812,22 @@ if (feeSchedule) {
 const pendingFees = await pool.getPendingFees(beneficiaryAddress);
 console.log('Pending fees (token0):', pendingFees.fees0);
 console.log('Pending fees (token1):', pendingFees.fees1);
+
+// Preview pending fees for multiple launched tokens. By default this builds
+// one multicall for all requested tokens.
+const multicurveFees = new MulticurveFees(
+  publicClient,
+  walletClient,
+  [assetAddress, anotherAssetAddress],
+  { tokenBatchSize: 25 },
+);
+const pendingFeesByToken =
+  await multicurveFees.getPendingFees(beneficiaryAddress);
+for (const pendingFees of pendingFeesByToken) {
+  console.log('Asset:', pendingFees.tokenAddress);
+  console.log('Pending fees (token0):', pendingFees.fees0);
+  console.log('Pending fees (token1):', pendingFees.fees1);
+}
 
 // Claim fees from a beneficiary wallet while the pool is locked.
 // Any account can call collectFees(), but only a configured beneficiary caller
@@ -831,7 +855,9 @@ The SDK handles the complexity of fee collection by:
 **Important Notes:**
 
 - Fees accumulate from swap activity on the pool (only if fee tier > 0)
-- `getPendingFees(beneficiary)` returns the beneficiary's pending share for both tokens in the pair
+- `MulticurvePool.getPendingFees(beneficiary)` returns the beneficiary's pending share for both tokens in one pair
+- `MulticurveFees.getPendingFees(beneficiary)` returns pending fees for each requested token and uses one multicall by default
+- `MulticurveFees` accepts `tokenBatchSize` when large token lists need to be split into smaller multicalls
 - `collectFees()` sends a transaction; the caller needs a wallet client
 - Anyone can call `collectFees()`, but only a configured beneficiary caller receives their pending share
 - The `collectFees()` return values are the newly collected pool fees, not necessarily the caller's beneficiary payout
@@ -843,12 +869,13 @@ The SDK handles the complexity of fee collection by:
 
 **Common Use Cases:**
 
+- Preview pending fees for a portfolio or paginated token list
 - Set up periodic fee collection (e.g., daily or weekly)
 - Integrate with a bot that automatically collects fees when threshold is reached
 - Allow any beneficiary to trigger collection after significant trading activity
 - Monitor swap events to determine optimal collection timing
 
-See [docs/multicurve-fees.md](./docs/multicurve-fees.md) for a focused guide and [examples/multicurve-collect-fees.ts](./examples/multicurve-collect-fees.ts) for a complete example.
+See [docs/multicurve-fees.md](./docs/multicurve-fees.md) for a focused guide, [examples/multicurve-get-pending-fees.ts](./examples/multicurve-get-pending-fees.ts) for batched previews, and [examples/multicurve-collect-fees.ts](./examples/multicurve-collect-fees.ts) for claims.
 
 ## Token Management
 

--- a/docs/multicurve-fees.md
+++ b/docs/multicurve-fees.md
@@ -1,22 +1,26 @@
 # Multicurve Fees
 
-This guide covers reading and claiming fees for multicurve launches that use
-lockable beneficiaries.
+This guide covers reading pending fees and claiming fees for multicurve launches
+that use lockable beneficiaries.
 
 ## Supported Scope
 
-The SDK currently supports pending-fee previews and claims for initializer-side
-multicurve pools in `Locked` status. These are typically multicurve launches
-created with `pool.beneficiaries` and `withMigration({ type: 'noOp' })`.
+The SDK currently supports pending-fee previews for one or many initializer-side
+multicurve pools in `Locked` status. It also supports claims for a single locked
+multicurve pool through `MulticurvePool.collectFees()`. These are typically
+multicurve launches created with `pool.beneficiaries` and
+`withMigration({ type: 'noOp' })`.
 
 The SDK does not currently support pending-fee previews or claiming for migrated
 multicurve launches. Once a multicurve pool is in `Exited` status, calls to
-`MulticurvePool.getPendingFees()` and `MulticurvePool.collectFees()` will throw.
+`MulticurvePool.getPendingFees()`, `MulticurveFees.getPendingFees()`, and
+`MulticurvePool.collectFees()` will throw.
 
 ## Setup
 
 Use the launched token address, also called the asset address in the contracts,
-to create a `MulticurvePool` instance.
+to create a `MulticurvePool` instance when you are working with one pool or
+claiming fees.
 
 ```typescript
 import {
@@ -57,7 +61,7 @@ if (state.status !== LockablePoolStatus.Locked) {
 `getPendingFees()` uses Multicall3. The viem chain attached to your public
 client must have a configured `chain.contracts.multicall3.address`.
 
-## Retrieve Pending Fees
+## Retrieve Pending Fees For One Token
 
 Call `getPendingFees(beneficiary)` with the address whose claimable balance you
 want to preview.
@@ -85,6 +89,78 @@ fee checkpoints. It does not send a transaction or update on-chain state.
 
 The method can return zero when the address is not a configured beneficiary,
 when no new fees have accrued, or when fees were already claimed.
+
+## Retrieve Pending Fees For Multiple Tokens
+
+Use `MulticurveFees` when you need pending fees for several multicurve tokens in
+one request path. The entity accepts multiple launched token addresses and
+returns one pending-fee result per token.
+
+`MulticurveFees` takes a wallet client for constructor compatibility, but it only
+reads pending fees today. Claims still go through `MulticurvePool.collectFees()`.
+
+```typescript
+import { MulticurveFees } from '@whetstone-research/doppler-sdk/evm';
+import type { Address } from 'viem';
+
+const tokenAddresses = [
+  process.env.ASSET_ADDRESS_1 as Address,
+  process.env.ASSET_ADDRESS_2 as Address,
+];
+
+const multicurveFees = new MulticurveFees(
+  publicClient,
+  walletClient,
+  tokenAddresses,
+);
+
+const pendingFeesByToken =
+  await multicurveFees.getPendingFees(beneficiaryAddress);
+
+for (const pendingFees of pendingFeesByToken) {
+  console.log('Asset:', pendingFees.tokenAddress);
+  console.log('Pending token0 fees:', pendingFees.fees0);
+  console.log('Pending token1 fees:', pendingFees.fees1);
+}
+```
+
+By default, `MulticurveFees.getPendingFees(beneficiary)` builds one multicall for
+all token addresses passed to the constructor. Each token contributes six calls
+to that multicall.
+
+If an RPC provider rejects large multicalls because of simulation gas ceilings,
+pass `tokenBatchSize` to limit how many tokens are included per multicall. The
+batch size is token-based, so the SDK never splits one token's six fee reads
+across different multicalls.
+
+```typescript
+const multicurveFees = new MulticurveFees(
+  publicClient,
+  walletClient,
+  tokenAddresses,
+  { tokenBatchSize: 25 },
+);
+
+const pendingFeesByToken =
+  await multicurveFees.getPendingFees(beneficiaryAddress);
+```
+
+You can also provide token addresses per call. This is useful for frontends that
+load token pages incrementally and do not know the full token list when the
+entity is created.
+
+```typescript
+const multicurveFees = new MulticurveFees(publicClient, walletClient, []);
+
+const pendingFeesByToken = await multicurveFees.getPendingFees(
+  beneficiaryAddress,
+  nextPageTokenAddresses,
+  { tokenBatchSize: 25 },
+);
+```
+
+Results are returned in the same order as the token addresses requested. Each
+result includes `tokenAddress`, `fees0`, and `fees1`.
 
 ## Claim Fees
 
@@ -122,8 +198,12 @@ the caller.
 - `Multicurve pool is not locked or was migrated`: the pool is not in `Locked`
   status. The SDK only supports initializer-side locked pool fee claims.
 - `Pending fee preview is only supported for initializer-side multicurve pools`:
-  the pool has exited/migrated. Migrated multicurve launch fee claiming is not
-  currently supported by the SDK.
+  one of the requested pools has exited/migrated. Migrated multicurve launch fee
+  claiming is not currently supported by the SDK.
+- `tokenBatchSize must be a positive integer`: pass a whole number greater than
+  zero, or omit `tokenBatchSize` to include all requested tokens in one multicall.
 
-See [examples/multicurve-collect-fees.ts](../examples/multicurve-collect-fees.ts)
-for a runnable script.
+See [examples/multicurve-get-pending-fees.ts](../examples/multicurve-get-pending-fees.ts)
+for a runnable multi-token pending-fee script and
+[examples/multicurve-collect-fees.ts](../examples/multicurve-collect-fees.ts)
+for a runnable claim script.

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -7,9 +7,13 @@ PRIVATE_KEY=0xYOUR_PRIVATE_KEY_HERE
 # Base Mainnet
 RPC_URL=https://mainnet.base.org
 
-# Pool address for fee collection example (optional)
-# Set this to the address of a multicurve pool with lockable beneficiaries
-# POOL_ADDRESS=0xYOUR_POOL_ADDRESS_HERE
+# Multicurve fee examples
+# Set ASSET_ADDRESS to one launched multicurve token for fee collection.
+# Set ASSET_ADDRESSES to a comma-separated list for multi-token fee previews.
+# ASSET_ADDRESS=0xYOUR_ASSET_ADDRESS_HERE
+# ASSET_ADDRESSES=0xASSET_ADDRESS_1,0xASSET_ADDRESS_2
+# BENEFICIARY_ADDRESS=0xBENEFICIARY_ADDRESS
+# PENDING_FEES_TOKEN_BATCH_SIZE=25
 
 # Base mainnet safety guard (used by decay base-mainnet examples)
 # CONFIRM_BASE_MAINNET=true

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,10 @@ Create a multicurve auction on Base Sepolia using NoOp migration (no liquidity m
 
 Collect and distribute trading fees from a multicurve pool with lockable beneficiaries. Demonstrates how beneficiaries can claim accumulated fees from swap activity.
 
+### 5a. [Multicurve Pending Fee Preview](./multicurve-get-pending-fees.ts)
+
+Preview pending fees for one beneficiary across multiple locked multicurve tokens with one multicall by default, plus optional token batching for RPC provider limits.
+
 ### 6. [Multicurve Pre-Buy with WETH](./multicurve-prebuy-weth.ts)
 
 Atomically create a multicurve auction and pre-buy tokens using WETH (not ETH) with Permit2 signatures. Demonstrates using `doppler-router` to build Universal Router commands for V4 swaps.

--- a/examples/multicurve-get-pending-fees.ts
+++ b/examples/multicurve-get-pending-fees.ts
@@ -1,0 +1,132 @@
+import './env';
+
+import { MulticurveFees } from '../src/evm';
+import {
+  createPublicClient,
+  createWalletClient,
+  formatUnits,
+  getAddress,
+  http,
+  isAddress,
+  isHex,
+  type Address,
+  type Hex,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { baseSepolia } from 'viem/chains';
+
+function readPrivateKey(): Hex {
+  const privateKey = process.env.PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error('PRIVATE_KEY is not set');
+  }
+
+  if (!isHex(privateKey)) {
+    throw new Error('PRIVATE_KEY must be a 0x-prefixed hex string');
+  }
+
+  return privateKey;
+}
+
+function readAddressList(name: string): readonly Address[] {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set`);
+  }
+
+  const addresses = value
+    .split(',')
+    .map((address) => address.trim())
+    .filter((address) => address.length > 0);
+
+  if (addresses.length === 0) {
+    throw new Error(`${name} must include at least one address`);
+  }
+
+  return addresses.map((address) => readAddress(name, address));
+}
+
+function readAddress(name: string, value: string): Address {
+  if (!isAddress(value)) {
+    throw new Error(`${name} contains an invalid address: ${value}`);
+  }
+
+  return getAddress(value);
+}
+
+function readOptionalAddress(name: string): Address | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+
+  return readAddress(name, value);
+}
+
+function readOptionalPositiveInteger(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const account = privateKeyToAccount(readPrivateKey());
+  const rpcUrl = process.env.RPC_URL ?? baseSepolia.rpcUrls.default.http[0];
+  const tokenAddresses = readAddressList('ASSET_ADDRESSES');
+  const beneficiary =
+    readOptionalAddress('BENEFICIARY_ADDRESS') ?? account.address;
+  const tokenBatchSize = readOptionalPositiveInteger(
+    'PENDING_FEES_TOKEN_BATCH_SIZE',
+  );
+
+  const publicClient = createPublicClient({
+    chain: baseSepolia,
+    transport: http(rpcUrl),
+  });
+  const walletClient = createWalletClient({
+    chain: baseSepolia,
+    transport: http(rpcUrl),
+    account,
+  });
+  const multicurveFees = new MulticurveFees(
+    publicClient,
+    walletClient,
+    tokenAddresses,
+    tokenBatchSize === undefined ? {} : { tokenBatchSize },
+  );
+
+  console.log('Beneficiary:', beneficiary);
+  console.log('Tokens:', tokenAddresses.length);
+  console.log(
+    'Token batch size:',
+    tokenBatchSize === undefined ? 'all tokens' : tokenBatchSize,
+  );
+  console.log();
+
+  const pendingFeesByToken = await multicurveFees.getPendingFees(beneficiary);
+
+  for (const pendingFees of pendingFeesByToken) {
+    console.log('Asset:', pendingFees.tokenAddress);
+    console.log('Pending token0 fees:', formatUnits(pendingFees.fees0, 18));
+    console.log('Pending token1 fees:', formatUnits(pendingFees.fees1, 18));
+    console.log();
+  }
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof Error) {
+    console.error('Error:', error.message);
+  } else {
+    console.error('Error:', String(error));
+  }
+
+  process.exit(1);
+});

--- a/src/evm/entities/auction/MulticurveFees.ts
+++ b/src/evm/entities/auction/MulticurveFees.ts
@@ -1,0 +1,105 @@
+import type { Address, WalletClient } from 'viem';
+import type { SupportedPublicClient } from '../../types';
+import type { MulticurveTokenPendingFees } from './multicurve/multicurvePendingFees';
+import { getPendingFeesForMulticurveTokens } from './multicurve/multicurvePendingFeeReader';
+
+export interface MulticurveFeesOptions {
+  readonly tokenBatchSize?: number;
+}
+
+export class MulticurveFees {
+  private readonly client: SupportedPublicClient;
+  private readonly tokenAddresses: readonly Address[];
+  private readonly options: MulticurveFeesOptions;
+
+  constructor(
+    client: SupportedPublicClient,
+    _walletClient: WalletClient | undefined,
+    tokenAddresses: readonly Address[],
+    options: MulticurveFeesOptions = {},
+  ) {
+    this.client = client;
+    this.tokenAddresses = [...tokenAddresses];
+    this.options = { ...options };
+  }
+
+  getPendingFees(
+    beneficiary: Address,
+  ): Promise<readonly MulticurveTokenPendingFees[]>;
+  getPendingFees(
+    beneficiary: Address,
+    options: MulticurveFeesOptions,
+  ): Promise<readonly MulticurveTokenPendingFees[]>;
+  getPendingFees(
+    beneficiary: Address,
+    tokenAddresses: readonly Address[],
+  ): Promise<readonly MulticurveTokenPendingFees[]>;
+  getPendingFees(
+    beneficiary: Address,
+    tokenAddresses: readonly Address[],
+    options: MulticurveFeesOptions,
+  ): Promise<readonly MulticurveTokenPendingFees[]>;
+  async getPendingFees(
+    beneficiary: Address,
+    tokenAddressesOrOptions?: readonly Address[] | MulticurveFeesOptions,
+    options?: MulticurveFeesOptions,
+  ): Promise<readonly MulticurveTokenPendingFees[]> {
+    const hasTokenAddressOverride = isTokenAddressList(tokenAddressesOrOptions);
+    const tokenAddresses = hasTokenAddressOverride
+      ? tokenAddressesOrOptions
+      : this.tokenAddresses;
+    const callOptions = hasTokenAddressOverride
+      ? options
+      : tokenAddressesOrOptions;
+    const tokenBatchSize = getTokenBatchSize(
+      callOptions?.tokenBatchSize ?? this.options.tokenBatchSize,
+    );
+
+    if (!tokenBatchSize || tokenAddresses.length <= tokenBatchSize) {
+      return getPendingFeesForMulticurveTokens({
+        client: this.client,
+        beneficiary,
+        tokenAddresses,
+      });
+    }
+
+    let pendingFees: readonly MulticurveTokenPendingFees[] = [];
+    for (
+      let index = 0;
+      index < tokenAddresses.length;
+      index += tokenBatchSize
+    ) {
+      const batchPendingFees = await getPendingFeesForMulticurveTokens({
+        client: this.client,
+        beneficiary,
+        tokenAddresses: tokenAddresses.slice(index, index + tokenBatchSize),
+      });
+      pendingFees = [...pendingFees, ...batchPendingFees];
+    }
+
+    return pendingFees;
+  }
+}
+
+function isTokenAddressList(
+  value: readonly Address[] | MulticurveFeesOptions | undefined,
+): value is readonly Address[] {
+  return Array.isArray(value);
+}
+
+function getTokenBatchSize(tokenBatchSize: number | undefined) {
+  if (tokenBatchSize === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isInteger(tokenBatchSize) || tokenBatchSize < 1) {
+    throw new Error('tokenBatchSize must be a positive integer');
+  }
+
+  return tokenBatchSize;
+}
+
+export type {
+  MulticurveTokenPendingFees,
+  MulticurveFeesOptions as MulticurvePendingFeesOptions,
+};

--- a/src/evm/entities/auction/MulticurvePool.ts
+++ b/src/evm/entities/auction/MulticurvePool.ts
@@ -5,26 +5,23 @@ import {
   type Hash,
 } from 'viem';
 import {
-  LockablePoolStatus,
   type MulticurveDecayFeeSchedule,
   type MulticurvePoolState,
   type SupportedPublicClient,
 } from '../../types';
 import { getAddresses } from '../../addresses';
 import type { SupportedChainId } from '../../addresses';
-import { computePoolId } from '../../utils/poolKey';
-import { callAggregate3, type Multicall3Client } from '../../utils/multicall3';
-import {
-  calculatePendingFees,
-  createPendingFeePreviewCalls,
-  type MulticurvePendingFees,
-} from './multicurve/multicurvePendingFees';
+import type { MulticurvePendingFees } from './multicurve/multicurvePendingFees';
 import {
   findMulticurveInitializerForPool,
   type InitializerDiscoveryClient,
 } from './multicurve/multicurveInitializerDiscovery';
 import { collectMulticurveFees } from './multicurve/multicurveFeeCollection';
 import { getMulticurveFeeSchedule } from './multicurve/multicurveFeeSchedule';
+import {
+  getPendingFeesForMulticurvePool,
+  type MulticurvePendingFeesClient,
+} from './multicurve/multicurvePendingFeeReader';
 export type { MulticurvePendingFees } from './multicurve/multicurvePendingFees';
 
 /**
@@ -135,26 +132,11 @@ export class MulticurvePool {
    * Preview pending fees for a beneficiary on an initializer-side multicurve pool.
    */
   async getPendingFees(beneficiary: Address): Promise<MulticurvePendingFees> {
-    const { initializerAddress, state } = await this.findInitializerForPool();
-
-    if (state.status === LockablePoolStatus.Exited) {
-      throw new Error(
-        'Pending fee preview is only supported for initializer-side multicurve pools',
-      );
-    }
-
-    if (state.status !== LockablePoolStatus.Locked) {
-      throw new Error('Multicurve pool is not locked or was migrated');
-    }
-
-    const poolId = computePoolId(state.poolKey);
-
-    const callResults = await callAggregate3(
-      this.rpc as Multicall3Client,
-      createPendingFeePreviewCalls(initializerAddress, poolId, beneficiary),
-    );
-
-    return calculatePendingFees(callResults);
+    return getPendingFeesForMulticurvePool({
+      client: this.rpc as MulticurvePendingFeesClient,
+      beneficiary,
+      poolContext: await this.findInitializerForPool(),
+    });
   }
 
   /**

--- a/src/evm/entities/auction/index.ts
+++ b/src/evm/entities/auction/index.ts
@@ -1,7 +1,13 @@
 export { StaticAuction } from './StaticAuction';
 export { DynamicAuction } from './DynamicAuction';
 export { MulticurvePool } from './MulticurvePool';
+export { MulticurveFees } from './MulticurveFees';
 export type { MulticurvePendingFees } from './MulticurvePool';
+export type {
+  MulticurveFeesOptions,
+  MulticurvePendingFeesOptions,
+  MulticurveTokenPendingFees,
+} from './MulticurveFees';
 export { RehypeDopplerHook } from './RehypeDopplerHook';
 export { RehypeDopplerHookMigrator } from './RehypeDopplerHookMigrator';
 export { OpeningAuction } from './OpeningAuction';

--- a/src/evm/entities/auction/multicurve/multicurveInitializerDiscovery.ts
+++ b/src/evm/entities/auction/multicurve/multicurveInitializerDiscovery.ts
@@ -1,7 +1,9 @@
 import {
   BaseError,
   ContractFunctionRevertedError,
+  decodeErrorResult,
   type Address,
+  type Hex,
   zeroAddress,
 } from 'viem';
 import type { ChainAddresses } from '../../../addresses';
@@ -25,11 +27,11 @@ export type InitializerDiscoveryClient = {
   }): Promise<unknown>;
 };
 
-type InitializerKind = 'standard' | 'dopplerHook';
+export type MulticurveInitializerKind = 'standard' | 'dopplerHook';
 
-type InitializerCandidate = {
+export type MulticurveInitializerCandidate = {
   address: Address;
-  kind: InitializerKind;
+  kind: MulticurveInitializerKind;
 };
 
 type StructLike = Record<string, unknown> & {
@@ -43,6 +45,11 @@ interface ParsedInitializerState {
   farTick: number;
 }
 
+const ABSENT_POOL_ERROR_ABI = [
+  { type: 'error', name: 'PoolNotFound', inputs: [] },
+  { type: 'error', name: 'PoolNotInitialized', inputs: [] },
+] as const;
+
 export async function findMulticurveInitializerForPool({
   client,
   tokenAddress,
@@ -52,7 +59,7 @@ export async function findMulticurveInitializerForPool({
   tokenAddress: Address;
   addresses: ChainAddresses;
 }): Promise<InitializerDiscoveryResult> {
-  const initializersToTry = getInitializerCandidates(addresses);
+  const initializersToTry = getMulticurveInitializerCandidates(addresses);
 
   if (initializersToTry.length === 0) {
     throw new Error(
@@ -71,10 +78,7 @@ export async function findMulticurveInitializerForPool({
     try {
       stateData = await client.readContract({
         address: initializerAddress,
-        abi:
-          kind === 'dopplerHook'
-            ? dopplerHookInitializerAbi
-            : v4MulticurveInitializerAbi,
+        abi: getMulticurveInitializerAbi(kind),
         functionName: 'getState',
         args: [tokenAddress],
       });
@@ -90,25 +94,15 @@ export async function findMulticurveInitializerForPool({
       continue;
     }
 
-    const parsedState =
-      kind === 'dopplerHook'
-        ? parseDopplerHookInitializerState(stateData)
-        : parseStandardInitializerState(stateData);
+    const discoveryResult = parseMulticurveInitializerDiscoveryResult({
+      tokenAddress,
+      initializerAddress,
+      kind,
+      stateData,
+    });
 
-    const { numeraire, status, poolKey, farTick } = parsedState;
-    if (poolKey.hooks !== zeroAddress && poolKey.tickSpacing !== 0) {
-      return {
-        initializerAddress,
-        state: {
-          asset: tokenAddress,
-          numeraire,
-          fee: poolKey.fee,
-          tickSpacing: poolKey.tickSpacing,
-          status,
-          poolKey,
-          farTick: Number(farTick),
-        },
-      };
+    if (isInitializedMulticurvePoolKey(discoveryResult.state.poolKey)) {
+      return discoveryResult;
     }
   }
 
@@ -144,9 +138,9 @@ export function parseMulticurvePoolKey(rawPoolKey: unknown): V4PoolKey {
   };
 }
 
-function getInitializerCandidates(
+export function getMulticurveInitializerCandidates(
   addresses: ChainAddresses,
-): readonly InitializerCandidate[] {
+): readonly MulticurveInitializerCandidate[] {
   return [
     {
       address: addresses.v4MulticurveInitializer,
@@ -164,9 +158,74 @@ function getInitializerCandidates(
       address: addresses.dopplerHookInitializer,
       kind: 'dopplerHook' as const,
     },
-  ].filter((entry): entry is InitializerCandidate =>
+  ].filter((entry): entry is MulticurveInitializerCandidate =>
     Boolean(entry.address && entry.address !== zeroAddress),
   );
+}
+
+export function getMulticurveInitializerAbi(
+  kind: MulticurveInitializerKind,
+): typeof dopplerHookInitializerAbi | typeof v4MulticurveInitializerAbi {
+  return kind === 'dopplerHook'
+    ? dopplerHookInitializerAbi
+    : v4MulticurveInitializerAbi;
+}
+
+export function parseMulticurveInitializerDiscoveryResult({
+  tokenAddress,
+  initializerAddress,
+  kind,
+  stateData,
+}: {
+  tokenAddress: Address;
+  initializerAddress: Address;
+  kind: MulticurveInitializerKind;
+  stateData: unknown;
+}): InitializerDiscoveryResult {
+  const parsedState =
+    kind === 'dopplerHook'
+      ? parseDopplerHookInitializerState(stateData)
+      : parseStandardInitializerState(stateData);
+
+  const { numeraire, status, poolKey, farTick } = parsedState;
+  return {
+    initializerAddress,
+    state: {
+      asset: tokenAddress,
+      numeraire,
+      fee: poolKey.fee,
+      tickSpacing: poolKey.tickSpacing,
+      status,
+      poolKey,
+      farTick: Number(farTick),
+    },
+  };
+}
+
+export function isInitializedMulticurvePoolKey(poolKey: V4PoolKey): boolean {
+  return poolKey.hooks !== zeroAddress && poolKey.tickSpacing !== 0;
+}
+
+export function isAbsentPoolRevertData(data: Hex): boolean {
+  if (data === '0x') {
+    return false;
+  }
+
+  try {
+    const decodedError = decodeErrorResult({
+      abi: ABSENT_POOL_ERROR_ABI,
+      data,
+    });
+    return (
+      decodedError.errorName === 'PoolNotFound' ||
+      decodedError.errorName === 'PoolNotInitialized'
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      return false;
+    }
+    throw error;
+  }
 }
 
 function parseStandardInitializerState(

--- a/src/evm/entities/auction/multicurve/multicurvePendingFeeReader.ts
+++ b/src/evm/entities/auction/multicurve/multicurvePendingFeeReader.ts
@@ -1,0 +1,258 @@
+import { decodeFunctionResult, encodeFunctionData, type Address } from 'viem';
+import { getAddresses, type SupportedChainId } from '../../../addresses';
+import { LockablePoolStatus, type SupportedPublicClient } from '../../../types';
+import { computePoolId } from '../../../utils/poolKey';
+import {
+  callAggregate3,
+  type Aggregate3Call,
+  type Aggregate3Result,
+  type Multicall3Client,
+} from '../../../utils/multicall3';
+import {
+  calculatePendingFees,
+  createPendingFeePreviewCalls,
+  PENDING_FEE_PREVIEW_CALL_COUNT,
+  type MulticurvePendingFees,
+  type MulticurveTokenPendingFees,
+} from './multicurvePendingFees';
+import {
+  getMulticurveInitializerAbi,
+  getMulticurveInitializerCandidates,
+  isAbsentPoolRevertData,
+  isInitializedMulticurvePoolKey,
+  parseMulticurveInitializerDiscoveryResult,
+  type InitializerDiscoveryResult,
+  type MulticurveInitializerCandidate,
+} from './multicurveInitializerDiscovery';
+
+export type MulticurvePendingFeesClient = Multicall3Client & {
+  getChainId(): Promise<number>;
+};
+
+type DiscoveryCallContext = {
+  tokenAddress: Address;
+  initializer: MulticurveInitializerCandidate;
+};
+
+export async function getPendingFeesForMulticurvePool({
+  client,
+  beneficiary,
+  poolContext,
+}: {
+  client: MulticurvePendingFeesClient;
+  beneficiary: Address;
+  poolContext: InitializerDiscoveryResult;
+}): Promise<MulticurvePendingFees> {
+  const pendingFees = await getPendingFeesForDiscoveredMulticurvePools({
+    client,
+    beneficiary,
+    poolContexts: [poolContext],
+  });
+  const poolPendingFees = pendingFees[0];
+  if (!poolPendingFees) {
+    throw new Error('Pending fee preview returned no pool result');
+  }
+
+  return {
+    fees0: poolPendingFees.fees0,
+    fees1: poolPendingFees.fees1,
+  };
+}
+
+export async function getPendingFeesForMulticurveTokens({
+  client,
+  beneficiary,
+  tokenAddresses,
+}: {
+  client: SupportedPublicClient;
+  beneficiary: Address;
+  tokenAddresses: readonly Address[];
+}): Promise<readonly MulticurveTokenPendingFees[]> {
+  if (tokenAddresses.length === 0) {
+    return [];
+  }
+
+  const feeClient = client as MulticurvePendingFeesClient;
+  const poolContexts = await discoverMulticurveFeePoolContexts(
+    feeClient,
+    tokenAddresses,
+  );
+  return getPendingFeesForDiscoveredMulticurvePools({
+    client: feeClient,
+    beneficiary,
+    poolContexts,
+  });
+}
+
+async function discoverMulticurveFeePoolContexts(
+  client: MulticurvePendingFeesClient,
+  tokenAddresses: readonly Address[],
+): Promise<readonly InitializerDiscoveryResult[]> {
+  const chainId = await client.getChainId();
+  const addresses = getAddresses(chainId as SupportedChainId);
+  const initializers = getMulticurveInitializerCandidates(addresses);
+
+  if (initializers.length === 0) {
+    throw new Error(
+      'No V4 multicurve initializer addresses configured for this chain',
+    );
+  }
+
+  const discoveryContexts = createDiscoveryCallContexts(
+    tokenAddresses,
+    initializers,
+  );
+  const discoveryResults = await callAggregate3(
+    client,
+    createDiscoveryCalls(discoveryContexts),
+  );
+
+  if (discoveryResults.length !== discoveryContexts.length) {
+    throw new Error(
+      'Multicall3 aggregate3 returned an incomplete initializer discovery result',
+    );
+  }
+
+  return tokenAddresses.map((tokenAddress, tokenIndex) =>
+    findInitializedPoolForToken({
+      tokenAddress,
+      initializers,
+      discoveryResults: discoveryResults.slice(
+        tokenIndex * initializers.length,
+        (tokenIndex + 1) * initializers.length,
+      ),
+    }),
+  );
+}
+
+function createDiscoveryCallContexts(
+  tokenAddresses: readonly Address[],
+  initializers: readonly MulticurveInitializerCandidate[],
+): readonly DiscoveryCallContext[] {
+  return tokenAddresses.flatMap((tokenAddress) =>
+    initializers.map((initializer) => ({
+      tokenAddress,
+      initializer,
+    })),
+  );
+}
+
+function createDiscoveryCalls(
+  contexts: readonly DiscoveryCallContext[],
+): readonly Aggregate3Call[] {
+  return contexts.map(({ tokenAddress, initializer }) => ({
+    target: initializer.address,
+    allowFailure: true,
+    callData: encodeFunctionData({
+      abi: getMulticurveInitializerAbi(initializer.kind),
+      functionName: 'getState',
+      args: [tokenAddress],
+    }),
+  }));
+}
+
+function findInitializedPoolForToken({
+  tokenAddress,
+  initializers,
+  discoveryResults,
+}: {
+  tokenAddress: Address;
+  initializers: readonly MulticurveInitializerCandidate[];
+  discoveryResults: readonly Aggregate3Result[];
+}): InitializerDiscoveryResult {
+  for (const [index, result] of discoveryResults.entries()) {
+    const initializer = initializers[index];
+    if (!initializer) {
+      throw new Error(
+        'Multicall3 aggregate3 returned an incomplete initializer discovery result',
+      );
+    }
+
+    if (!result.success) {
+      if (isAbsentPoolRevertData(result.returnData)) {
+        continue;
+      }
+
+      throw new Error(
+        `${initializer.address} getState failed for token ${tokenAddress}`,
+      );
+    }
+
+    if (!result.returnData || result.returnData === '0x') {
+      throw new Error(
+        `${initializer.address} getState returned no data for token ${tokenAddress}`,
+      );
+    }
+
+    const discoveryResult = parseMulticurveInitializerDiscoveryResult({
+      tokenAddress,
+      initializerAddress: initializer.address,
+      kind: initializer.kind,
+      stateData: decodeFunctionResult({
+        abi: getMulticurveInitializerAbi(initializer.kind),
+        functionName: 'getState',
+        data: result.returnData,
+      }),
+    });
+
+    if (isInitializedMulticurvePoolKey(discoveryResult.state.poolKey)) {
+      assertPendingFeePreviewable(discoveryResult);
+      return discoveryResult;
+    }
+  }
+
+  throw new Error(
+    `Pool not found for token ${tokenAddress}. ` +
+      `Tried initializers: ${initializers
+        .map((initializer) => initializer.address)
+        .join(', ')}`,
+  );
+}
+
+function assertPendingFeePreviewable(
+  discoveryResult: InitializerDiscoveryResult,
+) {
+  const { asset, status } = discoveryResult.state;
+  if (status === LockablePoolStatus.Exited) {
+    throw new Error(
+      `Pending fee preview is only supported for initializer-side multicurve pools: ${asset}`,
+    );
+  }
+
+  if (status !== LockablePoolStatus.Locked) {
+    throw new Error(`Multicurve pool is not locked or was migrated: ${asset}`);
+  }
+}
+
+async function getPendingFeesForDiscoveredMulticurvePools({
+  client,
+  beneficiary,
+  poolContexts,
+}: {
+  client: MulticurvePendingFeesClient;
+  beneficiary: Address;
+  poolContexts: readonly InitializerDiscoveryResult[];
+}): Promise<readonly MulticurveTokenPendingFees[]> {
+  for (const poolContext of poolContexts) {
+    assertPendingFeePreviewable(poolContext);
+  }
+
+  const previewCalls = poolContexts.flatMap(({ initializerAddress, state }) =>
+    createPendingFeePreviewCalls(
+      initializerAddress,
+      computePoolId(state.poolKey),
+      beneficiary,
+    ),
+  );
+  const previewResults = await callAggregate3(client, previewCalls);
+
+  return poolContexts.map(({ state }, index) => ({
+    tokenAddress: state.asset,
+    ...calculatePendingFees(
+      previewResults.slice(
+        index * PENDING_FEE_PREVIEW_CALL_COUNT,
+        (index + 1) * PENDING_FEE_PREVIEW_CALL_COUNT,
+      ),
+    ),
+  }));
+}

--- a/src/evm/entities/auction/multicurve/multicurvePendingFees.ts
+++ b/src/evm/entities/auction/multicurve/multicurvePendingFees.ts
@@ -16,6 +16,10 @@ export interface MulticurvePendingFees {
   fees1: bigint;
 }
 
+export interface MulticurveTokenPendingFees extends MulticurvePendingFees {
+  tokenAddress: Address;
+}
+
 type PendingFeeReadFunctionName =
   | 'getShares'
   | 'getCumulatedFees0'
@@ -33,6 +37,8 @@ const PENDING_FEE_CALL_ORDER = [
   'getLastCumulatedFees0',
   'getLastCumulatedFees1',
 ] as const satisfies readonly PendingFeeCallFunctionName[];
+
+export const PENDING_FEE_PREVIEW_CALL_COUNT = PENDING_FEE_CALL_ORDER.length;
 
 export function createPendingFeePreviewCalls(
   target: Address,

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -16,6 +16,7 @@ export {
   StaticAuction,
   DynamicAuction,
   MulticurvePool,
+  MulticurveFees,
   RehypeDopplerHook,
   RehypeDopplerHookMigrator,
   OpeningAuction,
@@ -23,7 +24,12 @@ export {
   OpeningAuctionBidManager,
   OpeningAuctionPositionManager,
 } from './entities/auction';
-export type { MulticurvePendingFees } from './entities/auction';
+export type {
+  MulticurveFeesOptions,
+  MulticurvePendingFees,
+  MulticurvePendingFeesOptions,
+  MulticurveTokenPendingFees,
+} from './entities/auction';
 
 // Export quoter
 export { Quoter } from './entities/quoter';

--- a/test/evm/unit/entities/multicurve/MulticurveFees.pendingFees.batchSize.test.ts
+++ b/test/evm/unit/entities/multicurve/MulticurveFees.pendingFees.batchSize.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  decodeFunctionData,
+  encodeFunctionResult,
+  getAddress,
+  type Address,
+} from 'viem';
+import { v4MulticurveInitializerAbi } from '@/abis';
+import { MulticurveFees } from '@/entities/auction/MulticurveFees';
+import { LockablePoolStatus, type V4PoolKey } from '@/types';
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+} from '@test/setup/fixtures/clients';
+import {
+  buildPendingFeeAggregateResults,
+  createZeroState,
+  decodePendingFeeAggregateCalls,
+  defaultAddresses,
+  encodePendingFeeAggregateResults,
+  expectedPendingFeeCallOrder,
+  mockBeneficiary,
+  mockFarTick,
+  mockHook,
+  mockNumeraire,
+  mockScheduledInitializer,
+  type AggregateResult,
+  type MockPublicClient,
+  type PendingFeeValues,
+} from './multicurvePoolTestHelpers';
+
+const batchAddresses = {
+  ...defaultAddresses,
+  v4ScheduledMulticurveInitializer: mockScheduledInitializer,
+};
+
+vi.mock('@/addresses', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/addresses')>();
+  return {
+    ...actual,
+    getAddresses: vi.fn(() => batchAddresses),
+  };
+});
+
+const tokenA = getAddress(
+  '0x0aaa0000000000000000000000000000000000aa',
+) as Address;
+const tokenB = getAddress(
+  '0x0bbb0000000000000000000000000000000000bb',
+) as Address;
+const tokenC = getAddress(
+  '0x0ccc0000000000000000000000000000000000cc',
+) as Address;
+
+type GetStateResult = readonly [Address, number, V4PoolKey, number];
+
+describe('MulticurveFees getPendingFees token batch size', () => {
+  let publicClient: MockPublicClient;
+
+  beforeEach(() => {
+    publicClient = createMockPublicClient() as MockPublicClient;
+    vi.clearAllMocks();
+  });
+
+  it('splits pending fee previews by token batch size without splitting a token', async () => {
+    mockPendingFeeBatch([tokenA, tokenB], [pendingFees(100n), pendingFees(200n)]);
+    mockPendingFeeBatch([tokenC], [pendingFees(300n)]);
+    const fees = new MulticurveFees(
+      publicClient,
+      createMockWalletClient(),
+      [tokenA, tokenB, tokenC],
+    );
+
+    const result = await fees.getPendingFees(mockBeneficiary, {
+      tokenBatchSize: 2,
+    });
+
+    expect(result).toEqual([
+      { tokenAddress: tokenA, fees0: 100n, fees1: 110n },
+      { tokenAddress: tokenB, fees0: 200n, fees1: 210n },
+      { tokenAddress: tokenC, fees0: 300n, fees1: 310n },
+    ]);
+    expect(publicClient.call).toHaveBeenCalledTimes(4);
+    expect(decodeDiscoveryTokens(0)).toEqual([
+      tokenA,
+      tokenA,
+      tokenA,
+      tokenB,
+      tokenB,
+      tokenB,
+    ]);
+    expect(decodeAggregateCalls(1)).toHaveLength(
+      expectedPendingFeeCallOrder.length * 2,
+    );
+    expect(decodeDiscoveryTokens(2)).toEqual([tokenC, tokenC, tokenC]);
+    expect(decodeAggregateCalls(3)).toHaveLength(
+      expectedPendingFeeCallOrder.length,
+    );
+  });
+
+  it('uses constructor token batch size unless a call override is provided', async () => {
+    mockPendingFeeBatch([tokenB, tokenC], [pendingFees(200n), pendingFees(300n)]);
+    const fees = new MulticurveFees(
+      publicClient,
+      createMockWalletClient(),
+      [tokenA],
+      { tokenBatchSize: 1 },
+    );
+
+    await expect(
+      fees.getPendingFees(mockBeneficiary, [tokenB, tokenC], {
+        tokenBatchSize: 2,
+      }),
+    ).resolves.toEqual([
+      { tokenAddress: tokenB, fees0: 200n, fees1: 210n },
+      { tokenAddress: tokenC, fees0: 300n, fees1: 310n },
+    ]);
+    expect(publicClient.call).toHaveBeenCalledTimes(2);
+    expect(decodeDiscoveryTokens(0)).toEqual([
+      tokenB,
+      tokenB,
+      tokenB,
+      tokenC,
+      tokenC,
+      tokenC,
+    ]);
+  });
+
+  it('throws when token batch size is not a positive integer', async () => {
+    const fees = new MulticurveFees(
+      publicClient,
+      createMockWalletClient(),
+      [tokenA],
+    );
+
+    await expect(
+      fees.getPendingFees(mockBeneficiary, { tokenBatchSize: 0 }),
+    ).rejects.toThrow('tokenBatchSize must be a positive integer');
+    expect(publicClient.call).not.toHaveBeenCalled();
+  });
+
+  function mockPendingFeeBatch(
+    tokenAddresses: readonly Address[],
+    pendingFeeValues: readonly PendingFeeValues[],
+  ) {
+    vi.mocked(publicClient.call)
+      .mockResolvedValueOnce({
+        data: encodePendingFeeAggregateResults(
+          tokenAddresses.flatMap((tokenAddress) => [
+            encodeGetStateResult(createLockedState(createPoolKey(tokenAddress))),
+            encodeGetStateResult(createZeroState()),
+            encodeGetStateResult(createZeroState()),
+          ]),
+        ),
+      })
+      .mockResolvedValueOnce({
+        data: encodePendingFeeAggregateResults(
+          pendingFeeValues.flatMap((values) =>
+            buildPendingFeeAggregateResults(values),
+          ),
+        ),
+      });
+  }
+
+  function decodeDiscoveryTokens(callIndex: number) {
+    return decodeAggregateCalls(callIndex).map(
+      (call) =>
+        decodeFunctionData({
+          abi: v4MulticurveInitializerAbi,
+          data: call.callData,
+        }).args[0],
+    );
+  }
+
+  function decodeAggregateCalls(callIndex: number) {
+    const request = vi.mocked(publicClient.call).mock.calls[callIndex]?.[0];
+    if (!request) {
+      throw new Error(`Expected aggregate3 call ${callIndex}`);
+    }
+
+    return decodePendingFeeAggregateCalls(request.data);
+  }
+});
+
+function createPoolKey(tokenAddress: Address): V4PoolKey {
+  return {
+    currency0: tokenAddress,
+    currency1: mockNumeraire,
+    fee: 3000,
+    tickSpacing: 60,
+    hooks: mockHook,
+  };
+}
+
+function createLockedState(poolKey: V4PoolKey): GetStateResult {
+  return [mockNumeraire, LockablePoolStatus.Locked, poolKey, mockFarTick];
+}
+
+function encodeGetStateResult(result: GetStateResult): AggregateResult {
+  return {
+    success: true,
+    returnData: encodeFunctionResult({
+      abi: v4MulticurveInitializerAbi,
+      functionName: 'getState',
+      result,
+    }),
+  };
+}
+
+function pendingFees(fees0: bigint): PendingFeeValues {
+  return {
+    simulatedFees0: 0n,
+    simulatedFees1: 0n,
+    shares: 1000000000000000000n,
+    cumulatedFees0: fees0,
+    cumulatedFees1: fees0 + 10n,
+    lastCumulatedFees0: 0n,
+    lastCumulatedFees1: 0n,
+  };
+}

--- a/test/evm/unit/entities/multicurve/MulticurveFees.pendingFees.test.ts
+++ b/test/evm/unit/entities/multicurve/MulticurveFees.pendingFees.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  decodeFunctionData,
+  encodeFunctionResult,
+  getAddress,
+  type Address,
+} from 'viem';
+import { v4MulticurveInitializerAbi } from '@/abis';
+import { MulticurveFees } from '@/entities/auction/MulticurveFees';
+import { LockablePoolStatus, type V4PoolKey } from '@/types';
+import { computePoolId } from '@/utils/poolKey';
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+} from '@test/setup/fixtures/clients';
+import {
+  buildPendingFeeAggregateResults,
+  createZeroState,
+  decodePendingFeeAggregateCalls,
+  decodePendingFeeInnerCall,
+  defaultAddresses,
+  encodePendingFeeAggregateResults,
+  expectedPendingFeeCallOrder,
+  mockBeneficiary,
+  mockFarTick,
+  mockHook,
+  mockNumeraire,
+  mockScheduledInitializer,
+  type AggregateResult,
+  type MockPublicClient,
+  type PendingFeeValues,
+} from './multicurvePoolTestHelpers';
+
+const batchAddresses = {
+  ...defaultAddresses,
+  v4ScheduledMulticurveInitializer: mockScheduledInitializer,
+};
+
+vi.mock('@/addresses', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/addresses')>();
+  return {
+    ...actual,
+    getAddresses: vi.fn(() => batchAddresses),
+  };
+});
+
+const tokenA = getAddress(
+  '0x0aaa0000000000000000000000000000000000aa',
+) as Address;
+const tokenB = getAddress(
+  '0x0bbb0000000000000000000000000000000000bb',
+) as Address;
+const tokenC = getAddress(
+  '0x0ccc0000000000000000000000000000000000cc',
+) as Address;
+
+type GetStateResult = readonly [Address, number, V4PoolKey, number];
+
+describe('MulticurveFees getPendingFees', () => {
+  let publicClient: MockPublicClient;
+
+  beforeEach(() => {
+    publicClient = createMockPublicClient() as MockPublicClient;
+    vi.clearAllMocks();
+  });
+
+  it('returns pending fees for multiple tokens with one fee-preview multicall', async () => {
+    const poolKeyA = createPoolKey(tokenA);
+    const poolKeyB = createPoolKey(tokenB);
+    mockPendingFeeBatch(
+      [createLockedState(poolKeyA), createLockedState(poolKeyB)],
+      [
+        {
+          simulatedFees0: 300n,
+          simulatedFees1: 600n,
+          shares: 500000000000000000n,
+          cumulatedFees0: 1300n,
+          cumulatedFees1: 2600n,
+          lastCumulatedFees0: 100n,
+          lastCumulatedFees1: 400n,
+        },
+        {
+          simulatedFees0: 100n,
+          simulatedFees1: 200n,
+          shares: 1000000000000000000n,
+          cumulatedFees0: 1500n,
+          cumulatedFees1: 2900n,
+          lastCumulatedFees0: 1000n,
+          lastCumulatedFees1: 2000n,
+        },
+      ],
+    );
+
+    const fees = new MulticurveFees(
+      publicClient,
+      createMockWalletClient(),
+      [tokenA, tokenB],
+    );
+    const result = await fees.getPendingFees(mockBeneficiary);
+
+    expect(result).toEqual([
+      { tokenAddress: tokenA, fees0: 600n, fees1: 1100n },
+      { tokenAddress: tokenB, fees0: 500n, fees1: 900n },
+    ]);
+    expect(publicClient.call).toHaveBeenCalledTimes(2);
+
+    const discoveryCalls = decodeAggregateCalls(0);
+    expect(discoveryCalls).toHaveLength(6);
+    expect(
+      discoveryCalls.map(
+        (call) =>
+          decodeFunctionData({
+            abi: v4MulticurveInitializerAbi,
+            data: call.callData,
+          }).args[0],
+      ),
+    ).toEqual([tokenA, tokenA, tokenA, tokenB, tokenB, tokenB]);
+
+    const feeCalls = decodeAggregateCalls(1);
+    expect(feeCalls).toHaveLength(expectedPendingFeeCallOrder.length * 2);
+    expect(feeCalls.map((call) => call.target)).toEqual(
+      Array(expectedPendingFeeCallOrder.length * 2).fill(
+        defaultAddresses.v4MulticurveInitializer,
+      ),
+    );
+    expect(
+      feeCalls.map((call) => decodePendingFeeInnerCall(call.callData)),
+    ).toEqual([
+      ...expectedFeeInnerCalls(poolKeyA),
+      ...expectedFeeInnerCalls(poolKeyB),
+    ]);
+  });
+
+  it('uses constructor tokens when no override tokens are provided', async () => {
+    const poolKeyA = createPoolKey(tokenA);
+    mockPendingFeeBatch([createLockedState(poolKeyA)], [defaultPendingFees()]);
+    const fees = new MulticurveFees(
+      publicClient,
+      createMockWalletClient(),
+      [tokenA],
+    );
+
+    await expect(fees.getPendingFees(mockBeneficiary)).resolves.toEqual([
+      { tokenAddress: tokenA, fees0: 600n, fees1: 1100n },
+    ]);
+  });
+
+  it('uses override tokens instead of constructor tokens when provided', async () => {
+    const poolKeyB = createPoolKey(tokenB);
+    const poolKeyC = createPoolKey(tokenC);
+    mockPendingFeeBatch(
+      [createLockedState(poolKeyB), createLockedState(poolKeyC)],
+      [defaultPendingFees(), defaultPendingFees()],
+    );
+    const fees = new MulticurveFees(
+      publicClient,
+      createMockWalletClient(),
+      [tokenA],
+    );
+
+    await expect(
+      fees.getPendingFees(mockBeneficiary, [tokenB, tokenC]),
+    ).resolves.toEqual([
+      { tokenAddress: tokenB, fees0: 600n, fees1: 1100n },
+      { tokenAddress: tokenC, fees0: 600n, fees1: 1100n },
+    ]);
+
+    const discoveryCalls = decodeAggregateCalls(0);
+    expect(
+      discoveryCalls.map(
+        (call) =>
+          decodeFunctionData({
+            abi: v4MulticurveInitializerAbi,
+            data: call.callData,
+          }).args[0],
+      ),
+    ).toEqual([tokenB, tokenB, tokenB, tokenC, tokenC, tokenC]);
+  });
+
+  function mockPendingFeeBatch(
+    states: readonly GetStateResult[],
+    pendingFeeValues: readonly PendingFeeValues[],
+  ) {
+    vi.mocked(publicClient.call)
+      .mockResolvedValueOnce({
+        data: encodePendingFeeAggregateResults(
+          states.flatMap((state) => [
+            encodeGetStateResult(state),
+            encodeGetStateResult(createZeroState()),
+            encodeGetStateResult(createZeroState()),
+          ]),
+        ),
+      })
+      .mockResolvedValueOnce({
+        data: encodePendingFeeAggregateResults(
+          pendingFeeValues.flatMap((values) =>
+            buildPendingFeeAggregateResults(values),
+          ),
+        ),
+      });
+  }
+
+  function decodeAggregateCalls(callIndex: number) {
+    const request = vi.mocked(publicClient.call).mock.calls[callIndex]?.[0];
+    if (!request) {
+      throw new Error(`Expected aggregate3 call ${callIndex}`);
+    }
+
+    return decodePendingFeeAggregateCalls(request.data);
+  }
+});
+
+function createPoolKey(tokenAddress: Address): V4PoolKey {
+  return {
+    currency0: tokenAddress,
+    currency1: mockNumeraire,
+    fee: 3000,
+    tickSpacing: 60,
+    hooks: mockHook,
+  };
+}
+
+function createLockedState(poolKey: V4PoolKey): GetStateResult {
+  return [mockNumeraire, LockablePoolStatus.Locked, poolKey, mockFarTick];
+}
+
+function encodeGetStateResult(result: GetStateResult): AggregateResult {
+  return {
+    success: true,
+    returnData: encodeFunctionResult({
+      abi: v4MulticurveInitializerAbi,
+      functionName: 'getState',
+      result,
+    }),
+  };
+}
+
+function defaultPendingFees(): PendingFeeValues {
+  return {
+    simulatedFees0: 300n,
+    simulatedFees1: 600n,
+    shares: 500000000000000000n,
+    cumulatedFees0: 1300n,
+    cumulatedFees1: 2600n,
+    lastCumulatedFees0: 100n,
+    lastCumulatedFees1: 400n,
+  };
+}
+
+function expectedFeeInnerCalls(poolKey: V4PoolKey) {
+  const poolId = computePoolId(poolKey);
+  const beneficiary = getAddress(mockBeneficiary);
+  return expectedPendingFeeCallOrder.map((functionName) => ({
+    functionName,
+    args:
+      functionName === 'collectFees' ||
+      functionName === 'getCumulatedFees0' ||
+      functionName === 'getCumulatedFees1'
+        ? [poolId]
+        : [poolId, beneficiary],
+  }));
+}


### PR DESCRIPTION
Adds a new `MulticurveFees` entity for retrieving pending fees for a beneficiary across multiple multicurve tokens in one batched multicall flow. The existing `MulticurvePool.getPendingFees` path now delegates to the same internal multicurve fee reader, preserving single-token behavior while sharing the implementation used by the new multi-token entity. `MulticurveFees` also supports optional token-based batching so large token sets can be split across multiple multicalls without splitting a token’s fee reads across batches.

- `src/evm/entities/auction/MulticurveFees.ts`: Adds the new `MulticurveFees` entity with constructor-token support, per-call token override support, and optional `tokenBatchSize` handling for pending fee reads.
- `src/evm/entities/auction/MulticurvePool.ts`: Refactors `getPendingFees` to use the shared multicurve pending-fee reader while preserving the existing public API and behavior.
- `src/evm/entities/auction/index.ts`: Exports `MulticurveFees` and its pending-fee result/options types from the auction entity barrel.
- `src/evm/entities/auction/multicurve/multicurveInitializerDiscovery.ts`: Exposes initializer candidate, ABI, parsing, and absent-pool revert helpers so single-token and batch discovery share the same logic.
- `src/evm/entities/auction/multicurve/multicurvePendingFeeReader.ts`: Adds the shared internal reader that handles single-token and multi-token pending-fee preview flows.
- `src/evm/entities/auction/multicurve/multicurvePendingFees.ts`: Adds the token-address-aware pending-fee result type and exposes the preview call count for batch result slicing.
- `src/evm/index.ts`: Exports `MulticurveFees`, `MulticurveTokenPendingFees`, and pending-fee option types from the public EVM entrypoint.
- `test/evm/unit/entities/multicurve/MulticurveFees.pendingFees.test.ts`: Adds coverage for batched pending-fee retrieval, constructor token usage, and per-call token override behavior.
- `test/evm/unit/entities/multicurve/MulticurveFees.pendingFees.batchSize.test.ts`: Adds coverage for token-batch chunking, constructor default batching, per-call batch override behavior, and invalid batch-size validation.
- `README.md`: Documents multi-token pending-fee previews with `MulticurveFees` and the optional `tokenBatchSize` setting.
- `docs/multicurve-fees.md`: Expands the multicurve fee guide with single-token and multi-token pending-fee flows, per-call token overrides, batching behavior, and claim-scope clarification.
- `examples/multicurve-get-pending-fees.ts`: Adds a runnable example for retrieving pending fees for one beneficiary across multiple multicurve tokens.
- `examples/README.md`: Lists the new multi-token pending-fee preview example.
- `examples/.env.example`: Adds environment variables for the new pending-fee preview example.