### PR TITLE
fix(evm): default multicurve to scheduled initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,9 +360,9 @@ See [examples/opening-auction-lifecycle.ts](./examples/opening-auction-lifecycle
 
 ### Multicurve Auction (V4 Multicurve Initializer)
 
-Multicurve auctions use a Uniswap V4-style initializer that seeds liquidity across multiple curves in a single pool. This enables richer distributions and can be combined with any supported migration path (V2, V3, V4, or NoOp). Multicurve initializer modes are modeled as a typed variant (`standard`, `scheduled`, `decay`, `rehype`) so new hook/initializer variations can be added without breaking existing integrations.
+Multicurve auctions use a Uniswap V4-style initializer that seeds liquidity across multiple curves in a single pool. This enables richer distributions and can be combined with any supported migration path (V2, V3, V4, or NoOp). Multicurve initializer modes are modeled as a typed variant (`standard`, `scheduled`, `decay`, `rehype`) so new hook/initializer variations can be added without breaking existing integrations. The default multicurve initializer mode is `scheduled` with `startTime: 0`, which launches immediately.
 
-**Standard Multicurve with Migration:**
+**Default Multicurve with Migration:**
 
 ```typescript
 import { MulticurveBuilder } from '@whetstone-research/doppler-sdk/evm';
@@ -500,6 +500,7 @@ console.log('Token address:', scheduledResult.tokenAddress);
 ```
 
 Ensure the target chain has the scheduled multicurve initializer whitelisted. If you are targeting a custom deployment, override it via `.withV4ScheduledMulticurveInitializer('0x...')`.
+Omit `.withSchedule(...)` to use the same scheduled initializer with an instant `startTime` of `0`.
 
 **Decay Multicurve Launch (Dynamic Fee):**
 

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -269,7 +269,7 @@ const paramsManual = new DynamicAuctionBuilder(chainId)
 
 ## MulticurveBuilder (V4 Multicurve Initializer)
 
-Recommended when you want to seed a Uniswap V4 pool with multiple curves in a single initializer call. This supports richer liquidity distributions and works with any migration type (V2, V3, or V4).
+Recommended when you want to seed a Uniswap V4 pool with multiple curves in a single initializer call. This supports richer liquidity distributions and works with any migration type (V2, V3, or V4). Multicurve launches default to the scheduled initializer with `startTime: 0`, so they launch immediately unless `withSchedule({ startTime })` provides a future start.
 
 Methods (chainable):
 
@@ -311,6 +311,8 @@ Methods (chainable):
   - withAirlock(address)
   - withTokenFactory(address)
   - withV4MulticurveInitializer(address)
+  - withV4ScheduledMulticurveInitializer(address)
+  - withDopplerHookInitializer(address)
   - withGovernanceFactory(address)
   - withV2Migrator(address)
   - withV2MigratorSplit(address)

--- a/src/evm/builders/MulticurveBuilder.ts
+++ b/src/evm/builders/MulticurveBuilder.ts
@@ -752,19 +752,11 @@ export class MulticurveBuilder<
   }
 
   withSchedule(params?: { startTime: number | bigint | Date }): this {
-    if (!params) {
-      if (this.initializer?.type === 'scheduled') {
-        this.initializer = { type: 'standard' };
-      }
-      this.schedule = undefined;
-      return this;
-    }
-
     this.assertCanSetInitializer('scheduled');
-    const startTimeSeconds = this.parseStartTimeSeconds(
-      params.startTime,
-      'Schedule startTime',
-    );
+    const startTimeSeconds =
+      params === undefined
+        ? 0
+        : this.parseStartTimeSeconds(params.startTime, 'Schedule startTime');
     this.schedule = { startTime: startTimeSeconds };
     this.initializer = { type: 'scheduled', startTime: startTimeSeconds };
     return this;
@@ -1011,25 +1003,32 @@ export class MulticurveBuilder<
       dopplerHook = { ...dopplerHook, farTick };
     }
 
+    const hasDopplerHookInitializerOverride =
+      this.moduleAddresses?.dopplerHookInitializer !== undefined;
+    const hasStandardMulticurveInitializerOverride =
+      this.moduleAddresses?.v4MulticurveInitializer !== undefined;
+
     const initializer =
       this.initializer ??
       (dopplerHook
         ? { type: 'rehype', config: dopplerHook }
-        : this.schedule
-          ? { type: 'scheduled', startTime: this.schedule.startTime }
-          : { type: 'standard' });
+        : hasDopplerHookInitializerOverride
+          ? undefined
+          : hasStandardMulticurveInitializerOverride
+            ? { type: 'standard' }
+            : { type: 'scheduled', startTime: this.schedule?.startTime ?? 0 });
 
-    if (initializer.type === 'scheduled' && dopplerHook) {
+    if (initializer?.type === 'scheduled' && dopplerHook) {
       throw new Error(
         'Cannot combine scheduled multicurve with rehype initializer. Use exactly one initializer mode.',
       );
     }
-    if (initializer.type === 'decay' && dopplerHook) {
+    if (initializer?.type === 'decay' && dopplerHook) {
       throw new Error(
         'Cannot combine decay multicurve with rehype initializer. Use exactly one initializer mode.',
       );
     }
-    if (initializer.type === 'decay') {
+    if (initializer?.type === 'decay') {
       const startFee = Number(initializer.startFee);
       const terminalFee = Number(this.pool.fee);
 
@@ -1047,11 +1046,11 @@ export class MulticurveBuilder<
     }
 
     const schedule =
-      initializer.type === 'scheduled'
+      initializer?.type === 'scheduled'
         ? { startTime: initializer.startTime }
         : undefined;
     dopplerHook =
-      initializer.type === 'rehype' ? initializer.config : undefined;
+      initializer?.type === 'rehype' ? initializer.config : undefined;
 
     // Default governance: noOp on supported chains, default on others (e.g., Ink)
     const governance =

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -4196,6 +4196,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     const legacyHook = params.dopplerHook;
     const hasLegacySchedule = legacySchedule !== undefined;
     const hasLegacyHook = legacyHook !== undefined;
+    const hasExplicitInitializerMode =
+      params.initializer !== undefined || hasLegacySchedule || hasLegacyHook;
 
     if (hasLegacySchedule && hasLegacyHook) {
       throw new Error(
@@ -4221,7 +4223,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           hookConfig: legacyHook,
         };
       } else {
-        mode = { type: 'standard' };
+        mode = { type: 'scheduled', startTime: 0 };
       }
     } else {
       switch (initializer.type) {
@@ -4326,13 +4328,22 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     // Backwards-compatible behavior: an explicit dopplerHookInitializer override
     // selects the DopplerHookInitializer path even without hook config.
     if (params.modules?.dopplerHookInitializer !== undefined) {
-      if (mode.type === 'standard') {
+      if (
+        mode.type === 'standard' ||
+        (!hasExplicitInitializerMode && mode.type === 'scheduled')
+      ) {
         mode = { type: 'rehype' };
       } else if (mode.type !== 'rehype') {
         throw new Error(
           'modules.dopplerHookInitializer can only be used with the rehype or standard multicurve initializer mode',
         );
       }
+    } else if (
+      !hasExplicitInitializerMode &&
+      params.modules?.v4MulticurveInitializer !== undefined &&
+      params.modules.v4ScheduledMulticurveInitializer === undefined
+    ) {
+      mode = { type: 'standard' };
     }
 
     return mode;

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -1051,7 +1051,7 @@ export interface CreateMulticurveParams<
     beneficiaries?: BeneficiaryData[];
   };
 
-  // Preferred initializer configuration. Defaults to { type: 'standard' }.
+  // Preferred initializer configuration. Defaults to { type: 'scheduled', startTime: 0 }.
   initializer?: MulticurveInitializerConfig;
 
   /**

--- a/test/evm/setup/fixtures/addresses.ts
+++ b/test/evm/setup/fixtures/addresses.ts
@@ -38,6 +38,9 @@ export const mockAddresses: ChainAddresses = {
   v4MulticurveInitializer: getAddress(
     '0x7100000000000000000000000000000000000007',
   ) as Address,
+  v4ScheduledMulticurveInitializer: getAddress(
+    '0x7100000000000000000000000000000000000017',
+  ) as Address,
   v4DecayMulticurveInitializer: getAddress(
     '0x7200000000000000000000000000000000000007',
   ) as Address,

--- a/test/evm/unit/builders/MulticurveBuilder.test.ts
+++ b/test/evm/unit/builders/MulticurveBuilder.test.ts
@@ -230,6 +230,56 @@ describe('MulticurveBuilder', () => {
         );
     }
 
+    it('defaults to the scheduled initializer with an instant start time', () => {
+      const params = buildBaseBuilder().build();
+
+      expect(params.initializer).toEqual({
+        type: 'scheduled',
+        startTime: 0,
+      });
+      expect(params.schedule).toEqual({ startTime: 0 });
+    });
+
+    it('uses an instant scheduled initializer when withSchedule is called without params', () => {
+      const params = buildBaseBuilder().withSchedule().build();
+
+      expect(params.initializer).toEqual({
+        type: 'scheduled',
+        startTime: 0,
+      });
+      expect(params.schedule).toEqual({ startTime: 0 });
+    });
+
+    it('keeps an explicit DopplerHookInitializer override on the factory-selected path', () => {
+      const dopplerHookInitializer =
+        '0x7777777777777777777777777777777777777777' as Address;
+
+      const params = buildBaseBuilder()
+        .withDopplerHookInitializer(dopplerHookInitializer)
+        .build();
+
+      expect(params.initializer).toBeUndefined();
+      expect(params.schedule).toBeUndefined();
+      expect(params.modules?.dopplerHookInitializer).toBe(
+        dopplerHookInitializer,
+      );
+    });
+
+    it('uses the legacy standard initializer when its address is explicitly overridden', () => {
+      const standardInitializer =
+        '0x9999999999999999999999999999999999999999' as Address;
+
+      const params = buildBaseBuilder()
+        .withV4MulticurveInitializer(standardInitializer)
+        .build();
+
+      expect(params.initializer).toEqual({ type: 'standard' });
+      expect(params.schedule).toBeUndefined();
+      expect(params.modules?.v4MulticurveInitializer).toBe(
+        standardInitializer,
+      );
+    });
+
     it('builds decay initializer config and keeps pool.fee as terminal fee', () => {
       const startTime = Math.floor(Date.now() / 1000) + 600;
       const params = buildBaseBuilder()

--- a/test/evm/unit/entities/DopplerFactory.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.test.ts
@@ -92,7 +92,11 @@ describe('DopplerFactory', () => {
       const params = multicurveParams();
       const createParams = factory.encodeCreateMulticurveParams(params);
 
-      // Basic UniswapV4MulticurveInitializer expects 4-field InitData struct
+      expect(createParams.poolInitializer).toBe(
+        mockAddresses.v4ScheduledMulticurveInitializer,
+      );
+
+      // The default scheduled initializer uses a 5-field InitData struct.
       const [poolInitData] = decodeAbiParameters(
         [
           {
@@ -118,6 +122,7 @@ describe('DopplerFactory', () => {
                   { name: 'shares', type: 'uint96' },
                 ],
               },
+              { name: 'startingTime', type: 'uint32' },
             ],
           },
         ],
@@ -149,6 +154,67 @@ describe('DopplerFactory', () => {
       expect(Number(fallback.tickUpper)).toBe(expectedTickUpper);
       expect(Number(fallback.numPositions)).toBe(
         params.pool.curves[params.pool.curves.length - 1]!.numPositions,
+      );
+      expect(Number(poolInitData.startingTime)).toBe(0);
+    });
+
+    it('uses the standard multicurve initializer only when explicitly requested', () => {
+      const params = multicurveParams();
+      params.initializer = { type: 'standard' };
+
+      const createParams = factory.encodeCreateMulticurveParams(params);
+
+      expect(createParams.poolInitializer).toBe(
+        mockAddresses.v4MulticurveInitializer,
+      );
+
+      const [poolInitData] = decodeAbiParameters(
+        [
+          {
+            type: 'tuple',
+            components: [
+              { name: 'fee', type: 'uint24' },
+              { name: 'tickSpacing', type: 'int24' },
+              {
+                name: 'curves',
+                type: 'tuple[]',
+                components: [
+                  { name: 'tickLower', type: 'int24' },
+                  { name: 'tickUpper', type: 'int24' },
+                  { name: 'numPositions', type: 'uint16' },
+                  { name: 'shares', type: 'uint256' },
+                ],
+              },
+              {
+                name: 'beneficiaries',
+                type: 'tuple[]',
+                components: [
+                  { name: 'beneficiary', type: 'address' },
+                  { name: 'shares', type: 'uint96' },
+                ],
+              },
+            ],
+          },
+        ],
+        createParams.poolInitializerData,
+      ) as any;
+
+      expect(Number(poolInitData.fee)).toBe(params.pool.fee);
+      expect(Number(poolInitData.tickSpacing)).toBe(params.pool.tickSpacing);
+      expect(poolInitData.curves).toHaveLength(params.pool.curves.length + 1);
+    });
+
+    it('uses the standard multicurve initializer when its module address is explicitly overridden', () => {
+      const params = multicurveParams();
+      params.modules = {
+        v4MulticurveInitializer:
+          '0x7100000000000000000000000000000000000099' as Address,
+      };
+
+      const createParams = factory.encodeCreateMulticurveParams(params);
+
+      expect(createParams.poolInitializer).toBe(
+        params.modules.v4MulticurveInitializer,
       );
     });
 


### PR DESCRIPTION
## Summary

- Default multicurve launches to the scheduled initializer with `startTime: 0` when no initializer mode is provided.
- Keep explicit legacy paths available for `initializer: { type: 'standard' }`, `withV4MulticurveInitializer(...)`, and direct DopplerHookInitializer overrides.
- Update EVM docs/types and add focused unit coverage for the new default and compatibility paths.

Closes #41.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm exec vitest run test/evm/unit/builders/MulticurveBuilder.test.ts test/evm/unit/entities/DopplerFactory.test.ts`
- `pnpm test:unit`

`pnpm typecheck:test` still fails on unrelated existing test typing issues outside this change.