### PR TITLE
feat: default multicurve to scheduled initializer with instant launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,9 @@ See [examples/opening-auction-lifecycle.ts](./examples/opening-auction-lifecycle
 
 Multicurve auctions use a Uniswap V4-style initializer that seeds liquidity across multiple curves in a single pool. This enables richer distributions and can be combined with any supported migration path (V2, V3, V4, or NoOp). Multicurve initializer modes are modeled as a typed variant (`standard`, `scheduled`, `decay`, `rehype`) so new hook/initializer variations can be added without breaking existing integrations.
 
-**Standard Multicurve with Migration:**
+By default the SDK uses the **scheduled** multicurve initializer. When `withSchedule()` is omitted the pool is created with `startTime: 0`, which launches instantly — equivalent to the legacy standard behavior but routed through the scheduled initializer. Call `withSchedule({ startTime })` to schedule a future launch. The non-scheduled `standard` initializer is deprecated and only used when explicitly requested via `initializer: { type: 'standard' }`.
+
+**Multicurve with Migration (instant launch):**
 
 ```typescript
 import { MulticurveBuilder } from '@whetstone-research/doppler-sdk/evm';

--- a/src/evm/builders/MulticurveBuilder.ts
+++ b/src/evm/builders/MulticurveBuilder.ts
@@ -705,7 +705,7 @@ export class MulticurveBuilder<
   }): this {
     if (!params) {
       if (this.initializer?.type === 'decay') {
-        this.initializer = { type: 'standard' };
+        this.initializer = undefined;
       }
       return this;
     }
@@ -754,7 +754,7 @@ export class MulticurveBuilder<
   withSchedule(params?: { startTime: number | bigint | Date }): this {
     if (!params) {
       if (this.initializer?.type === 'scheduled') {
-        this.initializer = { type: 'standard' };
+        this.initializer = undefined;
       }
       this.schedule = undefined;
       return this;
@@ -1011,13 +1011,17 @@ export class MulticurveBuilder<
       dopplerHook = { ...dopplerHook, farTick };
     }
 
+    // Default to the scheduled initializer with instant launch (startTime 0)
+    // when no initializer mode is configured. The non-scheduled standard
+    // multicurve initializer is deprecated and only reachable by explicitly
+    // setting `initializer: { type: 'standard' }` on CreateMulticurveParams.
     const initializer =
       this.initializer ??
       (dopplerHook
         ? { type: 'rehype', config: dopplerHook }
         : this.schedule
           ? { type: 'scheduled', startTime: this.schedule.startTime }
-          : { type: 'standard' });
+          : { type: 'scheduled', startTime: 0 });
 
     if (initializer.type === 'scheduled' && dopplerHook) {
       throw new Error(

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -4220,8 +4220,15 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           type: 'rehype',
           hookConfig: legacyHook,
         };
+      } else if (params.modules?.dopplerHookInitializer !== undefined) {
+        // An explicit dopplerHookInitializer override selects the rehype path
+        // even without an initializer/hook config (backwards-compatible).
+        mode = { type: 'rehype' };
       } else {
-        mode = { type: 'standard' };
+        // Default to the scheduled initializer with instant launch (startTime 0).
+        // The non-scheduled standard initializer is deprecated and only used
+        // when explicitly requested via initializer: { type: 'standard' }.
+        mode = { type: 'scheduled', startTime: 0 };
       }
     } else {
       switch (initializer.type) {

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -1051,7 +1051,10 @@ export interface CreateMulticurveParams<
     beneficiaries?: BeneficiaryData[];
   };
 
-  // Preferred initializer configuration. Defaults to { type: 'standard' }.
+  // Preferred initializer configuration. When omitted, defaults to the
+  // scheduled initializer with instant launch ({ type: 'scheduled', startTime: 0 }).
+  // The non-scheduled { type: 'standard' } initializer is deprecated and must be
+  // requested explicitly.
   initializer?: MulticurveInitializerConfig;
 
   /**

--- a/test/evm/setup/fixtures/addresses.ts
+++ b/test/evm/setup/fixtures/addresses.ts
@@ -38,6 +38,9 @@ export const mockAddresses: ChainAddresses = {
   v4MulticurveInitializer: getAddress(
     '0x7100000000000000000000000000000000000007',
   ) as Address,
+  v4ScheduledMulticurveInitializer: getAddress(
+    '0x7150000000000000000000000000000000000007',
+  ) as Address,
   v4DecayMulticurveInitializer: getAddress(
     '0x7200000000000000000000000000000000000007',
   ) as Address,

--- a/test/evm/unit/builders/MulticurveBuilder.test.ts
+++ b/test/evm/unit/builders/MulticurveBuilder.test.ts
@@ -336,6 +336,33 @@ describe('MulticurveBuilder', () => {
       expect(params.modules?.v4DecayMulticurveInitializer).toBe(decayInitializer);
     });
 
+    it('defaults to the scheduled initializer with instant launch (startTime 0)', () => {
+      const params = buildBaseBuilder().build();
+
+      expect(params.initializer).toEqual({ type: 'scheduled', startTime: 0 });
+      expect(params.schedule).toEqual({ startTime: 0 });
+    });
+
+    it('builds scheduled initializer config from withSchedule', () => {
+      const startTime = Math.floor(Date.now() / 1000) + 600;
+      const params = buildBaseBuilder()
+        .withSchedule({ startTime })
+        .build();
+
+      expect(params.initializer).toEqual({ type: 'scheduled', startTime });
+      expect(params.schedule).toEqual({ startTime });
+    });
+
+    it('reverts to the default scheduled instant launch when withSchedule is cleared', () => {
+      const params = buildBaseBuilder()
+        .withSchedule({ startTime: Math.floor(Date.now() / 1000) + 600 })
+        .withSchedule()
+        .build();
+
+      expect(params.initializer).toEqual({ type: 'scheduled', startTime: 0 });
+      expect(params.schedule).toEqual({ startTime: 0 });
+    });
+
     it('builds rehype initializer config with fee schedule and distribution matrix', () => {
       const params = buildBaseBuilder()
         .withRehypeDopplerHook({

--- a/test/evm/unit/entities/DopplerFactory.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.test.ts
@@ -167,6 +167,50 @@ describe('DopplerFactory', () => {
       expect(() => factory.encodeCreateMulticurveParams(params)).not.toThrow();
     });
 
+    it('defaults to the scheduled initializer with instant launch when no initializer is set', () => {
+      const params = multicurveParams();
+      const createParams = factory.encodeCreateMulticurveParams(params);
+
+      expect(createParams.poolInitializer).toBe(
+        mockAddresses.v4ScheduledMulticurveInitializer,
+      );
+
+      // Scheduled initializer encodes a 5-field InitData struct ending in startingTime
+      const [poolInitData] = decodeAbiParameters(
+        [
+          {
+            type: 'tuple',
+            components: [
+              { name: 'fee', type: 'uint24' },
+              { name: 'tickSpacing', type: 'int24' },
+              {
+                name: 'curves',
+                type: 'tuple[]',
+                components: [
+                  { name: 'tickLower', type: 'int24' },
+                  { name: 'tickUpper', type: 'int24' },
+                  { name: 'numPositions', type: 'uint16' },
+                  { name: 'shares', type: 'uint256' },
+                ],
+              },
+              {
+                name: 'beneficiaries',
+                type: 'tuple[]',
+                components: [
+                  { name: 'beneficiary', type: 'address' },
+                  { name: 'shares', type: 'uint96' },
+                ],
+              },
+              { name: 'startingTime', type: 'uint32' },
+            ],
+          },
+        ],
+        createParams.poolInitializerData,
+      ) as any;
+
+      expect(Number(poolInitData.startingTime)).toBe(0);
+    });
+
     it('encodes decay multicurve params with decay initializer', () => {
       const params = multicurveParams();
       params.initializer = {


### PR DESCRIPTION
## What

Makes the **scheduled** multicurve initializer the SDK default. When `withSchedule()` is not set, pools are now created via the scheduled initializer with `startTime: 0` (instant launch). The non-scheduled `standard` initializer is deprecated and only used when explicitly requested via `initializer: { type: 'standard' }`.

## Why

The non-scheduled multicurve initializer is being deprecated/discouraged. The default should route through the scheduled contract.

This also fixes broken default behavior: `v4MulticurveInitializer` (standard) is only deployed on Base and Base Sepolia, whereas the scheduled initializer is deployed on Mainnet, ETH Sepolia, Base, Base Sepolia, and Monad Mainnet. The previous `standard` default failed with "address not configured" on Mainnet/ETH Sepolia/Monad Mainnet.

## Changes

- `MulticurveBuilder.build()` defaults to `{ type: 'scheduled', startTime: 0 }`; `withSchedule()`/`withDecay()` with no args reset the initializer to the default rather than pinning `standard`.
- `DopplerFactory.resolveMulticurveInitializerMode()` defaults to scheduled instant launch; the `dopplerHookInitializer` override path is preserved.
- Updated `CreateMulticurveParams.initializer` doc comment and the README multicurve section.
- Added `v4ScheduledMulticurveInitializer` to the test address fixture and added unit tests for the new default (builder + factory encoding).

## Behavior note

On Base / Base Sepolia, callers relying on the implicit `standard` default will now get pools created through the scheduled initializer, which has a different initializer/hook address and therefore different resulting pool addresses. This is the intended deprecation direction.