### PR TITLE
fix(examples): add multicurve tail ranges

### DIFF
--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -338,7 +338,9 @@ const params = sdk.buildMulticurveAuction()
       // Curve 2: Mid-range (provides depth as price rises)
       { marketCap: { start: 1_000_000, end: 5_000_000 }, numPositions: 15, shares: parseEther('0.4') }, // 40%
       // Curve 3: Upper range (moon bag for high market cap)
-      { marketCap: { start: 4_000_000, end: 50_000_000 }, numPositions: 10, shares: parseEther('0.3') }, // 30%
+      { marketCap: { start: 4_000_000, end: 50_000_000 }, numPositions: 10, shares: parseEther('0.29') }, // 29%
+      // Tail position: extends from the highest curve to infinity ('max')
+      { marketCap: { start: 50_000_000, end: 'max' }, numPositions: 10, shares: parseEther('0.01') }, // 1%
     ],
   })
   .withVesting({ duration: BigInt(365*24*60*60) })

--- a/docs/market-cap-configuration.md
+++ b/docs/market-cap-configuration.md
@@ -81,7 +81,9 @@ const params = sdk.buildMulticurveAuction()
     curves: [
       { marketCap: { start: 500_000, end: 1_500_000 }, numPositions: 10, shares: parseEther('0.3') },
       { marketCap: { start: 1_000_000, end: 5_000_000 }, numPositions: 20, shares: parseEther('0.5') },
-      { marketCap: { start: 4_000_000, end: 50_000_000 }, numPositions: 10, shares: parseEther('0.2') },
+      { marketCap: { start: 4_000_000, end: 50_000_000 }, numPositions: 10, shares: parseEther('0.19') },
+      // Tail position: extends from the highest curve to infinity
+      { marketCap: { start: 50_000_000, end: 'max' }, numPositions: 10, shares: parseEther('0.01') },
     ]
   })
   .withVesting()
@@ -222,12 +224,20 @@ Curve 3: $4M - $50M market cap → tickLower/tickUpper calculated
     { marketCap: { start: 1_000_000, end: 5_000_000 }, numPositions: 15, shares: parseEther('0.4') },
     
     // Upper range with overlap at $4M-$5M
-    { marketCap: { start: 4_000_000, end: 50_000_000 }, numPositions: 10, shares: parseEther('0.3') },
+    { marketCap: { start: 4_000_000, end: 50_000_000 }, numPositions: 10, shares: parseEther('0.29') },
+
+    // Tail position: from the highest curve to infinity ('max')
+    { marketCap: { start: 50_000_000, end: 'max' }, numPositions: 10, shares: parseEther('0.01') },
   ]
 })
 ```
 
 **Shares must sum to 1e18 (100%)**. The SDK validates this automatically.
+
+**Add a tail position from the highest curve to infinity.** Set the final curve's
+`marketCap.end` to `'max'` so the pool always retains liquidity above the top market
+cap target (no upper bound on price). Without it, swaps that would push the price past
+the highest curve have no liquidity to trade against.
 
 ---
 

--- a/examples/rehype/multicurve-rehype-by-marketcap-base-mainnet.ts
+++ b/examples/rehype/multicurve-rehype-by-marketcap-base-mainnet.ts
@@ -288,12 +288,12 @@ async function main() {
         {
           marketCap: { start: 4_000_000, end: 50_000_000 }, // $4M - $50M
           numPositions: 10,
-          shares: parseEther('0.29'),
+          shares: parseEther('0.29'), // 29%
         },
         {
-          marketCap: { start: 50_000_000, end: 'max' },
+          marketCap: { start: 50_000_000, end: 'max' }, // $50M - max
           numPositions: 10,
-          shares: parseEther('0.01'),
+          shares: parseEther('0.01'), // 1%
         },
       ],
       beneficiaries,

--- a/examples/rehype/multicurve-rehype-by-marketcap.ts
+++ b/examples/rehype/multicurve-rehype-by-marketcap.ts
@@ -136,12 +136,12 @@ async function main() {
         {
           marketCap: { start: 4_000_000, end: 50_000_000 }, // $4M - $50M
           numPositions: 10,
-          shares: parseEther('0.29'),
+          shares: parseEther('0.29'), // 29%
         },
         {
-          marketCap: { start: 50_000_000, end: 'max' },
+          marketCap: { start: 50_000_000, end: 'max' }, // $50M - max
           numPositions: 10,
-          shares: parseEther('0.01'),
+          shares: parseEther('0.01'), // 1%
         },
       ],
       beneficiaries,

--- a/examples/rehype/multicurve-with-graduation-market-cap.ts
+++ b/examples/rehype/multicurve-with-graduation-market-cap.ts
@@ -140,12 +140,13 @@ async function main() {
         {
           marketCap: { start: 4_000_000, end: 50_000_000 }, // $4M - $50M
           numPositions: 10,
-          shares: parseEther('0.29'),
+          shares: parseEther('0.29'), // 29%
         },
+        // Curve 4: Tail range to cover prices above the graduation target
         {
-          marketCap: { start: 50_000_000, end: 'max' },
+          marketCap: { start: 50_000_000, end: 'max' }, // $50M - max
           numPositions: 10,
-          shares: parseEther('0.01'),
+          shares: parseEther('0.01'), // 1%
         },
       ],
       beneficiaries,


### PR DESCRIPTION
## Summary

- Add explicit `50_000_000 -> max` tail ranges to remaining multicurve market-cap examples.
- Reduce the preceding upper-range curve share from 30% to 29% so curve shares continue to sum to 100%.
- Keep examples aligned with the existing `marketCap.end: 'max'` SDK keyword.

Closes #75

## Checks

- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:unit`
