### PR TITLE
fix(factory): reject duplicate beneficiary addresses at encode layer

### DIFF
--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -80,6 +80,7 @@ import {
   MIN_TICK,
   MAX_TICK,
   isToken0Expected,
+  sortBeneficiaries,
 } from '../utils';
 import { normalizeRehypeDopplerHookMigratorConfig } from '../utils/dopplerHookMigrator';
 import {
@@ -1191,14 +1192,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     let poolInitializerData: Hex;
 
     if (hasBeneficiaries) {
-      // Sort beneficiaries by address (ascending) as required by the contract
-      const sortedBeneficiaries = params.pool
-        .beneficiaries!.slice()
-        .sort((a, b) => {
-          const aAddr = a.beneficiary.toLowerCase();
-          const bAddr = b.beneficiary.toLowerCase();
-          return aAddr < bAddr ? -1 : aAddr > bAddr ? 1 : 0;
-        });
+      // Sort beneficiaries by address (ascending) and reject duplicates as
+      // required by the contract
+      const sortedBeneficiaries = sortBeneficiaries(params.pool.beneficiaries!);
 
       // Lockable V3 initializer encoding (6 fields including beneficiaries)
       poolInitializerData = encodeAbiParameters(
@@ -3768,14 +3764,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           return '0x';
         }
 
-        // Copy beneficiaries and sort by address in ascending order (required by contract)
-        const beneficiaryData = [...streamableFees.beneficiaries].sort(
-          (a, b) => {
-            const addrA = a.beneficiary.toLowerCase();
-            const addrB = b.beneficiary.toLowerCase();
-            return addrA < addrB ? -1 : addrA > addrB ? 1 : 0;
-          },
-        );
+        // Copy beneficiaries, sort by address ascending and reject duplicates (required by contract)
+        const beneficiaryData = sortBeneficiaries(streamableFees.beneficiaries);
 
         // Note: The contract will validate that the airlock owner gets at least 5%
         // If not present, the SDK user should add it manually
@@ -3802,12 +3792,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         );
 
       case 'uniswapV4Split': {
-        const beneficiaryData = [...config.streamableFees.beneficiaries].sort(
-          (a, b) => {
-            const addrA = a.beneficiary.toLowerCase();
-            const addrB = b.beneficiary.toLowerCase();
-            return addrA < addrB ? -1 : addrA > addrB ? 1 : 0;
-          },
+        const beneficiaryData = sortBeneficiaries(
+          config.streamableFees.beneficiaries,
         );
 
         const proceedsRecipient =
@@ -3849,13 +3835,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           );
         }
 
-        // Copy beneficiaries and sort by address in ascending order (required by contract)
-        const beneficiaries = [...dopplerHookConfig.beneficiaries].sort(
-          (a, b) => {
-            const addrA = a.beneficiary.toLowerCase();
-            const addrB = b.beneficiary.toLowerCase();
-            return addrA < addrB ? -1 : addrA > addrB ? 1 : 0;
-          },
+        // Copy beneficiaries, sort by address ascending and reject duplicates (required by contract)
+        const beneficiaries = sortBeneficiaries(
+          dopplerHookConfig.beneficiaries,
         );
 
         let dopplerHookAddress: Address = ZERO_ADDRESS;
@@ -4357,18 +4339,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     const addresses = getAddresses(this.chainId);
 
     // Pool initializer data: (fee, tickSpacing, farTick, curves[], beneficiaries[], dopplerHook, onInitializationCalldata, graduationCalldata)
-    const sortedBeneficiaries = (params.pool.beneficiaries ?? [])
-      .slice()
-      .sort(
-        (
-          a: NonNullable<typeof params.pool.beneficiaries>[number],
-          b: NonNullable<typeof params.pool.beneficiaries>[number],
-        ) => {
-          const aAddr = a.beneficiary.toLowerCase();
-          const bAddr = b.beneficiary.toLowerCase();
-          return aAddr < bAddr ? -1 : aAddr > bAddr ? 1 : 0;
-        },
-      );
+    const sortedBeneficiaries = sortBeneficiaries(
+      params.pool.beneficiaries ?? [],
+    );
 
     const initializerMode = this.resolveMulticurveInitializerMode(params);
     const useScheduledInitializer = initializerMode.type === 'scheduled';

--- a/src/evm/utils/beneficiaries.ts
+++ b/src/evm/utils/beneficiaries.ts
@@ -1,0 +1,45 @@
+import type { Address } from 'viem';
+
+/**
+ * Sort beneficiaries by address (ascending) as required by the pool contract,
+ * rejecting duplicate addresses up-front.
+ *
+ * The pool/migrator contracts enforce strictly ascending beneficiary addresses
+ * and revert with `UnorderedBeneficiaries()` when two entries share an address.
+ * Two equal addresses are not strictly ascending, so the transaction reverts and
+ * the integrator only finds out after spending gas, with an opaque error.
+ *
+ * Catching the duplicate here — at the encode layer that every create/migration
+ * path funnels through — surfaces a readable error before the transaction is
+ * broadcast. Address comparison is case-insensitive, so the same address supplied
+ * with different checksum casing is also caught.
+ *
+ * Generic over the beneficiary shape so it can be reused across the differently
+ * typed beneficiary lists (pool initializer, streamable fees, doppler hook).
+ */
+export function sortBeneficiaries<T extends { beneficiary: Address }>(
+  beneficiaries: readonly T[],
+): T[] {
+  const sorted = [...beneficiaries].sort((a, b) => {
+    const aAddr = a.beneficiary.toLowerCase();
+    const bAddr = b.beneficiary.toLowerCase();
+    return aAddr < bAddr ? -1 : aAddr > bAddr ? 1 : 0;
+  });
+
+  for (let i = 1; i < sorted.length; i++) {
+    if (
+      sorted[i].beneficiary.toLowerCase() ===
+      sorted[i - 1].beneficiary.toLowerCase()
+    ) {
+      throw new Error(
+        `Duplicate beneficiary address: ${sorted[i].beneficiary}. ` +
+          'Each beneficiary address must be unique — the contract requires ' +
+          'strictly ascending addresses and reverts with ' +
+          'UnorderedBeneficiaries() otherwise. Merge the entries into a ' +
+          'single beneficiary with the combined shares.',
+      );
+    }
+  }
+
+  return sorted;
+}

--- a/src/evm/utils/index.ts
+++ b/src/evm/utils/index.ts
@@ -63,6 +63,8 @@ export { resolveGasEstimate } from './gasEstimate';
 
 export { isToken0Expected } from './isToken0Expected';
 
+export { sortBeneficiaries } from './beneficiaries';
+
 export { encodeRehypeDopplerHookMigratorCalldata } from './dopplerHookMigrator';
 
 // Re-export market cap conversion utilities

--- a/test/evm/unit/entities/DopplerFactory.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.test.ts
@@ -613,6 +613,23 @@ describe('DopplerFactory', () => {
       );
     });
 
+    it('rejects duplicate pool beneficiary addresses', () => {
+      // The pool contract requires strictly ascending beneficiary addresses and
+      // reverts with UnorderedBeneficiaries() on duplicates. The encode layer
+      // should surface this as a readable error before broadcasting.
+      const duplicate =
+        '0x0000000000000000000000000000000000000001' as Address;
+      const params = multicurveParams();
+      params.pool.beneficiaries = [
+        { beneficiary: duplicate, shares: parseEther('0.5') },
+        { beneficiary: duplicate, shares: parseEther('0.5') },
+      ];
+
+      expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+        /Duplicate beneficiary address/,
+      );
+    });
+
     it('accepts decay startFee up to 80%', () => {
       const params = multicurveParams();
       params.initializer = {

--- a/test/evm/unit/utils/beneficiaries.test.ts
+++ b/test/evm/unit/utils/beneficiaries.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { parseEther, type Address } from 'viem';
+import { sortBeneficiaries } from '../../../../src/evm/utils/beneficiaries';
+
+const addr = (hex: string): Address => hex as Address;
+
+describe('sortBeneficiaries', () => {
+  it('sorts beneficiaries by address ascending', () => {
+    const result = sortBeneficiaries([
+      { beneficiary: addr('0x0000000000000000000000000000000000000003'), shares: parseEther('0.3') },
+      { beneficiary: addr('0x0000000000000000000000000000000000000001'), shares: parseEther('0.4') },
+      { beneficiary: addr('0x0000000000000000000000000000000000000002'), shares: parseEther('0.3') },
+    ]);
+
+    expect(result.map((b) => b.beneficiary)).toEqual([
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+      '0x0000000000000000000000000000000000000003',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      { beneficiary: addr('0x0000000000000000000000000000000000000002'), shares: 1n },
+      { beneficiary: addr('0x0000000000000000000000000000000000000001'), shares: 1n },
+    ];
+    const snapshot = input.map((b) => b.beneficiary);
+
+    sortBeneficiaries(input);
+
+    expect(input.map((b) => b.beneficiary)).toEqual(snapshot);
+  });
+
+  it('throws on duplicate addresses', () => {
+    const duplicate = addr('0x0000000000000000000000000000000000000001');
+    expect(() =>
+      sortBeneficiaries([
+        { beneficiary: duplicate, shares: parseEther('0.5') },
+        { beneficiary: duplicate, shares: parseEther('0.5') },
+      ]),
+    ).toThrow(/Duplicate beneficiary address/);
+  });
+
+  it('treats addresses as case-insensitive when detecting duplicates', () => {
+    expect(() =>
+      sortBeneficiaries([
+        { beneficiary: addr('0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa'), shares: 1n },
+        { beneficiary: addr('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), shares: 1n },
+      ]),
+    ).toThrow(/Duplicate beneficiary address/);
+  });
+
+  it('passes through empty and single-element lists', () => {
+    expect(sortBeneficiaries([])).toEqual([]);
+
+    const single = [
+      { beneficiary: addr('0x0000000000000000000000000000000000000001'), shares: 1n },
+    ];
+    expect(sortBeneficiaries(single)).toEqual(single);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #137 at the factory encode layer.

The builders sort `beneficiaries` by address but never reject duplicates. Two entries sharing an address pass straight through and produce parameters that revert on-chain with `UnorderedBeneficiaries()` — the pool/migrator contracts require strictly ascending addresses. The integrator only discovers this after spending gas, with an opaque revert. This is easy to hit when the token creator and an integrator/treasury address are the same wallet.

PR #138 addressed this in the three builder methods. The duplicate check is more robust at the **factory encode layer**, because:

- It is the single chokepoint that *every* path funnels through — builder output **and** callers who invoke `factory.create*` / `encodeCreate*Params` directly with hand-built params (which bypass the builders entirely).
- Beneficiaries are encoded in **four** distinct lists, not just the two the builders cover: the lockable V3 pool initializer, the multicurve pool initializer, `uniswapV4`/`uniswapV4Split` streamable fees, and `dopplerHook` migration. The builder-only fix leaves the streamable-fees and doppler-hook lists unguarded.

The check still runs before the transaction is broadcast, so the gas-saving / fail-fast goal is fully preserved.

## Change

- Add a shared, generic `sortBeneficiaries` helper in `src/evm/utils/beneficiaries.ts`. It sorts by address (ascending) and throws a readable error on duplicate addresses. Comparison is case-insensitive, so the same address with different checksum casing is also caught. It lives in `utils/` (the neutral layer) rather than `builders/shared.ts` so `entities/` can import it without a wrong-direction dependency.
- Replace all five inline sort sites in `DopplerFactory.ts` with the helper, removing the duplicated sort comparators.

Behavior for valid input is unchanged — only duplicates, which would have reverted on-chain anyway, now fail early with a clear message. This mirrors the existing fail-fast validation (e.g. beneficiary shares must sum to `WAD`).

## Notes

- This supersedes #138 by covering the direct-factory and migration paths it misses. The builder-level checks from #138 would become redundant once this lands; they can optionally be kept for an earlier, more precise error, or dropped in favor of this single home.

## Testing

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm test:unit` — 736 pass, including a focused `sortBeneficiaries` unit suite and a new `DopplerFactory` test asserting duplicate pool beneficiaries throw at encode time.