### PR TITLE
[SOL-31] fix(solana): remove initializer swap config account

### DIFF
--- a/examples/solana-adv-e2e-launch.ts
+++ b/examples/solana-adv-e2e-launch.ts
@@ -413,7 +413,6 @@ async function main() {
 
     const swapIx = initializer.createCurveSwapExactInInstruction(
       {
-        config: initializerConfig,
         launch,
         launchAuthority,
         baseVault: baseVault.address,

--- a/examples/solana-cosigner-gated-buy.ts
+++ b/examples/solana-cosigner-gated-buy.ts
@@ -476,7 +476,6 @@ async function main() {
     getSyncNativeInstruction({ account: userQuoteAta }),
   ];
   const swapAccounts = {
-    config: deployment.initializerConfig,
     launch,
     launchAuthority,
     baseVault: baseVault.address,

--- a/examples/solana-cosigner-gated-launch.ts
+++ b/examples/solana-cosigner-gated-launch.ts
@@ -487,7 +487,6 @@ async function main() {
 
     const swapIx = initializer.createCurveSwapExactInInstruction(
       {
-        config: initializerConfig,
         launch,
         launchAuthority,
         baseVault: baseVault.address,
@@ -513,7 +512,6 @@ async function main() {
 
     const unsignedSwapIx = initializer.createCurveSwapExactInInstruction(
       {
-        config: initializerConfig,
         launch,
         launchAuthority,
         baseVault: baseVault.address,

--- a/examples/solana-usdc-cosigner-gated-buy.ts
+++ b/examples/solana-usdc-cosigner-gated-buy.ts
@@ -524,7 +524,6 @@ async function main() {
     }),
   ];
   const swapAccounts = {
-    config: deployment.initializerConfig,
     launch,
     launchAuthority,
     baseVault: baseVault.address,

--- a/examples/solana-usdc-e2e-launch.ts
+++ b/examples/solana-usdc-e2e-launch.ts
@@ -462,7 +462,6 @@ async function main() {
     });
     const swapIx = initializer.createCurveSwapExactInInstruction(
       {
-        config: initializerConfig,
         launch,
         launchAuthority,
         baseVault: baseVault.address,

--- a/scripts/idl/initializer.json
+++ b/scripts/idl/initializer.json
@@ -160,24 +160,6 @@
       ],
       "accounts": [
         {
-          "name": "config",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
-              }
-            ]
-          }
-        },
-        {
           "name": "launch",
           "writable": true
         },

--- a/src/solana/generated/initializer/instructions/curveSwapExactIn.ts
+++ b/src/solana/generated/initializer/instructions/curveSwapExactIn.ts
@@ -57,7 +57,6 @@ export function getCurveSwapExactInDiscriminatorBytes() {
 
 export type CurveSwapExactInInstruction<
   TProgram extends string = typeof INITIALIZER_PROGRAM_ADDRESS,
-  TAccountConfig extends string | AccountMeta<string> = string,
   TAccountLaunch extends string | AccountMeta<string> = string,
   TAccountLaunchAuthority extends string | AccountMeta<string> = string,
   TAccountBaseVault extends string | AccountMeta<string> = string,
@@ -76,9 +75,6 @@ export type CurveSwapExactInInstruction<
   InstructionWithData<ReadonlyUint8Array> &
   InstructionWithAccounts<
     [
-      TAccountConfig extends string
-        ? ReadonlyAccount<TAccountConfig>
-        : TAccountConfig,
       TAccountLaunch extends string
         ? WritableAccount<TAccountLaunch>
         : TAccountLaunch,
@@ -167,7 +163,6 @@ export function getCurveSwapExactInInstructionDataCodec(): FixedSizeCodec<
 }
 
 export type CurveSwapExactInAsyncInput<
-  TAccountConfig extends string = string,
   TAccountLaunch extends string = string,
   TAccountLaunchAuthority extends string = string,
   TAccountBaseVault extends string = string,
@@ -182,7 +177,6 @@ export type CurveSwapExactInAsyncInput<
   TAccountBaseTokenProgram extends string = string,
   TAccountQuoteTokenProgram extends string = string,
 > = {
-  config?: Address<TAccountConfig>;
   launch: Address<TAccountLaunch>;
   launchAuthority: Address<TAccountLaunchAuthority>;
   baseVault: Address<TAccountBaseVault>;
@@ -203,7 +197,6 @@ export type CurveSwapExactInAsyncInput<
 };
 
 export async function getCurveSwapExactInInstructionAsync<
-  TAccountConfig extends string,
   TAccountLaunch extends string,
   TAccountLaunchAuthority extends string,
   TAccountBaseVault extends string,
@@ -220,7 +213,6 @@ export async function getCurveSwapExactInInstructionAsync<
   TProgramAddress extends Address = typeof INITIALIZER_PROGRAM_ADDRESS,
 >(
   input: CurveSwapExactInAsyncInput<
-    TAccountConfig,
     TAccountLaunch,
     TAccountLaunchAuthority,
     TAccountBaseVault,
@@ -239,7 +231,6 @@ export async function getCurveSwapExactInInstructionAsync<
 ): Promise<
   CurveSwapExactInInstruction<
     TProgramAddress,
-    TAccountConfig,
     TAccountLaunch,
     TAccountLaunchAuthority,
     TAccountBaseVault,
@@ -260,7 +251,6 @@ export async function getCurveSwapExactInInstructionAsync<
 
   // Original accounts.
   const originalAccounts = {
-    config: { value: input.config ?? null, isWritable: false },
     launch: { value: input.launch ?? null, isWritable: true },
     launchAuthority: {
       value: input.launchAuthority ?? null,
@@ -296,14 +286,6 @@ export async function getCurveSwapExactInInstructionAsync<
   const args = { ...input };
 
   // Resolve default values.
-  if (!accounts.config.value) {
-    accounts.config.value = await getProgramDerivedAddress({
-      programAddress,
-      seeds: [
-        getBytesEncoder().encode(new Uint8Array([99, 111, 110, 102, 105, 103])),
-      ],
-    });
-  }
   if (!accounts.launchFeeState.value) {
     accounts.launchFeeState.value = await getProgramDerivedAddress({
       programAddress,
@@ -327,7 +309,6 @@ export async function getCurveSwapExactInInstructionAsync<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   return Object.freeze({
     accounts: [
-      getAccountMeta('config', accounts.config),
       getAccountMeta('launch', accounts.launch),
       getAccountMeta('launchAuthority', accounts.launchAuthority),
       getAccountMeta('baseVault', accounts.baseVault),
@@ -348,7 +329,6 @@ export async function getCurveSwapExactInInstructionAsync<
     programAddress,
   } as CurveSwapExactInInstruction<
     TProgramAddress,
-    TAccountConfig,
     TAccountLaunch,
     TAccountLaunchAuthority,
     TAccountBaseVault,
@@ -366,7 +346,6 @@ export async function getCurveSwapExactInInstructionAsync<
 }
 
 export type CurveSwapExactInInput<
-  TAccountConfig extends string = string,
   TAccountLaunch extends string = string,
   TAccountLaunchAuthority extends string = string,
   TAccountBaseVault extends string = string,
@@ -381,7 +360,6 @@ export type CurveSwapExactInInput<
   TAccountBaseTokenProgram extends string = string,
   TAccountQuoteTokenProgram extends string = string,
 > = {
-  config: Address<TAccountConfig>;
   launch: Address<TAccountLaunch>;
   launchAuthority: Address<TAccountLaunchAuthority>;
   baseVault: Address<TAccountBaseVault>;
@@ -402,7 +380,6 @@ export type CurveSwapExactInInput<
 };
 
 export function getCurveSwapExactInInstruction<
-  TAccountConfig extends string,
   TAccountLaunch extends string,
   TAccountLaunchAuthority extends string,
   TAccountBaseVault extends string,
@@ -419,7 +396,6 @@ export function getCurveSwapExactInInstruction<
   TProgramAddress extends Address = typeof INITIALIZER_PROGRAM_ADDRESS,
 >(
   input: CurveSwapExactInInput<
-    TAccountConfig,
     TAccountLaunch,
     TAccountLaunchAuthority,
     TAccountBaseVault,
@@ -437,7 +413,6 @@ export function getCurveSwapExactInInstruction<
   config?: { programAddress?: TProgramAddress },
 ): CurveSwapExactInInstruction<
   TProgramAddress,
-  TAccountConfig,
   TAccountLaunch,
   TAccountLaunchAuthority,
   TAccountBaseVault,
@@ -457,7 +432,6 @@ export function getCurveSwapExactInInstruction<
 
   // Original accounts.
   const originalAccounts = {
-    config: { value: input.config ?? null, isWritable: false },
     launch: { value: input.launch ?? null, isWritable: true },
     launchAuthority: {
       value: input.launchAuthority ?? null,
@@ -495,7 +469,6 @@ export function getCurveSwapExactInInstruction<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   return Object.freeze({
     accounts: [
-      getAccountMeta('config', accounts.config),
       getAccountMeta('launch', accounts.launch),
       getAccountMeta('launchAuthority', accounts.launchAuthority),
       getAccountMeta('baseVault', accounts.baseVault),
@@ -516,7 +489,6 @@ export function getCurveSwapExactInInstruction<
     programAddress,
   } as CurveSwapExactInInstruction<
     TProgramAddress,
-    TAccountConfig,
     TAccountLaunch,
     TAccountLaunchAuthority,
     TAccountBaseVault,
@@ -539,21 +511,20 @@ export type ParsedCurveSwapExactInInstruction<
 > = {
   programAddress: Address<TProgram>;
   accounts: {
-    config: TAccountMetas[0];
-    launch: TAccountMetas[1];
-    launchAuthority: TAccountMetas[2];
-    baseVault: TAccountMetas[3];
-    quoteVault: TAccountMetas[4];
-    userBaseAccount: TAccountMetas[5];
-    userQuoteAccount: TAccountMetas[6];
-    baseMint: TAccountMetas[7];
-    quoteMint: TAccountMetas[8];
-    user: TAccountMetas[9];
+    launch: TAccountMetas[0];
+    launchAuthority: TAccountMetas[1];
+    baseVault: TAccountMetas[2];
+    quoteVault: TAccountMetas[3];
+    userBaseAccount: TAccountMetas[4];
+    userQuoteAccount: TAccountMetas[5];
+    baseMint: TAccountMetas[6];
+    quoteMint: TAccountMetas[7];
+    user: TAccountMetas[8];
     /** Optional hook program (must match launch.hook_program if set) */
-    hookProgram?: TAccountMetas[10] | undefined;
-    launchFeeState: TAccountMetas[11];
-    baseTokenProgram: TAccountMetas[12];
-    quoteTokenProgram: TAccountMetas[13];
+    hookProgram?: TAccountMetas[9] | undefined;
+    launchFeeState: TAccountMetas[10];
+    baseTokenProgram: TAccountMetas[11];
+    quoteTokenProgram: TAccountMetas[12];
   };
   data: CurveSwapExactInInstructionData;
 };
@@ -566,12 +537,12 @@ export function parseCurveSwapExactInInstruction<
     InstructionWithAccounts<TAccountMetas> &
     InstructionWithData<ReadonlyUint8Array>,
 ): ParsedCurveSwapExactInInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 14) {
+  if (instruction.accounts.length < 13) {
     throw new SolanaError(
       SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
       {
         actualAccountMetas: instruction.accounts.length,
-        expectedAccountMetas: 14,
+        expectedAccountMetas: 13,
       },
     );
   }
@@ -590,7 +561,6 @@ export function parseCurveSwapExactInInstruction<
   return {
     programAddress: instruction.programAddress,
     accounts: {
-      config: getNextAccount(),
       launch: getNextAccount(),
       launchAuthority: getNextAccount(),
       baseVault: getNextAccount(),

--- a/src/solana/initializer/instructions/curveSwapExactIn.ts
+++ b/src/solana/initializer/instructions/curveSwapExactIn.ts
@@ -59,7 +59,6 @@ function createRemainingAccountMeta(
 }
 
 export interface CurveSwapExactInAccounts {
-  config: Address;
   launch: Address;
   launchAuthority: Address;
   baseVault: Address;
@@ -83,7 +82,6 @@ export function createCurveSwapExactInInstruction(
   programId: Address = INITIALIZER_PROGRAM_ID,
 ): Instruction {
   const {
-    config,
     launch,
     launchAuthority,
     baseVault,
@@ -101,7 +99,6 @@ export function createCurveSwapExactInInstruction(
   } = accounts;
 
   const keys: (AccountMeta | AccountSignerMeta)[] = [
-    { address: config, role: AccountRole.READONLY },
     { address: launch, role: AccountRole.WRITABLE },
     { address: launchAuthority, role: AccountRole.READONLY },
     { address: baseVault, role: AccountRole.WRITABLE },


### PR DESCRIPTION
## Summary
- regenerate the Solana initializer client from the current IDL
- remove the obsolete `config` account from `curveSwapExactIn`
- update Solana examples to build swap instructions with the current account layout

## Testing
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test:solana`
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck:test` *(fails on existing EVM/vitest type errors unrelated to this Solana change)*