### PR TITLE
feat(evm): update multicurve preset defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,9 +444,9 @@ console.log('Token address:', presetResult.tokenAddress);
 
 The preset helper seeds three curated curve buckets sized for ~1B token supply targets:
 
-- `low`: ~5% of the sale allocated to a $7.5k-$30k market cap window.
-- `medium`: ~12.5% targeting roughly $50k-$150k market caps.
-- `high`: ~20% aimed at $250k-$750k market caps.
+- `low`: 50% of the sale allocated to a $0-$3M market cap window.
+- `medium`: 25% targeting roughly $1k-$40M market caps.
+- `high`: 24% aimed at $100k-$1B market caps.
 
 Pass `presets` to pick a subset (e.g. `['medium', 'high']`) or provide `overrides` to adjust ticks, positions, or shares for a specific tier. When the selected presets sum to less than 100%, the builder automatically appends a filler curve (using the highest selected tier's shape) so liquidity always covers the full sale. Shares must stay within 0-1e18 and the helper will throw if the total ever exceeds 100%.
 

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -389,9 +389,9 @@ const presetParams = new MulticurveBuilder(chainId)
 ```
 
 Preset tiers map to approximate market cap bands (assuming ~1B supply, $4,500 reference numeraire):
-- `low`: 5% allocation targeting $7.5k-$30k launches
-- `medium`: 12.5% allocation targeting $50k-$150k
-- `high`: 20% allocation targeting $250k-$750k
+- `low`: 50% allocation targeting $0-$3M launches
+- `medium`: 25% allocation targeting $1k-$40M
+- `high`: 24% allocation targeting $100k-$1B
 
 All presets use the curated tick ranges from `DEFAULT_MULTICURVE_*` constants. Shares are represented in WAD (1e18 = 100%); if you override shares, ensure they remain within bounds or the builder will throw.
 

--- a/src/evm/constants.ts
+++ b/src/evm/constants.ts
@@ -125,19 +125,20 @@ export const DEFAULT_OPENING_DOPPLER_FEE = FEE_TIERS.HIGH; // 1%
 export const DEFAULT_OPENING_DOPPLER_TICK_SPACING = DOPPLER_MAX_TICK_SPACING;
 
 // V4 Multicurve Default Tick Ranges
-// Based on market cap tiers: LOW ($7.5k -> $30k), MEDIUM ($50k -> $150k), HIGH ($250k -> $750k)
-// Calculated for 1B token supply, $4500 numeraire (e.g., WETH on Base)
+// Based on market cap tiers: LOW ($0 -> $3M), MEDIUM ($1k -> $40M), HIGH ($100k -> $1B)
+// Calculated for 1B token supply, $4500 numeraire (e.g., WETH on Base).
+// The zero-start low tier uses the lowest usable tick rounded to 100 tick spacing.
 export const DEFAULT_MULTICURVE_LOWER_TICKS = [
-  -202_100, -183_100, -167_000,
+  -887_200, -222_200, -176_200,
 ] as const;
 export const DEFAULT_MULTICURVE_UPPER_TICKS = [
-  -188_200, -172_100, -156_000,
+  -142_200, -116_300, -84_100,
 ] as const;
 export const DEFAULT_MULTICURVE_NUM_POSITIONS = [11, 11, 11] as const;
 export const DEFAULT_MULTICURVE_MAX_SUPPLY_SHARES = [
-  parseEther('0.05'), // 5% for LOW tier
-  parseEther('0.125'), // 12.5% for MEDIUM tier
-  parseEther('0.2'), // 20% for HIGH tier
+  parseEther('0.5'), // 50% for LOW tier
+  parseEther('0.25'), // 25% for MEDIUM tier
+  parseEther('0.24'), // 24% for HIGH tier
 ] as const;
 
 // Price bounds

--- a/test/evm/unit/builders/MulticurveBuilder.test.ts
+++ b/test/evm/unit/builders/MulticurveBuilder.test.ts
@@ -84,6 +84,18 @@ describe('MulticurveBuilder', () => {
       FEE_TIERS.LOW
     ];
 
+    expect(DEFAULT_MULTICURVE_LOWER_TICKS).toEqual([
+      -887_200, -222_200, -176_200,
+    ]);
+    expect(DEFAULT_MULTICURVE_UPPER_TICKS).toEqual([
+      -142_200, -116_300, -84_100,
+    ]);
+    expect(DEFAULT_MULTICURVE_MAX_SUPPLY_SHARES).toEqual([
+      parseEther('0.5'),
+      parseEther('0.25'),
+      parseEther('0.24'),
+    ]);
+
     const builder = MulticurveBuilder.forChain(CHAIN_IDS.BASE)
       .tokenConfig({
         type: 'standard',


### PR DESCRIPTION
## Summary

- update EVM multicurve market-cap preset defaults for low, medium, and high tiers
- document the new preset market-cap bands in the README and API builder docs
- pin the regenerated preset ticks and shares in the MulticurveBuilder unit test

## Presets

- `low`: $0 to $3M, 50%
- `medium`: $1k to $40M, 25%
- `high`: $100k to $1B, 24%

Closes #86

## Tests

- `pnpm exec vitest run test/evm/unit/builders/MulticurveBuilder.test.ts`
- `pnpm format:check`
