### PR TITLE
feat(solana): add cosigner gate expiry helpers

### DIFF
--- a/examples/solana-cosigner-gated-launch.ts
+++ b/examples/solana-cosigner-gated-launch.ts
@@ -176,6 +176,7 @@ async function main() {
   const CPMM_SWAP_FEE_SPLIT_BPS = 10_000; // migrated launch fees route through LaunchFeeState
   const INITIALIZER_HOOK_FLAGS =
     initializer.HF_BEFORE_SWAP | initializer.HF_FORWARD_READONLY_SIGNERS;
+  const COSIGN_GATE_SECONDS = Number(process.env.COSIGN_GATE_SECONDS ?? 300);
   // ── Graduation threshold and price floor ────────────────────────────────
   const MIN_SOL_RAISE = 0.1; // low example threshold
   const minRaiseQuote = BigInt(MIN_SOL_RAISE * 1_000_000_000);
@@ -213,6 +214,14 @@ async function main() {
     namespace,
     cosigner.address,
   ]);
+  const cosignGateExpiresAt = BigInt(
+    Math.floor(Date.now() / 1_000) + COSIGN_GATE_SECONDS,
+  );
+  const hookPayload = cosignerHook.encodeCosignerGateExpiryPayload({
+    mode: cosignerHook.GATE_EXPIRY_UNIX_TIMESTAMP,
+    value: cosignGateExpiresAt,
+    cosigner: cosigner.address,
+  });
 
   const [launch] = await initializer.getLaunchAddress(
     namespace,
@@ -267,6 +276,7 @@ async function main() {
   console.log('  Cosigner config:    ', cosignerConfig);
   console.log('  Active cosigners:   ', activeCosigners.join(', '));
   console.log('  Signing cosigner:   ', cosigner.address);
+  console.log('  Cosign gate expiry: ', cosignGateExpiresAt.toString());
   console.log('');
 
   const migratorInitPayload = cpmmMigrator.encodeRegisterLaunchPayload({
@@ -332,7 +342,7 @@ async function main() {
         allowBuy: true,
         allowSell: true,
         hookFlags: INITIALIZER_HOOK_FLAGS,
-        hookPayload: new Uint8Array(),
+        hookPayload,
         migratorInitPayload,
         migratorMigratePayload,
         hookRemainingAccountsHash,

--- a/src/solana/cosignerHook/constants.ts
+++ b/src/solana/cosignerHook/constants.ts
@@ -4,3 +4,9 @@ export const COSIGNER_HOOK_PROGRAM_ID = COSIGNER_HOOK_PROGRAM_ADDRESS;
 
 export const SEED_COSIGNER_HOOK_CONFIG = 'cosigner_hook_config';
 export const MAX_COSIGNERS = 32;
+export const GATE_EXPIRY_DISABLED = 0;
+export const GATE_EXPIRY_UNIX_TIMESTAMP = 1;
+export const GATE_EXPIRY_SLOT = 2;
+export const GATE_EXPIRY_PAYLOAD_VERSION = 1;
+export const GATE_EXPIRY_HEADER_LEN = 10;
+export const GATE_EXPIRY_PAYLOAD_LEN = 42;

--- a/src/solana/cosignerHook/gate.ts
+++ b/src/solana/cosignerHook/gate.ts
@@ -1,0 +1,207 @@
+import {
+  getAddressDecoder,
+  getAddressEncoder,
+  type Address,
+  type ReadonlyUint8Array,
+} from '@solana/kit';
+
+import {
+  GATE_EXPIRY_DISABLED,
+  GATE_EXPIRY_HEADER_LEN,
+  GATE_EXPIRY_PAYLOAD_LEN,
+  GATE_EXPIRY_PAYLOAD_VERSION,
+  GATE_EXPIRY_SLOT,
+  GATE_EXPIRY_UNIX_TIMESTAMP,
+} from './constants.js';
+
+const MAX_U64 = (1n << 64n) - 1n;
+
+export type CosignerGateClock = {
+  unixTimestamp?: bigint | number;
+  slot?: bigint | number;
+};
+
+export type CosignerGateExpiry = {
+  mode: number;
+  value: bigint;
+  cosigner?: Address;
+};
+
+export type CosignerGateExpiryArgs =
+  | {
+      mode: typeof GATE_EXPIRY_DISABLED;
+      value: bigint | number;
+      cosigner?: never;
+    }
+  | {
+      mode: typeof GATE_EXPIRY_UNIX_TIMESTAMP | typeof GATE_EXPIRY_SLOT;
+      value: bigint | number;
+      cosigner: Address;
+    };
+
+export type CosignerGateStatus = {
+  gateEnforced: boolean;
+  expiryMode: number;
+  expiryValue: bigint;
+  reason:
+    | 'expiry_disabled'
+    | 'timestamp_pending'
+    | 'timestamp_expired'
+    | 'slot_pending'
+    | 'slot_expired'
+    | 'slot_unavailable'
+    | 'invalid_expiry_payload'
+    | 'invalid_expiry_mode';
+};
+
+function toBigInt(value: bigint | number): bigint {
+  return typeof value === 'bigint' ? value : BigInt(value);
+}
+
+function isValidExpiryMode(mode: number): boolean {
+  return mode === GATE_EXPIRY_UNIX_TIMESTAMP || mode === GATE_EXPIRY_SLOT;
+}
+
+function readU64Le(bytes: ReadonlyUint8Array, offset: number): bigint {
+  let value = 0n;
+  for (let i = 0; i < 8; i++) {
+    value |= BigInt(bytes[offset + i] ?? 0) << BigInt(i * 8);
+  }
+  return value;
+}
+
+function writeU64Le(bytes: Uint8Array, offset: number, value: bigint): void {
+  for (let i = 0; i < 8; i++) {
+    bytes[offset + i] = Number((value >> BigInt(i * 8)) & 0xffn);
+  }
+}
+
+export function encodeCosignerGateExpiryPayload(
+  expiry: CosignerGateExpiryArgs,
+): Uint8Array {
+  if (expiry.mode === GATE_EXPIRY_DISABLED) {
+    if (expiry.cosigner !== undefined) {
+      throw new Error('Cosigner hint cannot be encoded for disabled gates');
+    }
+    return new Uint8Array();
+  }
+  if (!isValidExpiryMode(expiry.mode)) {
+    throw new Error(`Invalid cosigner gate expiry mode: ${expiry.mode}`);
+  }
+
+  const value = toBigInt(expiry.value);
+  if (value < 0n || value > MAX_U64) {
+    throw new Error(`Invalid cosigner gate expiry value: ${expiry.value}`);
+  }
+  if (expiry.cosigner === undefined) {
+    throw new Error('Cosigner hint is required for expiring gates');
+  }
+
+  const payload = new Uint8Array(GATE_EXPIRY_PAYLOAD_LEN);
+  payload[0] = GATE_EXPIRY_PAYLOAD_VERSION;
+  payload[1] = expiry.mode;
+  writeU64Le(payload, 2, value);
+  payload.set(
+    getAddressEncoder().encode(expiry.cosigner),
+    GATE_EXPIRY_HEADER_LEN,
+  );
+  return payload;
+}
+
+export function decodeCosignerGateExpiryPayload(
+  payload: ReadonlyUint8Array | null | undefined,
+): CosignerGateExpiry | null {
+  if (!payload || payload.length === 0) {
+    return { mode: GATE_EXPIRY_DISABLED, value: 0n };
+  }
+  if (
+    payload.length !== GATE_EXPIRY_PAYLOAD_LEN ||
+    payload[0] !== GATE_EXPIRY_PAYLOAD_VERSION
+  ) {
+    return null;
+  }
+
+  const mode = payload[1] ?? GATE_EXPIRY_DISABLED;
+  if (!isValidExpiryMode(mode)) {
+    return null;
+  }
+
+  return {
+    mode,
+    value: readU64Le(payload, 2),
+    cosigner: getAddressDecoder().decode(
+      payload.slice(GATE_EXPIRY_HEADER_LEN, GATE_EXPIRY_PAYLOAD_LEN),
+    ),
+  };
+}
+
+export function getCosignerGateStatus(
+  hookPayload: ReadonlyUint8Array | null | undefined,
+  clock: CosignerGateClock = {},
+): CosignerGateStatus {
+  const expiry = decodeCosignerGateExpiryPayload(hookPayload);
+  if (!expiry) {
+    return {
+      gateEnforced: true,
+      expiryMode: GATE_EXPIRY_DISABLED,
+      expiryValue: 0n,
+      reason: 'invalid_expiry_payload',
+    };
+  }
+
+  if (expiry.mode === GATE_EXPIRY_DISABLED) {
+    return {
+      gateEnforced: true,
+      expiryMode: expiry.mode,
+      expiryValue: expiry.value,
+      reason: 'expiry_disabled',
+    };
+  }
+
+  if (expiry.mode === GATE_EXPIRY_UNIX_TIMESTAMP) {
+    const unixTimestamp =
+      clock.unixTimestamp === undefined
+        ? BigInt(Math.floor(Date.now() / 1_000))
+        : toBigInt(clock.unixTimestamp);
+    const expired = unixTimestamp >= expiry.value;
+    return {
+      gateEnforced: !expired,
+      expiryMode: expiry.mode,
+      expiryValue: expiry.value,
+      reason: expired ? 'timestamp_expired' : 'timestamp_pending',
+    };
+  }
+
+  if (expiry.mode === GATE_EXPIRY_SLOT) {
+    if (clock.slot === undefined) {
+      return {
+        gateEnforced: true,
+        expiryMode: expiry.mode,
+        expiryValue: expiry.value,
+        reason: 'slot_unavailable',
+      };
+    }
+
+    const expired = toBigInt(clock.slot) >= expiry.value;
+    return {
+      gateEnforced: !expired,
+      expiryMode: expiry.mode,
+      expiryValue: expiry.value,
+      reason: expired ? 'slot_expired' : 'slot_pending',
+    };
+  }
+
+  return {
+    gateEnforced: true,
+    expiryMode: expiry.mode,
+    expiryValue: expiry.value,
+    reason: 'invalid_expiry_mode',
+  };
+}
+
+export function isCosignerGateEnforced(
+  hookPayload: ReadonlyUint8Array | null | undefined,
+  clock: CosignerGateClock = {},
+): boolean {
+  return getCosignerGateStatus(hookPayload, clock).gateEnforced;
+}

--- a/src/solana/cosignerHook/index.ts
+++ b/src/solana/cosignerHook/index.ts
@@ -1,3 +1,4 @@
 export * from '../generated/cosignerHook/index.js';
 export * from './constants.js';
+export * from './gate.js';
 export * from './pda.js';

--- a/test/solana/unit/cosignerHook/gate.test.ts
+++ b/test/solana/unit/cosignerHook/gate.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import type { Address } from '@solana/kit';
+import { cosignerHook } from '@/solana/index.js';
+
+describe('cosignerHook gate payload helpers', () => {
+  const cosigner = 'So11111111111111111111111111111111111111112' as Address;
+
+  it('encodes a per-launch unix timestamp expiry payload with a cosigner hint', () => {
+    const payload = cosignerHook.encodeCosignerGateExpiryPayload({
+      mode: cosignerHook.GATE_EXPIRY_UNIX_TIMESTAMP,
+      value: 300n,
+      cosigner,
+    });
+
+    expect(payload).toHaveLength(cosignerHook.GATE_EXPIRY_PAYLOAD_LEN);
+    expect(cosignerHook.decodeCosignerGateExpiryPayload(payload)).toEqual({
+      mode: cosignerHook.GATE_EXPIRY_UNIX_TIMESTAMP,
+      value: 300n,
+      cosigner,
+    });
+  });
+
+  it('encodes a per-launch slot expiry payload with a cosigner hint', () => {
+    const payload = cosignerHook.encodeCosignerGateExpiryPayload({
+      mode: cosignerHook.GATE_EXPIRY_SLOT,
+      value: 20n,
+      cosigner,
+    });
+
+    expect(payload).toHaveLength(cosignerHook.GATE_EXPIRY_PAYLOAD_LEN);
+    expect(cosignerHook.decodeCosignerGateExpiryPayload(payload)).toEqual({
+      mode: cosignerHook.GATE_EXPIRY_SLOT,
+      value: 20n,
+      cosigner,
+    });
+  });
+
+  it('encodes disabled gates as empty payloads', () => {
+    expect(
+      cosignerHook.encodeCosignerGateExpiryPayload({
+        mode: cosignerHook.GATE_EXPIRY_DISABLED,
+        value: 0n,
+      }),
+    ).toHaveLength(0);
+  });
+
+  it('reports whether timestamp and slot expiries still enforce the gate', () => {
+    const timestampPayload = cosignerHook.encodeCosignerGateExpiryPayload({
+      mode: cosignerHook.GATE_EXPIRY_UNIX_TIMESTAMP,
+      value: 1_000n,
+      cosigner,
+    });
+    const slotPayload = cosignerHook.encodeCosignerGateExpiryPayload({
+      mode: cosignerHook.GATE_EXPIRY_SLOT,
+      value: 20n,
+      cosigner,
+    });
+
+    expect(
+      cosignerHook.getCosignerGateStatus(timestampPayload, {
+        unixTimestamp: 999n,
+      }),
+    ).toMatchObject({ gateEnforced: true, reason: 'timestamp_pending' });
+    expect(
+      cosignerHook.getCosignerGateStatus(timestampPayload, {
+        unixTimestamp: 1_000n,
+      }),
+    ).toMatchObject({ gateEnforced: false, reason: 'timestamp_expired' });
+    expect(
+      cosignerHook.getCosignerGateStatus(slotPayload, { slot: 19n }),
+    ).toMatchObject({ gateEnforced: true, reason: 'slot_pending' });
+    expect(
+      cosignerHook.getCosignerGateStatus(slotPayload, { slot: 20n }),
+    ).toMatchObject({ gateEnforced: false, reason: 'slot_expired' });
+  });
+
+  it('keeps the gate enforced for empty or invalid payloads', () => {
+    expect(cosignerHook.getCosignerGateStatus(new Uint8Array())).toMatchObject({
+      gateEnforced: true,
+      reason: 'expiry_disabled',
+    });
+    expect(
+      cosignerHook.getCosignerGateStatus(new Uint8Array([1, 9, 0])),
+    ).toMatchObject({
+      gateEnforced: true,
+      reason: 'invalid_expiry_payload',
+    });
+    expect(
+      cosignerHook.getCosignerGateStatus(
+        new Uint8Array([1, 2, 20, 0, 0, 0, 0, 0, 0, 0]),
+      ),
+    ).toMatchObject({
+      gateEnforced: true,
+      reason: 'invalid_expiry_payload',
+    });
+    expect(
+      cosignerHook.getCosignerGateStatus(
+        cosignerHook.encodeCosignerGateExpiryPayload({
+          mode: cosignerHook.GATE_EXPIRY_SLOT,
+          value: 20n,
+          cosigner,
+        }),
+      ),
+    ).toMatchObject({ gateEnforced: true, reason: 'slot_unavailable' });
+  });
+
+  it('rejects invalid expiry args before encoding', () => {
+    const encodeUnchecked =
+      cosignerHook.encodeCosignerGateExpiryPayload as (expiry: {
+        mode: number;
+        value: bigint | number;
+        cosigner?: Address;
+      }) => Uint8Array;
+
+    expect(() => encodeUnchecked({ mode: 99, value: 0n })).toThrow(
+      /Invalid cosigner gate expiry mode/,
+    );
+    expect(() =>
+      cosignerHook.encodeCosignerGateExpiryPayload({
+        mode: cosignerHook.GATE_EXPIRY_SLOT,
+        value: -1n,
+        cosigner,
+      }),
+    ).toThrow(/Invalid cosigner gate expiry value/);
+    expect(() =>
+      cosignerHook.encodeCosignerGateExpiryPayload({
+        mode: cosignerHook.GATE_EXPIRY_SLOT,
+        value: 1n << 64n,
+        cosigner,
+      }),
+    ).toThrow(/Invalid cosigner gate expiry value/);
+    expect(() =>
+      encodeUnchecked({
+        mode: cosignerHook.GATE_EXPIRY_SLOT,
+        value: 20n,
+      }),
+    ).toThrow(/Cosigner hint is required/);
+    expect(() =>
+      encodeUnchecked({
+        mode: cosignerHook.GATE_EXPIRY_DISABLED,
+        value: 0n,
+        cosigner,
+      }),
+    ).toThrow(/Cosigner hint cannot be encoded/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds SDK support for the expiring Solana co-signer hook payload used by per-launch co-signer gates.

The SDK now models the canonical payload contract:

- empty payload: no expiry, gate remains enforced
- 42-byte payload: version, expiry mode, expiry value, and cosigner hint
- unhinted 10-byte expiry payloads: invalid

Active expiry payloads require a cosigner hint at the TypeScript type level and at runtime. That keeps every expiring launch self-describing for frontend/devtools and downstream adapters.

## Implementation

- Adds co-signer gate constants.
- Adds `encodeCosignerGateExpiryPayload`.
- Adds `decodeCosignerGateExpiryPayload`.
- Adds `getCosignerGateStatus` and `isCosignerGateEnforced` helpers so UI/devtools can determine whether the frontend still needs to request a server co-signature.
- Updates the co-signer-gated Solana launch example to encode a 5-minute timestamp gate by default using `COSIGN_GATE_SECONDS`, with the cosigner hint included in the hook payload.
- Adds focused Vitest coverage for encoding, decoding, status evaluation, and invalid argument/payload behavior.

## Testing

- `pnpm typecheck`
- `pnpm exec vitest run --config vitest.solana.config.ts test/solana/unit/cosignerHook/gate.test.ts`
- `pnpm exec oxlint src/solana/cosignerHook/gate.ts test/solana/unit/cosignerHook/gate.test.ts examples/solana-cosigner-gated-launch.ts`
- `pnpm exec oxfmt --check src/solana/cosignerHook/gate.ts test/solana/unit/cosignerHook/gate.test.ts examples/solana-cosigner-gated-launch.ts src/solana/cosignerHook/constants.ts src/solana/cosignerHook/index.ts`
- `git diff --cached --check`

## Companion Work

- Protocol hook behavior: https://github.com/whetstoneresearch/doppler-sol/pull/172
- DFlow post-expiry routing support: https://github.com/whetstoneresearch/doppler-dflow/pull/5
