### PR TITLE
[SOL-52] feat(solana): add root swap and migration helpers

### DIFF
--- a/examples/solana-adv-e2e-launch.ts
+++ b/examples/solana-adv-e2e-launch.ts
@@ -14,35 +14,24 @@
  */
 import './env.js';
 
-import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
-  getSyncNativeInstruction,
-} from '@solana-program/token';
-import {
-  SYSTEM_PROGRAM_ADDRESS,
-  getTransferSolInstruction,
-} from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
   cpmm,
   cpmmMigrator,
   createLaunch,
+  curveSwapExactIn,
   initializer,
+  migrateLaunch,
 } from '../src/solana/index.js';
 import {
   DEFAULT_SWAP_FEE_BPS,
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
   assertSolanaExampleNetwork,
-  createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
-  getTokenAccountRentLamports,
   loadKeypairSignerFromEnv,
   sendInitializeLaunchWithLookupTable,
   sendInstructions,
@@ -248,78 +237,30 @@ async function main() {
     console.log('');
 
     // ── Step 4: Execute the curve buy ────────────────────────────────────────
-    // ATA creation, WSOL deposit, and the curve buy are batched into a single
-    // transaction — instructions execute sequentially so the ATAs exist and are
-    // funded before the swap runs.
     console.log('Step 4: Executing bonding curve buy...');
 
-    const [userBaseAta] = await findAssociatedTokenPda({
-      owner: payer.address,
-      mint: baseMint.address,
-      tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    });
-    const [userQuoteAta] = await findAssociatedTokenPda({
-      owner: payer.address,
-      mint: WSOL_MINT,
-      tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    });
-
-    const createBaseAtaIx = getCreateAssociatedTokenIdempotentInstruction({
+    const curveBuy = await curveSwapExactIn({
+      deployment,
+      launch,
+      launchAuthority,
+      baseVault: baseVault.address,
+      quoteVault: quoteVault.address,
+      launchFeeState,
+      baseMint: baseMint.address,
+      quoteMint: WSOL_MINT,
       payer,
-      ata: userBaseAta,
-      owner: payer.address,
-      mint: baseMint.address,
+      amountIn: BUY_AMOUNT_IN,
+      minAmountOut: 1n, // accept any amount for the example; use preview.amountOut in prod
+      tradeDirection: initializer.TRADE_DIRECTION_BUY,
+      hookProgram: deployment.cpmmHookProgram,
     });
-    const createQuoteAtaIx = getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userQuoteAta,
-      owner: payer.address,
-      mint: WSOL_MINT,
-    });
-    const transferSolIx = getTransferSolInstruction({
-      source: payer,
-      destination: userQuoteAta,
-      amount: BUY_AMOUNT_IN + getTokenAccountRentLamports(),
-    });
-
-    const syncNativeIx = getSyncNativeInstruction({ account: userQuoteAta });
-
-    const swapIx = initializer.createCurveSwapExactInInstruction(
-      {
-        launch,
-        launchAuthority,
-        baseVault: baseVault.address,
-        quoteVault: quoteVault.address,
-        launchFeeState,
-        userBaseAccount: userBaseAta,
-        userQuoteAccount: userQuoteAta,
-        baseMint: baseMint.address,
-        quoteMint: WSOL_MINT,
-        user: payer,
-        hookProgram: deployment.cpmmHookProgram,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-      },
-      {
-        amountIn: BUY_AMOUNT_IN,
-        minAmountOut: 1n, // accept any amount for the example; use preview.amountOut in prod
-        tradeDirection: initializer.TRADE_DIRECTION_BUY,
-      },
-      deployment.initializerProgram,
-    );
 
     {
       const signature = await sendInstructions({
         rpc,
         rpcSubscriptions,
         payer,
-        instructions: [
-          createBaseAtaIx,
-          createQuoteAtaIx,
-          transferSolIx,
-          syncNativeIx,
-          swapIx,
-        ],
+        instructions: curveBuy.instructions,
       });
 
       console.log('  Curve buy confirmed:', signature);
@@ -335,43 +276,27 @@ async function main() {
     // at launch creation.
     console.log('Step 5: Migrating launch to CPMM pool...');
 
-    const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(
-      {
-        config: initializerConfig,
-        launch,
-        launchAuthority,
-        baseMint: baseMint.address,
-        quoteMint: WSOL_MINT,
-        baseVault: baseVault.address,
-        quoteVault: quoteVault.address,
-        launchFeeState,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        payer,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-      },
-      deployment.initializerProgram,
-    );
-
-    const migrateLaunchIx = {
-      ...migrateLaunchIxBase,
-      accounts: [
-        ...(migrateLaunchIxBase.accounts ?? []),
-        ...migrationAccounts.metas,
-      ],
-    };
+    const migration = migrateLaunch({
+      deployment,
+      config: initializerConfig,
+      launch,
+      launchAuthority,
+      baseMint: baseMint.address,
+      quoteMint: WSOL_MINT,
+      baseVault: baseVault.address,
+      quoteVault: quoteVault.address,
+      launchFeeState,
+      payer,
+      cpmmMigration: migrationAccounts,
+      computeUnitLimit: 400_000,
+    });
 
     {
       const signature = await sendInstructions({
         rpc,
         rpcSubscriptions,
         payer,
-        instructions: [
-          createSetComputeUnitLimitInstruction(400_000),
-          migrateLaunchIx,
-        ],
+        instructions: migration.instructions,
       });
 
       console.log('  Migration confirmed:', signature);

--- a/examples/solana-cosigner-gated-buy-token-2022.ts
+++ b/examples/solana-cosigner-gated-buy-token-2022.ts
@@ -13,24 +13,19 @@
  */
 import './env.js';
 
-import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
-  getSyncNativeInstruction,
-} from '@solana-program/token';
-import {
-  SYSTEM_PROGRAM_ADDRESS,
-  getTransferSolInstruction,
-} from '@solana-program/system';
+import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
+  assertMigrationQuoteThreshold,
   cosignerHook,
   cpmm,
   createLaunch,
+  curveSwapExactIn,
   initializer,
+  migrateLaunch,
+  swapExactIn,
 } from '../src/solana/index.js';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '../src/solana/core/constants.js';
 
@@ -39,14 +34,11 @@ import {
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
   assertCosignerRegistered,
-  assertMigrationQuoteThreshold,
   assertSimulationRejected,
   assertSolanaExampleNetwork,
-  createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
-  getTokenAccountRentLamports,
   loadCosigner,
   loadKeypairSignerFromEnv,
   loadLaunchBeneficiaries,
@@ -192,84 +184,44 @@ async function main() {
   });
   console.log('  Launch tx:         ', launchSignature);
 
-  const [userBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-  });
-  const [userQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: WSOL_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const setupAndFund = [
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userBaseAta,
-      owner: payer.address,
-      mint: baseMint.address,
-      tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-    }),
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userQuoteAta,
-      owner: payer.address,
-      mint: WSOL_MINT,
-    }),
-    getTransferSolInstruction({
-      source: payer,
-      destination: userQuoteAta,
-      amount: BUY_AMOUNT_IN + getTokenAccountRentLamports(),
-    }),
-    getSyncNativeInstruction({ account: userQuoteAta }),
-  ];
-  const swapAccounts = {
-    config: deployment.initializerConfig,
+  const swapBaseInput = {
+    deployment,
     launch,
     launchAuthority,
     baseVault: baseVault.address,
     quoteVault: quoteVault.address,
     launchFeeState,
-    userBaseAccount: userBaseAta,
-    userQuoteAccount: userQuoteAta,
     baseMint: baseMint.address,
     quoteMint: WSOL_MINT,
-    user: payer,
+    payer,
+    amountIn: BUY_AMOUNT_IN,
+    minAmountOut: 1n,
+    tradeDirection: initializer.TRADE_DIRECTION_BUY,
     hookProgram: deployment.cosignerHookProgram,
     baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-  };
+  } as const;
 
-  const unsignedSwapIx = initializer.createCurveSwapExactInInstruction(
-    { ...swapAccounts, remainingAccounts: unsignedHookRemainingAccounts },
-    {
-      amountIn: BUY_AMOUNT_IN,
-      minAmountOut: 1n,
-      tradeDirection: initializer.TRADE_DIRECTION_BUY,
-    },
-    deployment.initializerProgram,
-  );
+  const unsignedBuy = await curveSwapExactIn({
+    ...swapBaseInput,
+    remainingAccounts: unsignedHookRemainingAccounts,
+  });
   const unsignedResult = await simulateInstructions({
     rpc,
     payer,
-    instructions: [...setupAndFund, unsignedSwapIx],
+    instructions: unsignedBuy.instructions,
   });
   assertSimulationRejected('Unsigned bonding curve buy', unsignedResult.err);
 
-  const signedSwapIx = initializer.createCurveSwapExactInInstruction(
-    { ...swapAccounts, remainingAccounts: signedHookRemainingAccounts },
-    {
-      amountIn: BUY_AMOUNT_IN,
-      minAmountOut: 1n,
-      tradeDirection: initializer.TRADE_DIRECTION_BUY,
-    },
-    deployment.initializerProgram,
-  );
+  const signedBuy = await curveSwapExactIn({
+    ...swapBaseInput,
+    remainingAccounts: signedHookRemainingAccounts,
+  });
   const buySignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [...setupAndFund, signedSwapIx],
+    instructions: signedBuy.instructions,
   });
   console.log('  Cosigned buy tx:   ', buySignature);
 
@@ -299,52 +251,26 @@ async function main() {
   console.log('  Pending quote fees:', pendingQuoteFees.toString());
   console.log('');
 
-  const createRecipientAtaIxs = migrationAccounts.recipientAtas.map(
-    (ata, index) =>
-      getCreateAssociatedTokenIdempotentInstruction({
-        payer,
-        ata,
-        owner: launchBeneficiaries.recipients[index].wallet,
-        mint: baseMint.address,
-        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-      }),
-  );
-
-  const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(
-    {
-      config: deployment.initializerConfig,
-      launch,
-      launchAuthority,
-      baseMint: baseMint.address,
-      quoteMint: WSOL_MINT,
-      baseVault: baseVault.address,
-      quoteVault: quoteVault.address,
-      launchFeeState,
-      migratorProgram: deployment.cpmmMigratorProgram,
-      payer,
-      baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-      quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
-      rent: SYSVAR_RENT_ADDRESS,
-    },
-    deployment.initializerProgram,
-  );
-  const migrateLaunchIx = {
-    ...migrateLaunchIxBase,
-    accounts: [
-      ...(migrateLaunchIxBase.accounts ?? []),
-      ...migrationAccounts.metas,
-    ],
-  };
+  const migration = migrateLaunch({
+    deployment,
+    launch,
+    launchAuthority,
+    baseMint: baseMint.address,
+    quoteMint: WSOL_MINT,
+    baseVault: baseVault.address,
+    quoteVault: quoteVault.address,
+    launchFeeState,
+    payer,
+    cpmmMigration: migrationAccounts,
+    recipients: launchBeneficiaries.recipients,
+    baseTokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
+  });
   const migrationSignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [
-      createSetComputeUnitLimitInstruction(800_000),
-      ...createRecipientAtaIxs,
-      migrateLaunchIx,
-    ],
+    instructions: migration.instructions,
   });
   console.log('  Migration tx:      ', migrationSignature);
 
@@ -373,7 +299,7 @@ async function main() {
     throw new Error('CPMM pool was not found after migration');
   }
 
-  const { address: poolAddress, account: pool } = poolResult;
+  const { account: pool } = poolResult;
   if (pool.hookProgram !== SYSTEM_PROGRAM_ADDRESS || pool.hookFlags !== 0) {
     throw new Error(
       `Migrated pool hook mismatch: got program ${pool.hookProgram} flags ${pool.hookFlags}, expected no CPMM hook`,
@@ -382,25 +308,12 @@ async function main() {
 
   const tradeDirection = pool.token0Mint === baseMint.address ? 0 : 1;
   const CPMM_SWAP_AMOUNT_IN = 1_000_000n;
-  const quote = cpmm.getSwapQuote(pool, CPMM_SWAP_AMOUNT_IN, tradeDirection);
-  const minAmountOut = (quote.amountOut * 9_500n) / 10_000n;
-  const userToken0 =
-    pool.token0Mint === baseMint.address ? userBaseAta : userQuoteAta;
-  const userToken1 =
-    pool.token1Mint === baseMint.address ? userBaseAta : userQuoteAta;
-  const cpmmSwapIx = cpmm.createSwapInstruction({
-    config: migrationAccounts.cpmmConfig,
-    pool: poolAddress,
-    authority: pool.authority,
-    vault0: pool.vault0,
-    vault1: pool.vault1,
-    token0Mint: pool.token0Mint,
-    token1Mint: pool.token1Mint,
-    userToken0,
-    userToken1,
-    user: payer,
+  const cpmmSwap = await swapExactIn({
+    deployment,
+    pool: poolResult,
+    payer,
     amountIn: CPMM_SWAP_AMOUNT_IN,
-    minAmountOut,
+    slippageBps: 500n,
     tradeDirection,
     token0Program:
       pool.token0Mint === baseMint.address
@@ -410,13 +323,12 @@ async function main() {
       pool.token1Mint === baseMint.address
         ? TOKEN_2022_PROGRAM_ADDRESS
         : TOKEN_PROGRAM_ADDRESS,
-    programId: deployment.cpmmProgram,
   });
   const cpmmSwapSignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [createSetComputeUnitLimitInstruction(400_000), cpmmSwapIx],
+    instructions: cpmmSwap.instructions,
   });
   console.log('  Ungated CPMM swap tx:', cpmmSwapSignature);
   console.log('');

--- a/examples/solana-cosigner-gated-buy.ts
+++ b/examples/solana-cosigner-gated-buy.ts
@@ -13,24 +13,18 @@
  */
 import './env.js';
 
-import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
-  getSyncNativeInstruction,
-} from '@solana-program/token';
-import {
-  SYSTEM_PROGRAM_ADDRESS,
-  getTransferSolInstruction,
-} from '@solana-program/system';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
+  assertMigrationQuoteThreshold,
   cosignerHook,
   cpmm,
   createLaunch,
+  curveSwapExactIn,
   initializer,
+  migrateLaunch,
+  swapExactIn,
 } from '../src/solana/index.js';
 
 import {
@@ -38,14 +32,11 @@ import {
   DEFAULT_TEST_METADATA,
   WSOL_MINT,
   assertCosignerRegistered,
-  assertMigrationQuoteThreshold,
   assertSimulationRejected,
   assertSolanaExampleNetwork,
-  createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
-  getTokenAccountRentLamports,
   loadCosigner,
   loadKeypairSignerFromEnv,
   loadLaunchBeneficiaries,
@@ -190,82 +181,42 @@ async function main() {
   });
   console.log('  Launch tx:         ', launchSignature);
 
-  const [userBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const [userQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: WSOL_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const setupAndFund = [
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userBaseAta,
-      owner: payer.address,
-      mint: baseMint.address,
-    }),
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userQuoteAta,
-      owner: payer.address,
-      mint: WSOL_MINT,
-    }),
-    getTransferSolInstruction({
-      source: payer,
-      destination: userQuoteAta,
-      amount: BUY_AMOUNT_IN + getTokenAccountRentLamports(),
-    }),
-    getSyncNativeInstruction({ account: userQuoteAta }),
-  ];
-  const swapAccounts = {
+  const swapBaseInput = {
+    deployment,
     launch,
     launchAuthority,
     baseVault: baseVault.address,
     quoteVault: quoteVault.address,
     launchFeeState,
-    userBaseAccount: userBaseAta,
-    userQuoteAccount: userQuoteAta,
     baseMint: baseMint.address,
     quoteMint: WSOL_MINT,
-    user: payer,
+    payer,
+    amountIn: BUY_AMOUNT_IN,
+    minAmountOut: 1n,
+    tradeDirection: initializer.TRADE_DIRECTION_BUY,
     hookProgram: deployment.cosignerHookProgram,
-    baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-    quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-  };
+  } as const;
 
-  const unsignedSwapIx = initializer.createCurveSwapExactInInstruction(
-    { ...swapAccounts, remainingAccounts: unsignedHookRemainingAccounts },
-    {
-      amountIn: BUY_AMOUNT_IN,
-      minAmountOut: 1n,
-      tradeDirection: initializer.TRADE_DIRECTION_BUY,
-    },
-    deployment.initializerProgram,
-  );
+  const unsignedBuy = await curveSwapExactIn({
+    ...swapBaseInput,
+    remainingAccounts: unsignedHookRemainingAccounts,
+  });
   const unsignedResult = await simulateInstructions({
     rpc,
     payer,
-    instructions: [...setupAndFund, unsignedSwapIx],
+    instructions: unsignedBuy.instructions,
   });
   assertSimulationRejected('Unsigned bonding curve buy', unsignedResult.err);
 
-  const signedSwapIx = initializer.createCurveSwapExactInInstruction(
-    { ...swapAccounts, remainingAccounts: signedHookRemainingAccounts },
-    {
-      amountIn: BUY_AMOUNT_IN,
-      minAmountOut: 1n,
-      tradeDirection: initializer.TRADE_DIRECTION_BUY,
-    },
-    deployment.initializerProgram,
-  );
+  const signedBuy = await curveSwapExactIn({
+    ...swapBaseInput,
+    remainingAccounts: signedHookRemainingAccounts,
+  });
   const buySignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [...setupAndFund, signedSwapIx],
+    instructions: signedBuy.instructions,
   });
   console.log('  Cosigned buy tx:   ', buySignature);
 
@@ -295,51 +246,24 @@ async function main() {
   console.log('  Pending quote fees:', pendingQuoteFees.toString());
   console.log('');
 
-  const createRecipientAtaIxs = migrationAccounts.recipientAtas.map(
-    (ata, index) =>
-      getCreateAssociatedTokenIdempotentInstruction({
-        payer,
-        ata,
-        owner: launchBeneficiaries.recipients[index].wallet,
-        mint: baseMint.address,
-      }),
-  );
-
-  const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(
-    {
-      config: deployment.initializerConfig,
-      launch,
-      launchAuthority,
-      baseMint: baseMint.address,
-      quoteMint: WSOL_MINT,
-      baseVault: baseVault.address,
-      quoteVault: quoteVault.address,
-      launchFeeState,
-      migratorProgram: deployment.cpmmMigratorProgram,
-      payer,
-      baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-      quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
-      rent: SYSVAR_RENT_ADDRESS,
-    },
-    deployment.initializerProgram,
-  );
-  const migrateLaunchIx = {
-    ...migrateLaunchIxBase,
-    accounts: [
-      ...(migrateLaunchIxBase.accounts ?? []),
-      ...migrationAccounts.metas,
-    ],
-  };
+  const migration = migrateLaunch({
+    deployment,
+    launch,
+    launchAuthority,
+    baseMint: baseMint.address,
+    quoteMint: WSOL_MINT,
+    baseVault: baseVault.address,
+    quoteVault: quoteVault.address,
+    launchFeeState,
+    payer,
+    cpmmMigration: migrationAccounts,
+    recipients: launchBeneficiaries.recipients,
+  });
   const migrationSignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [
-      createSetComputeUnitLimitInstruction(800_000),
-      ...createRecipientAtaIxs,
-      migrateLaunchIx,
-    ],
+    instructions: migration.instructions,
   });
   console.log('  Migration tx:      ', migrationSignature);
 
@@ -368,7 +292,7 @@ async function main() {
     throw new Error('CPMM pool was not found after migration');
   }
 
-  const { address: poolAddress, account: pool } = poolResult;
+  const { account: pool } = poolResult;
   if (pool.hookProgram !== SYSTEM_PROGRAM_ADDRESS || pool.hookFlags !== 0) {
     throw new Error(
       `Migrated pool hook mismatch: got program ${pool.hookProgram} flags ${pool.hookFlags}, expected no CPMM hook`,
@@ -377,33 +301,19 @@ async function main() {
 
   const tradeDirection = pool.token0Mint === baseMint.address ? 0 : 1;
   const CPMM_SWAP_AMOUNT_IN = 1_000_000n;
-  const quote = cpmm.getSwapQuote(pool, CPMM_SWAP_AMOUNT_IN, tradeDirection);
-  const minAmountOut = (quote.amountOut * 9_500n) / 10_000n;
-  const userToken0 =
-    pool.token0Mint === baseMint.address ? userBaseAta : userQuoteAta;
-  const userToken1 =
-    pool.token1Mint === baseMint.address ? userBaseAta : userQuoteAta;
-  const cpmmSwapIx = cpmm.createSwapInstruction({
-    config: migrationAccounts.cpmmConfig,
-    pool: poolAddress,
-    authority: pool.authority,
-    vault0: pool.vault0,
-    vault1: pool.vault1,
-    token0Mint: pool.token0Mint,
-    token1Mint: pool.token1Mint,
-    userToken0,
-    userToken1,
-    user: payer,
+  const cpmmSwap = await swapExactIn({
+    deployment,
+    pool: poolResult,
+    payer,
     amountIn: CPMM_SWAP_AMOUNT_IN,
-    minAmountOut,
+    slippageBps: 500n,
     tradeDirection,
-    programId: deployment.cpmmProgram,
   });
   const cpmmSwapSignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [createSetComputeUnitLimitInstruction(400_000), cpmmSwapIx],
+    instructions: cpmmSwap.instructions,
   });
   console.log('  Ungated CPMM swap tx:', cpmmSwapSignature);
   console.log('');

--- a/examples/solana-cosigner-gated-launch.ts
+++ b/examples/solana-cosigner-gated-launch.ts
@@ -18,25 +18,18 @@
  */
 import './env.js';
 
-import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
-  getSyncNativeInstruction,
-} from '@solana-program/token';
-import {
-  SYSTEM_PROGRAM_ADDRESS,
-  getTransferSolInstruction,
-} from '@solana-program/system';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
   cosignerHook,
   cpmm,
   cpmmMigrator,
   createLaunch,
+  curveSwapExactIn,
   initializer,
+  migrateLaunch,
+  swapExactIn,
 } from '../src/solana/index.js';
 import {
   DEFAULT_SWAP_FEE_BPS,
@@ -44,12 +37,10 @@ import {
   WSOL_MINT,
   assertSimulationRejected,
   assertSolanaExampleNetwork,
-  createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
   fetchActiveCosigners,
   getSolPriceUsd,
   getSolanaCpmmDeploymentFromEnv,
-  getTokenAccountRentLamports,
   loadCosigner,
   loadKeypairSignerFromEnv,
   sendInitializeLaunchWithLookupTable,
@@ -279,104 +270,38 @@ async function main() {
     console.log('');
 
     // ── Step 3: Execute the curve buy ────────────────────────────────────────
-    // ATA creation, WSOL deposit, and the curve buy are batched into a single
-    // transaction — instructions execute sequentially so the ATAs exist and are
-    // funded before the swap runs.
     console.log('Step 3: Executing bonding curve buy...');
 
-    const [userBaseAta] = await findAssociatedTokenPda({
-      owner: payer.address,
-      mint: baseMint.address,
-      tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    });
-    const [userQuoteAta] = await findAssociatedTokenPda({
-      owner: payer.address,
-      mint: WSOL_MINT,
-      tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    });
-
-    const createBaseAtaIx = getCreateAssociatedTokenIdempotentInstruction({
+    const swapBaseInput = {
+      deployment,
+      launch,
+      launchAuthority,
+      baseVault: baseVault.address,
+      quoteVault: quoteVault.address,
+      launchFeeState,
+      baseMint: baseMint.address,
+      quoteMint: WSOL_MINT,
       payer,
-      ata: userBaseAta,
-      owner: payer.address,
-      mint: baseMint.address,
+      amountIn: BUY_AMOUNT_IN,
+      minAmountOut: 1n,
+      tradeDirection: initializer.TRADE_DIRECTION_BUY,
+      hookProgram: deployment.cosignerHookProgram,
+    } as const;
+    const signedBuy = await curveSwapExactIn({
+      ...swapBaseInput,
+      remainingAccounts: signedHookRemainingAccounts,
     });
-    const createQuoteAtaIx = getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userQuoteAta,
-      owner: payer.address,
-      mint: WSOL_MINT,
+    const unsignedBuy = await curveSwapExactIn({
+      ...swapBaseInput,
+      remainingAccounts: unsignedHookRemainingAccounts,
     });
-    const transferSolIx = getTransferSolInstruction({
-      source: payer,
-      destination: userQuoteAta,
-      amount: BUY_AMOUNT_IN + getTokenAccountRentLamports(),
-    });
-
-    const syncNativeIx = getSyncNativeInstruction({ account: userQuoteAta });
-
-    const swapIx = initializer.createCurveSwapExactInInstruction(
-      {
-        launch,
-        launchAuthority,
-        baseVault: baseVault.address,
-        quoteVault: quoteVault.address,
-        launchFeeState,
-        userBaseAccount: userBaseAta,
-        userQuoteAccount: userQuoteAta,
-        baseMint: baseMint.address,
-        quoteMint: WSOL_MINT,
-        user: payer,
-        hookProgram: deployment.cosignerHookProgram,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        remainingAccounts: signedHookRemainingAccounts,
-      },
-      {
-        amountIn: BUY_AMOUNT_IN,
-        minAmountOut: 1n, // accept any amount for the example; use preview.amountOut in prod
-        tradeDirection: initializer.TRADE_DIRECTION_BUY,
-      },
-      deployment.initializerProgram,
-    );
-
-    const unsignedSwapIx = initializer.createCurveSwapExactInInstruction(
-      {
-        launch,
-        launchAuthority,
-        baseVault: baseVault.address,
-        quoteVault: quoteVault.address,
-        launchFeeState,
-        userBaseAccount: userBaseAta,
-        userQuoteAccount: userQuoteAta,
-        baseMint: baseMint.address,
-        quoteMint: WSOL_MINT,
-        user: payer,
-        hookProgram: deployment.cosignerHookProgram,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        remainingAccounts: unsignedHookRemainingAccounts,
-      },
-      {
-        amountIn: BUY_AMOUNT_IN,
-        minAmountOut: 1n,
-        tradeDirection: initializer.TRADE_DIRECTION_BUY,
-      },
-      deployment.initializerProgram,
-    );
 
     // This intentionally omits the cosigner signer account. The initializer
     // hook is configured to reject this pre-migration swap.
     const unsignedCurveResult = await simulateInstructions({
       rpc,
       payer,
-      instructions: [
-        createBaseAtaIx,
-        createQuoteAtaIx,
-        transferSolIx,
-        syncNativeIx,
-        unsignedSwapIx,
-      ],
+      instructions: unsignedBuy.instructions,
     });
     assertSimulationRejected(
       'Unsigned bonding curve buy',
@@ -388,13 +313,7 @@ async function main() {
         rpc,
         rpcSubscriptions,
         payer,
-        instructions: [
-          createBaseAtaIx,
-          createQuoteAtaIx,
-          transferSolIx,
-          syncNativeIx,
-          swapIx,
-        ],
+        instructions: signedBuy.instructions,
       });
 
       console.log('  Cosigned curve buy confirmed:', signature);
@@ -410,43 +329,27 @@ async function main() {
     // at launch creation.
     console.log('Step 4: Migrating launch to CPMM pool...');
 
-    const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(
-      {
-        config: initializerConfig,
-        launch,
-        launchAuthority,
-        baseMint: baseMint.address,
-        quoteMint: WSOL_MINT,
-        baseVault: baseVault.address,
-        quoteVault: quoteVault.address,
-        launchFeeState,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        payer,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-      },
-      deployment.initializerProgram,
-    );
-
-    const migrateLaunchIx = {
-      ...migrateLaunchIxBase,
-      accounts: [
-        ...(migrateLaunchIxBase.accounts ?? []),
-        ...migrationAccounts.metas,
-      ],
-    };
+    const migration = migrateLaunch({
+      deployment,
+      config: initializerConfig,
+      launch,
+      launchAuthority,
+      baseMint: baseMint.address,
+      quoteMint: WSOL_MINT,
+      baseVault: baseVault.address,
+      quoteVault: quoteVault.address,
+      launchFeeState,
+      payer,
+      cpmmMigration: migrationAccounts,
+      computeUnitLimit: 400_000,
+    });
 
     {
       const signature = await sendInstructions({
         rpc,
         rpcSubscriptions,
         payer,
-        instructions: [
-          createSetComputeUnitLimitInstruction(400_000),
-          migrateLaunchIx,
-        ],
+        instructions: migration.instructions,
       });
 
       console.log('  Migration confirmed:', signature);
@@ -527,33 +430,13 @@ async function main() {
 
         const tradeDirection = pool.token0Mint === baseMint.address ? 0 : 1;
         const CPMM_SWAP_AMOUNT_IN = 1_000_000n; // 1 base token at 6 decimals
-        const quote = cpmm.getSwapQuote(
-          pool,
-          CPMM_SWAP_AMOUNT_IN,
-          tradeDirection,
-        );
-        const minAmountOut = (quote.amountOut * 9_500n) / 10_000n; // 5% example slippage
-
-        const userToken0 =
-          pool.token0Mint === baseMint.address ? userBaseAta : userQuoteAta;
-        const userToken1 =
-          pool.token1Mint === baseMint.address ? userBaseAta : userQuoteAta;
-
-        const cpmmSwapIx = cpmm.createSwapInstruction({
-          config: cpmmConfig,
-          pool: poolAddress,
-          authority: pool.authority,
-          vault0: pool.vault0,
-          vault1: pool.vault1,
-          token0Mint: pool.token0Mint,
-          token1Mint: pool.token1Mint,
-          userToken0,
-          userToken1,
-          user: payer,
+        const cpmmSwap = await swapExactIn({
+          deployment,
+          pool: poolResult,
+          payer,
           amountIn: CPMM_SWAP_AMOUNT_IN,
-          minAmountOut,
+          slippageBps: 500n,
           tradeDirection,
-          programId: deployment.cpmmProgram,
         });
 
         {
@@ -561,10 +444,7 @@ async function main() {
             rpc,
             rpcSubscriptions,
             payer,
-            instructions: [
-              createSetComputeUnitLimitInstruction(400_000),
-              cpmmSwapIx,
-            ],
+            instructions: cpmmSwap.instructions,
           });
 
           console.log('  Ungated CPMM swap confirmed:', signature);

--- a/examples/solana-swap.ts
+++ b/examples/solana-swap.ts
@@ -8,13 +8,8 @@
 import './env.js';
 
 import { address, type Address } from '@solana/kit';
-import {
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
-} from '@solana-program/token';
 
-import { cpmm } from '../src/solana/index.js';
+import { swapExactIn } from '../src/solana/index.js';
 import {
   assertSolanaExampleNetwork,
   createSolanaClientsFromEnv,
@@ -43,17 +38,25 @@ async function main() {
   assertSolanaExampleNetwork(network, ['devnet', 'custom']);
   const deployment = await getSolanaCpmmDeploymentFromEnv(network);
 
-  // ── Fetch pool state ─────────────────────────────────────────────────────
-  console.log('Fetching pool state...');
-  const poolResult = await cpmm.getPoolByMints(rpc, MINT_0, MINT_1, {
-    programId: deployment.cpmmProgram,
+  // ── Quote the swap ───────────────────────────────────────────────────────
+  // tradeDirection 0 = token0→token1, tradeDirection 1 = token1→token0.
+  const tradeDirection = (process.env.SWAP_DIRECTION === '1' ? 1 : 0) as 0 | 1;
+  const AMOUNT_IN = BigInt(process.env.AMOUNT_IN ?? '1000000');
+  const SLIPPAGE_BPS = 50n; // 0.5%
+
+  console.log('Preparing exact-in swap...');
+  const swap = await swapExactIn({
+    rpc,
+    deployment,
+    payer,
+    mintA: MINT_0,
+    mintB: MINT_1,
+    amountIn: AMOUNT_IN,
+    tradeDirection,
+    slippageBps: SLIPPAGE_BPS,
   });
 
-  if (!poolResult) {
-    throw new Error(`No pool found for ${MINT_0} / ${MINT_1}`);
-  }
-
-  const { address: poolAddress, account: pool } = poolResult;
+  const { address: poolAddress, account: pool } = swap.pool;
 
   console.log('  Pool address:  ', poolAddress);
   console.log('  token0 mint:   ', pool.token0Mint);
@@ -63,92 +66,41 @@ async function main() {
   console.log('  Swap fee:      ', pool.swapFeeBps, 'bps');
   console.log('');
 
-  // ── Quote the swap ───────────────────────────────────────────────────────
-  // tradeDirection 0 = token0→token1, tradeDirection 1 = token1→token0.
-  const tradeDirection = (process.env.SWAP_DIRECTION === '1' ? 1 : 0) as 0 | 1;
-  const AMOUNT_IN = BigInt(process.env.AMOUNT_IN ?? '1000000');
-
-  const quote = cpmm.getSwapQuote(pool, AMOUNT_IN, tradeDirection);
-
-  const SLIPPAGE_BPS = 50n; // 0.5%
-  const minAmountOut = (quote.amountOut * (10_000n - SLIPPAGE_BPS)) / 10_000n;
-
   console.log(
     `Swap quote (${tradeDirection === 0 ? 'token0 → token1' : 'token1 → token0'}):`,
   );
   console.log('  Amount in:     ', AMOUNT_IN.toString(), '(input token atoms)');
   console.log(
     '  Amount out:    ',
-    quote.amountOut.toString(),
+    swap.quote.amountOut.toString(),
     '(output token atoms, estimated)',
   );
   console.log(
     '  Fee:           ',
-    quote.feeTotal.toString(),
+    swap.quote.feeTotal.toString(),
     '(input token atoms)',
   );
-  console.log('  Price impact:  ', (quote.priceImpact * 100).toFixed(4), '%');
-  console.log('  Min out (0.5%):', minAmountOut.toString());
-  console.log('');
+  console.log(
+    '  Price impact:  ',
+    (swap.quote.priceImpact * 100).toFixed(4),
+    '%',
+  );
+  console.log('  Min out (0.5%):', swap.minAmountOut.toString());
 
-  // ── Derive PDAs and user token accounts ─────────────────────────────────
-  const config = deployment.cpmmConfig;
-  const [userToken0] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: pool.token0Mint,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const [userToken1] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: pool.token1Mint,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const userIn = tradeDirection === 0 ? userToken0 : userToken1;
-  const userOut = tradeDirection === 0 ? userToken1 : userToken0;
-
-  console.log('  Config:   ', config);
-  console.log('  User ATA (in): ', userIn);
-  console.log('  User ATA (out):', userOut);
+  console.log('  Config:   ', deployment.cpmmConfig);
+  console.log('  User ATA (in): ', swap.userIn);
+  console.log('  User ATA (out):', swap.userOut);
   console.log('');
 
   // ── Build and send the swap instruction ──────────────────────────────────
   console.log('Submitting swap...');
 
   try {
-    const ix = cpmm.createSwapInstruction({
-      config,
-      pool: poolAddress,
-      authority: pool.authority,
-      vault0: pool.vault0,
-      vault1: pool.vault1,
-      token0Mint: pool.token0Mint,
-      token1Mint: pool.token1Mint,
-      userToken0,
-      userToken1,
-      user: payer,
-      amountIn: AMOUNT_IN,
-      minAmountOut,
-      tradeDirection,
-      programId: deployment.cpmmProgram,
-    });
-    const createUserInAtaIx = getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userToken0,
-      owner: payer.address,
-      mint: pool.token0Mint,
-    });
-    const createUserOutAtaIx = getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userToken1,
-      owner: payer.address,
-      mint: pool.token1Mint,
-    });
-
     const signature = await sendInstructions({
       rpc,
       rpcSubscriptions,
       payer,
-      instructions: [createUserInAtaIx, createUserOutAtaIx, ix],
+      instructions: swap.instructions,
     });
 
     console.log('');
@@ -157,7 +109,7 @@ async function main() {
     console.log('  Sent:       ', AMOUNT_IN.toString(), 'input token atoms');
     console.log(
       '  Received:   ~',
-      quote.amountOut.toString(),
+      swap.quote.amountOut.toString(),
       'output token atoms',
     );
   } catch (error) {

--- a/examples/solana-usdc-cosigner-gated-buy.ts
+++ b/examples/solana-usdc-cosigner-gated-buy.ts
@@ -16,17 +16,19 @@ import './env.js';
 import {
   TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
 } from '@solana-program/token';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
+  assertMigrationQuoteThreshold,
   cosignerHook,
   cpmm,
   createLaunch,
+  curveSwapExactIn,
   initializer,
+  migrateLaunch,
+  swapExactIn,
 } from '../src/solana/index.js';
 
 import {
@@ -34,11 +36,9 @@ import {
   DEFAULT_TEST_METADATA,
   DEVNET_USDC_MINT as USDC_MINT,
   assertCosignerRegistered,
-  assertMigrationQuoteThreshold,
   assertSimulationRejected,
   assertSolanaExampleNetwork,
   assertTokenBalance,
-  createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
   getSolanaCpmmDeploymentFromEnv,
   loadCosigner,
@@ -199,76 +199,42 @@ async function main() {
   });
   console.log('  Launch tx:         ', launchSignature);
 
-  const [userBaseAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: baseMint.address,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const [userQuoteAta] = await findAssociatedTokenPda({
-    owner: payer.address,
-    mint: USDC_MINT,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-  });
-  const setupAndFund = [
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userBaseAta,
-      owner: payer.address,
-      mint: baseMint.address,
-    }),
-    getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userQuoteAta,
-      owner: payer.address,
-      mint: USDC_MINT,
-    }),
-  ];
-  const swapAccounts = {
+  const swapBaseInput = {
+    deployment,
     launch,
     launchAuthority,
     baseVault: baseVault.address,
     quoteVault: quoteVault.address,
     launchFeeState,
-    userBaseAccount: userBaseAta,
-    userQuoteAccount: userQuoteAta,
     baseMint: baseMint.address,
     quoteMint: USDC_MINT,
-    user: payer,
+    payer,
+    amountIn: BUY_AMOUNT_IN,
+    minAmountOut: 1n,
+    tradeDirection: initializer.TRADE_DIRECTION_BUY,
     hookProgram: deployment.cosignerHookProgram,
-    baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-    quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-  };
+  } as const;
 
-  const unsignedSwapIx = initializer.createCurveSwapExactInInstruction(
-    { ...swapAccounts, remainingAccounts: unsignedHookRemainingAccounts },
-    {
-      amountIn: BUY_AMOUNT_IN,
-      minAmountOut: 1n,
-      tradeDirection: initializer.TRADE_DIRECTION_BUY,
-    },
-    deployment.initializerProgram,
-  );
+  const unsignedBuy = await curveSwapExactIn({
+    ...swapBaseInput,
+    remainingAccounts: unsignedHookRemainingAccounts,
+  });
   const unsignedResult = await simulateInstructions({
     rpc,
     payer,
-    instructions: [...setupAndFund, unsignedSwapIx],
+    instructions: unsignedBuy.instructions,
   });
   assertSimulationRejected('Unsigned bonding curve buy', unsignedResult.err);
 
-  const signedSwapIx = initializer.createCurveSwapExactInInstruction(
-    { ...swapAccounts, remainingAccounts: signedHookRemainingAccounts },
-    {
-      amountIn: BUY_AMOUNT_IN,
-      minAmountOut: 1n,
-      tradeDirection: initializer.TRADE_DIRECTION_BUY,
-    },
-    deployment.initializerProgram,
-  );
+  const signedBuy = await curveSwapExactIn({
+    ...swapBaseInput,
+    remainingAccounts: signedHookRemainingAccounts,
+  });
   const buySignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [...setupAndFund, signedSwapIx],
+    instructions: signedBuy.instructions,
   });
   console.log('  Cosigned buy tx:   ', buySignature);
 
@@ -298,51 +264,24 @@ async function main() {
   console.log('  Pending quote fees:', pendingQuoteFees.toString());
   console.log('');
 
-  const createRecipientAtaIxs = migrationAccounts.recipientAtas.map(
-    (ata, index) =>
-      getCreateAssociatedTokenIdempotentInstruction({
-        payer,
-        ata,
-        owner: launchBeneficiaries.recipients[index].wallet,
-        mint: baseMint.address,
-      }),
-  );
-
-  const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(
-    {
-      config: deployment.initializerConfig,
-      launch,
-      launchAuthority,
-      baseMint: baseMint.address,
-      quoteMint: USDC_MINT,
-      baseVault: baseVault.address,
-      quoteVault: quoteVault.address,
-      launchFeeState,
-      migratorProgram: deployment.cpmmMigratorProgram,
-      payer,
-      baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-      quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
-      rent: SYSVAR_RENT_ADDRESS,
-    },
-    deployment.initializerProgram,
-  );
-  const migrateLaunchIx = {
-    ...migrateLaunchIxBase,
-    accounts: [
-      ...(migrateLaunchIxBase.accounts ?? []),
-      ...migrationAccounts.metas,
-    ],
-  };
+  const migration = migrateLaunch({
+    deployment,
+    launch,
+    launchAuthority,
+    baseMint: baseMint.address,
+    quoteMint: USDC_MINT,
+    baseVault: baseVault.address,
+    quoteVault: quoteVault.address,
+    launchFeeState,
+    payer,
+    cpmmMigration: migrationAccounts,
+    recipients: launchBeneficiaries.recipients,
+  });
   const migrationSignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [
-      createSetComputeUnitLimitInstruction(800_000),
-      ...createRecipientAtaIxs,
-      migrateLaunchIx,
-    ],
+    instructions: migration.instructions,
   });
   console.log('  Migration tx:      ', migrationSignature);
 
@@ -371,7 +310,7 @@ async function main() {
     throw new Error('CPMM pool was not found after migration');
   }
 
-  const { address: poolAddress, account: pool } = poolResult;
+  const { account: pool } = poolResult;
   if (pool.hookProgram !== SYSTEM_PROGRAM_ADDRESS || pool.hookFlags !== 0) {
     throw new Error(
       `Migrated pool hook mismatch: got program ${pool.hookProgram} flags ${pool.hookFlags}, expected no CPMM hook`,
@@ -380,33 +319,19 @@ async function main() {
 
   const tradeDirection = pool.token0Mint === baseMint.address ? 0 : 1;
   const CPMM_SWAP_AMOUNT_IN = 1_000_000n;
-  const quote = cpmm.getSwapQuote(pool, CPMM_SWAP_AMOUNT_IN, tradeDirection);
-  const minAmountOut = (quote.amountOut * 9_500n) / 10_000n;
-  const userToken0 =
-    pool.token0Mint === baseMint.address ? userBaseAta : userQuoteAta;
-  const userToken1 =
-    pool.token1Mint === baseMint.address ? userBaseAta : userQuoteAta;
-  const cpmmSwapIx = cpmm.createSwapInstruction({
-    config: migrationAccounts.cpmmConfig,
-    pool: poolAddress,
-    authority: pool.authority,
-    vault0: pool.vault0,
-    vault1: pool.vault1,
-    token0Mint: pool.token0Mint,
-    token1Mint: pool.token1Mint,
-    userToken0,
-    userToken1,
-    user: payer,
+  const cpmmSwap = await swapExactIn({
+    deployment,
+    pool: poolResult,
+    payer,
     amountIn: CPMM_SWAP_AMOUNT_IN,
-    minAmountOut,
+    slippageBps: 500n,
     tradeDirection,
-    programId: deployment.cpmmProgram,
   });
   const cpmmSwapSignature = await sendInstructions({
     rpc,
     rpcSubscriptions,
     payer,
-    instructions: [createSetComputeUnitLimitInstruction(400_000), cpmmSwapIx],
+    instructions: cpmmSwap.instructions,
   });
   console.log('  Ungated CPMM swap tx:', cpmmSwapSignature);
   console.log('');

--- a/examples/solana-usdc-e2e-launch.ts
+++ b/examples/solana-usdc-e2e-launch.ts
@@ -17,17 +17,17 @@ import './env.js';
 import {
   TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda,
-  getCreateAssociatedTokenIdempotentInstruction,
 } from '@solana-program/token';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
-import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 
 import {
   cpmm,
   initializer,
   cpmmMigrator,
   createLaunch,
+  curveSwapExactIn,
+  migrateLaunch,
+  assertMigrationQuoteThreshold,
 } from '../src/solana/index.js';
 import { fetchLaunchFeeState } from '../src/solana/generated/initializer/accounts/launchFeeState.js';
 
@@ -36,10 +36,8 @@ import {
   DEFAULT_TEST_METADATA,
   DEVNET_USDC_MINT as USDC_MINT,
   assertBigintEqual,
-  assertMigrationQuoteThreshold,
   assertSolanaExampleNetwork,
   assertTokenBalance,
-  createSetComputeUnitLimitInstruction,
   createSolanaClientsFromEnv,
   getSolanaCpmmDeploymentFromEnv,
   loadKeypairSignerFromEnv,
@@ -260,59 +258,28 @@ async function main() {
     // The payer's USDC ATA must already be funded on devnet.
     console.log('Step 4: Executing bonding curve buy...');
 
-    const [userBaseAta] = await findAssociatedTokenPda({
-      owner: payer.address,
-      mint: baseMint.address,
-      tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    });
-    const [userQuoteAta] = await findAssociatedTokenPda({
-      owner: payer.address,
-      mint: USDC_MINT,
-      tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    });
-
-    const createBaseAtaIx = getCreateAssociatedTokenIdempotentInstruction({
+    const curveBuy = await curveSwapExactIn({
+      deployment,
+      launch,
+      launchAuthority,
+      baseVault: baseVault.address,
+      quoteVault: quoteVault.address,
+      launchFeeState,
+      baseMint: baseMint.address,
+      quoteMint: USDC_MINT,
       payer,
-      ata: userBaseAta,
-      owner: payer.address,
-      mint: baseMint.address,
+      amountIn: BUY_AMOUNT_IN,
+      minAmountOut: 1n, // accept any amount for the example; use preview.amountOut in prod
+      tradeDirection: initializer.TRADE_DIRECTION_BUY,
+      hookProgram: deployment.cpmmHookProgram,
     });
-    const createQuoteAtaIx = getCreateAssociatedTokenIdempotentInstruction({
-      payer,
-      ata: userQuoteAta,
-      owner: payer.address,
-      mint: USDC_MINT,
-    });
-    const swapIx = initializer.createCurveSwapExactInInstruction(
-      {
-        launch,
-        launchAuthority,
-        baseVault: baseVault.address,
-        quoteVault: quoteVault.address,
-        launchFeeState,
-        userBaseAccount: userBaseAta,
-        userQuoteAccount: userQuoteAta,
-        baseMint: baseMint.address,
-        quoteMint: USDC_MINT,
-        user: payer,
-        hookProgram: deployment.cpmmHookProgram,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-      },
-      {
-        amountIn: BUY_AMOUNT_IN,
-        minAmountOut: 1n, // accept any amount for the example; use preview.amountOut in prod
-        tradeDirection: initializer.TRADE_DIRECTION_BUY,
-      },
-      deployment.initializerProgram,
-    );
 
     {
       const signature = await sendInstructions({
         rpc,
         rpcSubscriptions,
         payer,
-        instructions: [createBaseAtaIx, createQuoteAtaIx, swapIx],
+        instructions: curveBuy.instructions,
       });
 
       console.log('  Curve buy confirmed:', signature);
@@ -361,43 +328,27 @@ async function main() {
     // at launch creation.
     console.log('Step 5: Migrating launch to CPMM pool...');
 
-    const migrateLaunchIxBase = initializer.createMigrateLaunchInstruction(
-      {
-        config: initializerConfig,
-        launch,
-        launchAuthority,
-        baseMint: baseMint.address,
-        quoteMint: USDC_MINT,
-        baseVault: baseVault.address,
-        quoteVault: quoteVault.address,
-        launchFeeState,
-        migratorProgram: deployment.cpmmMigratorProgram,
-        payer,
-        baseTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        quoteTokenProgram: TOKEN_PROGRAM_ADDRESS,
-        systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
-      },
-      deployment.initializerProgram,
-    );
-
-    const migrateLaunchIx = {
-      ...migrateLaunchIxBase,
-      accounts: [
-        ...(migrateLaunchIxBase.accounts ?? []),
-        ...migrationAccounts.metas,
-      ],
-    };
+    const migration = migrateLaunch({
+      deployment,
+      config: initializerConfig,
+      launch,
+      launchAuthority,
+      baseMint: baseMint.address,
+      quoteMint: USDC_MINT,
+      baseVault: baseVault.address,
+      quoteVault: quoteVault.address,
+      launchFeeState,
+      payer,
+      cpmmMigration: migrationAccounts,
+      computeUnitLimit: 400_000,
+    });
 
     {
       const signature = await sendInstructions({
         rpc,
         rpcSubscriptions,
         payer,
-        instructions: [
-          createSetComputeUnitLimitInstruction(400_000),
-          migrateLaunchIx,
-        ],
+        instructions: migration.instructions,
       });
 
       console.log('  Migration confirmed:', signature);

--- a/examples/solanaExampleHelpers.ts
+++ b/examples/solanaExampleHelpers.ts
@@ -8,7 +8,6 @@ import {
   createTransactionMessage,
   getBase64EncodedWireTransaction,
   getTransactionMessageSize,
-  getMinimumBalanceForRentExemption,
   getSignatureFromTransaction,
   isTransactionMessageWithinSizeLimit,
   pipe,
@@ -44,7 +43,6 @@ export type SolanaExampleNetwork =
   | keyof typeof SOLANA_NETWORK_ENDPOINTS
   | 'custom';
 export const DEFAULT_SOLANA_EXAMPLE_NETWORK: SolanaExampleNetwork = 'devnet';
-export const TOKEN_ACCOUNT_SPACE = 165n;
 export const SOLANA_TRANSACTION_SIZE_LIMIT = 1232;
 export const WSOL_MINT = address('So11111111111111111111111111111111111111112');
 export const DEVNET_USDC_MINT = address(
@@ -57,10 +55,6 @@ export const DEFAULT_TEST_METADATA = {
 } as const;
 export const DEFAULT_SWAP_FEE_BPS = 200;
 export const DEFAULT_CPMM_FEE_SPLIT_BPS = 10_000;
-
-const COMPUTE_BUDGET_PROGRAM_ID = address(
-  'ComputeBudget111111111111111111111111111111',
-);
 
 export function createSolanaClientsFromEnv() {
   const network = parseSolanaNetwork(
@@ -177,23 +171,6 @@ export async function loadKeypairSignerFromEnv({
   return createKeyPairSignerFromBytes(
     new Uint8Array(JSON.parse(keypairJson) as number[]),
   );
-}
-
-export function createSetComputeUnitLimitInstruction(
-  units: number,
-): Instruction {
-  const data = new Uint8Array(5);
-  data[0] = 2;
-  new DataView(data.buffer).setUint32(1, units, true);
-  return {
-    programAddress: COMPUTE_BUDGET_PROGRAM_ID,
-    accounts: [],
-    data,
-  };
-}
-
-export function getTokenAccountRentLamports(): bigint {
-  return getMinimumBalanceForRentExemption(TOKEN_ACCOUNT_SPACE);
 }
 
 export function getMetadataByteLength(params: {
@@ -702,66 +679,6 @@ export async function sendInitializeLaunchWithLookupTable({
   );
 
   return getSignatureFromTransaction(signedTransaction);
-}
-
-export async function getMigrationQuoteProgress({
-  rpc,
-  quoteVault,
-  pendingQuoteFees,
-}: {
-  rpc: SolanaClients['rpc'];
-  quoteVault: Address;
-  pendingQuoteFees: bigint;
-}) {
-  const vaultBalance = await rpc
-    .getTokenAccountBalance(quoteVault, { commitment: 'confirmed' })
-    .send();
-  const quoteVaultAmount = BigInt(vaultBalance.value.amount);
-  if (pendingQuoteFees > quoteVaultAmount) {
-    throw new Error(
-      'Pending quote fees ' +
-        pendingQuoteFees +
-        ' exceed quote vault balance ' +
-        quoteVaultAmount,
-    );
-  }
-
-  const migrationQuoteAmount = quoteVaultAmount - pendingQuoteFees;
-
-  return {
-    quoteVaultAmount,
-    pendingQuoteFees,
-    migrationQuoteAmount,
-  };
-}
-
-export async function assertMigrationQuoteThreshold({
-  rpc,
-  quoteVault,
-  pendingQuoteFees,
-  minRaiseQuote,
-}: {
-  rpc: SolanaClients['rpc'];
-  quoteVault: Address;
-  pendingQuoteFees: bigint;
-  minRaiseQuote: bigint;
-}) {
-  const progress = await getMigrationQuoteProgress({
-    rpc,
-    quoteVault,
-    pendingQuoteFees,
-  });
-
-  if (progress.migrationQuoteAmount < minRaiseQuote) {
-    throw new Error(
-      'Quote available for migration ' +
-        progress.migrationQuoteAmount +
-        ' is below minRaiseQuote ' +
-        minRaiseQuote,
-    );
-  }
-
-  return progress;
 }
 
 export async function getSolPriceUsd(): Promise<number> {

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -27,6 +27,23 @@ export type {
   LaunchTokenPrograms,
   XykCurveConfig,
 } from './initializer/createLaunch.js';
+export {
+  curveSwapExactIn,
+  swapExactIn,
+  type CurveSwapExactInInput,
+  type CurveSwapExactInResult,
+  type SolanaRemainingAccount,
+  type SwapExactInInput,
+  type SwapExactInResult,
+} from './swaps.js';
+export {
+  assertMigrationQuoteThreshold,
+  getMigrationQuoteProgress,
+  migrateLaunch,
+  type MigrateLaunchInput,
+  type MigrateLaunchResult,
+  type MigrationQuoteProgress,
+} from './migrateLaunch.js';
 
 export {
   DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,

--- a/src/solana/migrateLaunch.ts
+++ b/src/solana/migrateLaunch.ts
@@ -1,0 +1,224 @@
+import {
+  address,
+  type Address,
+  type Instruction,
+  type TransactionSigner,
+} from '@solana/kit';
+import { getCreateAssociatedTokenIdempotentInstruction } from '@solana-program/token';
+
+import {
+  SYSTEM_PROGRAM_ADDRESS,
+  SYSVAR_RENT_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
+} from './core/constants.js';
+import type { SolanaCpmmDeployment } from './deployment.js';
+import {
+  CPMM_MIGRATOR_PROGRAM_ID,
+  type CpmmMigrationRemainingAccounts,
+  type RecipientArgs,
+} from './migrators/cpmmMigrator/index.js';
+import {
+  INITIALIZER_PROGRAM_ID,
+  createMigrateLaunchInstruction,
+} from './initializer/index.js';
+
+type TokenBalanceRpc = {
+  getTokenAccountBalance(
+    address: Address,
+    config?: { commitment?: 'processed' | 'confirmed' | 'finalized' },
+  ): {
+    send(): Promise<{ value: { amount: string } }>;
+  };
+};
+
+export type MigrateLaunchInput = {
+  deployment?: Pick<
+    SolanaCpmmDeployment,
+    'initializerProgram' | 'initializerConfig' | 'cpmmMigratorProgram'
+  >;
+  programId?: Address;
+  config?: Address;
+  launch: Address;
+  launchAuthority: Address;
+  baseMint: Address;
+  quoteMint: Address;
+  baseVault: Address;
+  quoteVault: Address;
+  launchFeeState: Address;
+  payer: TransactionSigner;
+  cpmmMigration: CpmmMigrationRemainingAccounts;
+  recipients?: ReadonlyArray<Pick<RecipientArgs, 'wallet'>>;
+  computeUnitLimit?: number | false;
+  baseTokenProgram?: Address;
+  quoteTokenProgram?: Address;
+  systemProgram?: Address;
+  rent?: Address;
+};
+
+export type MigrateLaunchResult = {
+  recipientAtaInstructions: Instruction[];
+  computeUnitLimitInstruction?: Instruction;
+  migrateInstruction: Instruction;
+  instructions: Instruction[];
+};
+
+export type MigrationQuoteProgress = {
+  quoteVaultAmount: bigint;
+  pendingQuoteFees: bigint;
+  migrationQuoteAmount: bigint;
+};
+
+const COMPUTE_BUDGET_PROGRAM_ID = address(
+  'ComputeBudget111111111111111111111111111111',
+);
+
+function createSetComputeUnitLimitInstruction(units: number): Instruction {
+  const data = new Uint8Array(5);
+  data[0] = 2;
+  new DataView(data.buffer).setUint32(1, units, true);
+  return {
+    programAddress: COMPUTE_BUDGET_PROGRAM_ID,
+    accounts: [],
+    data,
+  };
+}
+
+function getDefaultComputeUnitLimit(
+  cpmmMigration: CpmmMigrationRemainingAccounts,
+): number {
+  return cpmmMigration.recipientAtas.length > 0 ? 800_000 : 400_000;
+}
+
+export function migrateLaunch(input: MigrateLaunchInput): MigrateLaunchResult {
+  const baseTokenProgram = input.baseTokenProgram ?? TOKEN_PROGRAM_ADDRESS;
+  const quoteTokenProgram = input.quoteTokenProgram ?? TOKEN_PROGRAM_ADDRESS;
+  const recipients = input.recipients ? [...input.recipients] : [];
+  if (
+    recipients.length > 0 &&
+    recipients.length !== input.cpmmMigration.recipientAtas.length
+  ) {
+    throw new Error(
+      'recipients length must match cpmmMigration.recipientAtas length',
+    );
+  }
+  const initializerConfig = input.config ?? input.deployment?.initializerConfig;
+  if (!initializerConfig) {
+    throw new Error('config or deployment.initializerConfig is required');
+  }
+
+  const recipientAtaInstructions = recipients.map((recipient, index) =>
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: input.payer,
+      ata: input.cpmmMigration.recipientAtas[index],
+      owner: recipient.wallet,
+      mint: input.baseMint,
+      tokenProgram: baseTokenProgram,
+    }),
+  );
+  const migrateLaunchInstruction = createMigrateLaunchInstruction(
+    {
+      config: initializerConfig,
+      launch: input.launch,
+      launchAuthority: input.launchAuthority,
+      baseMint: input.baseMint,
+      quoteMint: input.quoteMint,
+      baseVault: input.baseVault,
+      quoteVault: input.quoteVault,
+      launchFeeState: input.launchFeeState,
+      migratorProgram:
+        input.deployment?.cpmmMigratorProgram ?? CPMM_MIGRATOR_PROGRAM_ID,
+      payer: input.payer,
+      baseTokenProgram,
+      quoteTokenProgram,
+      systemProgram: input.systemProgram ?? SYSTEM_PROGRAM_ADDRESS,
+      rent: input.rent ?? SYSVAR_RENT_ADDRESS,
+    },
+    input.programId ??
+      input.deployment?.initializerProgram ??
+      INITIALIZER_PROGRAM_ID,
+  );
+  const migrateInstruction = {
+    ...migrateLaunchInstruction,
+    accounts: [
+      ...(migrateLaunchInstruction.accounts ?? []),
+      ...input.cpmmMigration.metas,
+    ],
+  };
+  const computeUnitLimit =
+    input.computeUnitLimit === undefined
+      ? getDefaultComputeUnitLimit(input.cpmmMigration)
+      : input.computeUnitLimit;
+  const computeUnitLimitInstruction =
+    computeUnitLimit === false
+      ? undefined
+      : createSetComputeUnitLimitInstruction(computeUnitLimit);
+  const instructions = [
+    ...(computeUnitLimitInstruction ? [computeUnitLimitInstruction] : []),
+    ...recipientAtaInstructions,
+    migrateInstruction,
+  ];
+
+  return {
+    recipientAtaInstructions,
+    computeUnitLimitInstruction,
+    migrateInstruction,
+    instructions,
+  };
+}
+
+export async function getMigrationQuoteProgress({
+  rpc,
+  quoteVault,
+  pendingQuoteFees,
+  commitment = 'confirmed',
+}: {
+  rpc: TokenBalanceRpc;
+  quoteVault: Address;
+  pendingQuoteFees: bigint;
+  commitment?: 'processed' | 'confirmed' | 'finalized';
+}): Promise<MigrationQuoteProgress> {
+  const vaultBalance = await rpc
+    .getTokenAccountBalance(quoteVault, { commitment })
+    .send();
+  const quoteVaultAmount = BigInt(vaultBalance.value.amount);
+  if (pendingQuoteFees > quoteVaultAmount) {
+    throw new Error(
+      'pendingQuoteFees cannot exceed the quote vault token balance',
+    );
+  }
+
+  return {
+    quoteVaultAmount,
+    pendingQuoteFees,
+    migrationQuoteAmount: quoteVaultAmount - pendingQuoteFees,
+  };
+}
+
+export async function assertMigrationQuoteThreshold({
+  rpc,
+  quoteVault,
+  pendingQuoteFees,
+  minRaiseQuote,
+  commitment = 'confirmed',
+}: {
+  rpc: TokenBalanceRpc;
+  quoteVault: Address;
+  pendingQuoteFees: bigint;
+  minRaiseQuote: bigint;
+  commitment?: 'processed' | 'confirmed' | 'finalized';
+}): Promise<MigrationQuoteProgress> {
+  const progress = await getMigrationQuoteProgress({
+    rpc,
+    quoteVault,
+    pendingQuoteFees,
+    commitment,
+  });
+
+  if (progress.migrationQuoteAmount < minRaiseQuote) {
+    throw new Error(
+      `Quote available for migration ${progress.migrationQuoteAmount} is below minRaiseQuote ${minRaiseQuote}`,
+    );
+  }
+
+  return progress;
+}

--- a/src/solana/swaps.ts
+++ b/src/solana/swaps.ts
@@ -1,0 +1,372 @@
+import {
+  address,
+  type AccountMeta,
+  type AccountSignerMeta,
+  type Address,
+  type GetAccountInfoApi,
+  type Instruction,
+  type Rpc,
+  type TransactionSigner,
+} from '@solana/kit';
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getSyncNativeInstruction,
+} from '@solana-program/token';
+import { getTransferSolInstruction } from '@solana-program/system';
+
+import { type TradeDirection, type SwapQuote } from './core/index.js';
+import { TOKEN_PROGRAM_ADDRESS } from './core/constants.js';
+import { getSwapQuote } from './core/math.js';
+import { getPoolByMints, type PoolWithAddress } from './client/index.js';
+import { createSwapInstruction } from './instructions/index.js';
+import type { SolanaCpmmDeployment } from './deployment.js';
+import {
+  INITIALIZER_PROGRAM_ID,
+  TRADE_DIRECTION_BUY,
+  type CurveSwapExactInAccounts,
+  createCurveSwapExactInInstruction,
+} from './initializer/index.js';
+
+export type SolanaRemainingAccount =
+  | Address
+  | AccountMeta
+  | AccountSignerMeta
+  | TransactionSigner;
+
+type AddressOrSigner = Address | TransactionSigner;
+
+export type CurveSwapExactInInput = {
+  deployment?: Pick<SolanaCpmmDeployment, 'initializerProgram'> &
+    Partial<Pick<SolanaCpmmDeployment, 'cpmmHookProgram'>>;
+  programId?: Address;
+  launch: Address;
+  launchAuthority: Address;
+  baseVault: Address;
+  quoteVault: Address;
+  launchFeeState: Address;
+  baseMint: Address;
+  quoteMint: Address;
+  payer: TransactionSigner;
+  user?: AddressOrSigner;
+  amountIn: bigint;
+  minAmountOut: bigint;
+  tradeDirection: 0 | 1;
+  hookProgram?: Address;
+  remainingAccounts?: ReadonlyArray<SolanaRemainingAccount>;
+  baseTokenProgram?: Address;
+  quoteTokenProgram?: Address;
+  wrapSol?: boolean;
+};
+
+export type CurveSwapExactInResult = {
+  userBaseAccount: Address;
+  userQuoteAccount: Address;
+  userIn: Address;
+  userOut: Address;
+  setupInstructions: Instruction[];
+  swapInstruction: Instruction;
+  instructions: Instruction[];
+};
+
+type SwapExactInBaseInput = {
+  deployment?: Pick<SolanaCpmmDeployment, 'cpmmProgram' | 'cpmmConfig'>;
+  programId?: Address;
+  config?: Address;
+  payer: TransactionSigner;
+  user?: AddressOrSigner;
+  amountIn: bigint;
+  tradeDirection: TradeDirection;
+  minAmountOut?: bigint;
+  slippageBps?: number | bigint;
+  token0Program?: Address;
+  token1Program?: Address;
+  tokenProgram?: Address;
+  oracle?: Address;
+  remainingAccounts?: ReadonlyArray<SolanaRemainingAccount>;
+  updateOracle?: boolean;
+};
+
+export type SwapExactInInput =
+  | (SwapExactInBaseInput & {
+      pool: PoolWithAddress;
+      rpc?: never;
+      mintA?: never;
+      mintB?: never;
+    })
+  | (SwapExactInBaseInput & {
+      rpc: Rpc<GetAccountInfoApi>;
+      mintA: Address;
+      mintB: Address;
+      pool?: never;
+    });
+
+export type SwapExactInResult = {
+  pool: PoolWithAddress;
+  quote: SwapQuote;
+  minAmountOut: bigint;
+  userToken0: Address;
+  userToken1: Address;
+  userIn: Address;
+  userOut: Address;
+  setupInstructions: Instruction[];
+  swapInstruction: Instruction;
+  instructions: Instruction[];
+};
+
+const WRAPPED_SOL_MINT = address('So11111111111111111111111111111111111111112');
+const BPS_DENOMINATOR = 10_000n;
+
+function isTransactionSigner(
+  value: AddressOrSigner,
+): value is TransactionSigner {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'address' in value &&
+    'signTransactions' in value
+  );
+}
+
+function getAddress(value: AddressOrSigner): Address {
+  return isTransactionSigner(value) ? value.address : value;
+}
+
+async function getAssociatedTokenAddress({
+  owner,
+  mint,
+  tokenProgram,
+}: {
+  owner: Address;
+  mint: Address;
+  tokenProgram: Address;
+}): Promise<Address> {
+  const [ata] = await findAssociatedTokenPda({
+    owner,
+    mint,
+    tokenProgram,
+  });
+  return ata;
+}
+
+function resolveSlippageBps(slippageBps: number | bigint | undefined): bigint {
+  const resolved = slippageBps === undefined ? 50n : BigInt(slippageBps);
+  if (resolved < 0n || resolved > BPS_DENOMINATOR) {
+    throw new Error('slippageBps must be between 0 and 10000');
+  }
+  return resolved;
+}
+
+function getMinAmountOut({
+  quotedAmountOut,
+  minAmountOut,
+  slippageBps,
+}: {
+  quotedAmountOut: bigint;
+  minAmountOut?: bigint;
+  slippageBps?: number | bigint;
+}): bigint {
+  if (minAmountOut !== undefined) {
+    return minAmountOut;
+  }
+  const slippage = resolveSlippageBps(slippageBps);
+  return (quotedAmountOut * (BPS_DENOMINATOR - slippage)) / BPS_DENOMINATOR;
+}
+
+export async function curveSwapExactIn(
+  input: CurveSwapExactInInput,
+): Promise<CurveSwapExactInResult> {
+  const programId =
+    input.programId ??
+    input.deployment?.initializerProgram ??
+    INITIALIZER_PROGRAM_ID;
+  const user = input.user ?? input.payer;
+  const userAddress = getAddress(user);
+  const baseTokenProgram = input.baseTokenProgram ?? TOKEN_PROGRAM_ADDRESS;
+  const quoteTokenProgram = input.quoteTokenProgram ?? TOKEN_PROGRAM_ADDRESS;
+  const userBaseAccount = await getAssociatedTokenAddress({
+    owner: userAddress,
+    mint: input.baseMint,
+    tokenProgram: baseTokenProgram,
+  });
+  const userQuoteAccount = await getAssociatedTokenAddress({
+    owner: userAddress,
+    mint: input.quoteMint,
+    tokenProgram: quoteTokenProgram,
+  });
+
+  const setupInstructions: Instruction[] = [
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: input.payer,
+      ata: userBaseAccount,
+      owner: userAddress,
+      mint: input.baseMint,
+      tokenProgram: baseTokenProgram,
+    }),
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: input.payer,
+      ata: userQuoteAccount,
+      owner: userAddress,
+      mint: input.quoteMint,
+      tokenProgram: quoteTokenProgram,
+    }),
+  ];
+  const shouldWrapSol =
+    input.wrapSol ??
+    (input.quoteMint === WRAPPED_SOL_MINT &&
+      input.tradeDirection === TRADE_DIRECTION_BUY);
+
+  if (shouldWrapSol) {
+    setupInstructions.push(
+      getTransferSolInstruction({
+        source: input.payer,
+        destination: userQuoteAccount,
+        amount: input.amountIn,
+      }),
+      getSyncNativeInstruction({ account: userQuoteAccount }),
+    );
+  }
+
+  const swapAccounts: CurveSwapExactInAccounts = {
+    launch: input.launch,
+    launchAuthority: input.launchAuthority,
+    baseVault: input.baseVault,
+    quoteVault: input.quoteVault,
+    launchFeeState: input.launchFeeState,
+    userBaseAccount,
+    userQuoteAccount,
+    baseMint: input.baseMint,
+    quoteMint: input.quoteMint,
+    user,
+    hookProgram: input.hookProgram ?? input.deployment?.cpmmHookProgram,
+    baseTokenProgram,
+    quoteTokenProgram,
+    remainingAccounts: input.remainingAccounts
+      ? [...input.remainingAccounts]
+      : undefined,
+  };
+  const swapInstruction = createCurveSwapExactInInstruction(
+    swapAccounts,
+    {
+      amountIn: input.amountIn,
+      minAmountOut: input.minAmountOut,
+      tradeDirection: input.tradeDirection,
+    },
+    programId,
+  );
+  const userIn =
+    input.tradeDirection === TRADE_DIRECTION_BUY
+      ? userQuoteAccount
+      : userBaseAccount;
+  const userOut =
+    input.tradeDirection === TRADE_DIRECTION_BUY
+      ? userBaseAccount
+      : userQuoteAccount;
+
+  return {
+    userBaseAccount,
+    userQuoteAccount,
+    userIn,
+    userOut,
+    setupInstructions,
+    swapInstruction,
+    instructions: [...setupInstructions, swapInstruction],
+  };
+}
+
+export async function swapExactIn(
+  input: SwapExactInInput,
+): Promise<SwapExactInResult> {
+  const programId =
+    input.programId ?? input.deployment?.cpmmProgram ?? undefined;
+  const pool =
+    'pool' in input
+      ? input.pool
+      : await getPoolByMints(input.rpc, input.mintA, input.mintB, {
+          programId,
+        });
+  if (!pool) {
+    throw new Error(`No pool found for ${input.mintA} / ${input.mintB}`);
+  }
+
+  const user = input.user ?? input.payer;
+  const userAddress = getAddress(user);
+  const token0Program =
+    input.token0Program ?? input.tokenProgram ?? TOKEN_PROGRAM_ADDRESS;
+  const token1Program =
+    input.token1Program ?? input.tokenProgram ?? TOKEN_PROGRAM_ADDRESS;
+  const quote = getSwapQuote(
+    pool.account,
+    input.amountIn,
+    input.tradeDirection,
+  );
+  const minAmountOut = getMinAmountOut({
+    quotedAmountOut: quote.amountOut,
+    minAmountOut: input.minAmountOut,
+    slippageBps: input.slippageBps,
+  });
+  const userToken0 = await getAssociatedTokenAddress({
+    owner: userAddress,
+    mint: pool.account.token0Mint,
+    tokenProgram: token0Program,
+  });
+  const userToken1 = await getAssociatedTokenAddress({
+    owner: userAddress,
+    mint: pool.account.token1Mint,
+    tokenProgram: token1Program,
+  });
+  const setupInstructions: Instruction[] = [
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: input.payer,
+      ata: userToken0,
+      owner: userAddress,
+      mint: pool.account.token0Mint,
+      tokenProgram: token0Program,
+    }),
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: input.payer,
+      ata: userToken1,
+      owner: userAddress,
+      mint: pool.account.token1Mint,
+      tokenProgram: token1Program,
+    }),
+  ];
+  const swapInstruction = createSwapInstruction({
+    config: input.config ?? input.deployment?.cpmmConfig ?? pool.account.config,
+    pool: pool.address,
+    authority: pool.account.authority,
+    vault0: pool.account.vault0,
+    vault1: pool.account.vault1,
+    token0Mint: pool.account.token0Mint,
+    token1Mint: pool.account.token1Mint,
+    userToken0,
+    userToken1,
+    user,
+    amountIn: input.amountIn,
+    minAmountOut,
+    tradeDirection: input.tradeDirection,
+    oracle: input.oracle,
+    remainingAccounts: input.remainingAccounts
+      ? [...input.remainingAccounts]
+      : undefined,
+    updateOracle: input.updateOracle,
+    token0Program,
+    token1Program,
+    programId: programId ?? input.deployment?.cpmmProgram,
+  });
+  const userIn = input.tradeDirection === 0 ? userToken0 : userToken1;
+  const userOut = input.tradeDirection === 0 ? userToken1 : userToken0;
+
+  return {
+    pool,
+    quote,
+    minAmountOut,
+    userToken0,
+    userToken1,
+    userIn,
+    userOut,
+    setupInstructions,
+    swapInstruction,
+    instructions: [...setupInstructions, swapInstruction],
+  };
+}

--- a/test/solana/unit/workflows.test.ts
+++ b/test/solana/unit/workflows.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+import { address, type Address } from '@solana/kit';
+import { generateKeyPairSigner } from '@solana/signers';
+
+import {
+  assertMigrationQuoteThreshold,
+  cpmm,
+  cpmmMigrator,
+  curveSwapExactIn,
+  getMigrationQuoteProgress,
+  initializer,
+  migrateLaunch,
+  swapExactIn,
+} from '@/solana/index.js';
+import {
+  SYSTEM_PROGRAM_ADDRESS,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
+} from '@/solana/core/constants.js';
+import type { Pool } from '@/solana/core/types.js';
+
+const WSOL_MINT = address('So11111111111111111111111111111111111111112');
+const COMPUTE_BUDGET_PROGRAM_ID = address(
+  'ComputeBudget111111111111111111111111111111',
+);
+
+function createTestPool({
+  config,
+  token0Mint,
+  token1Mint,
+  vault0,
+  vault1,
+  authority,
+}: {
+  config: Address;
+  token0Mint: Address;
+  token1Mint: Address;
+  vault0: Address;
+  vault1: Address;
+  authority: Address;
+}): Pool {
+  return {
+    config,
+    token0Mint,
+    token1Mint,
+    vault0,
+    vault1,
+    authority,
+    bump: 255,
+    reserve0: 1_000_000n,
+    reserve1: 2_000_000n,
+    totalShares: 1_000_000n,
+    swapFeeBps: 100,
+    feeSplitBps: 5_000,
+    feeGrowthGlobal0Q64: 0n,
+    feeGrowthGlobal1Q64: 0n,
+    feesUnclaimed0: 0n,
+    feesUnclaimed1: 0n,
+    hookProgram: SYSTEM_PROGRAM_ADDRESS,
+    hookFlags: 0,
+    liquidityMeasureTokenIndex: 0,
+    kLast: 0n,
+    protocolFeePosition: address('11111111111111111111111111111111'),
+    locked: 0,
+    version: 1,
+    reserved: new Uint8Array(7),
+  };
+}
+
+describe('Solana workflow helpers', () => {
+  it('prepares a WSOL curve exact-in buy with setup before the swap', async () => {
+    const payer = await generateKeyPairSigner();
+    const cosigner = await generateKeyPairSigner();
+    const baseMint = await generateKeyPairSigner();
+    const baseVault = await generateKeyPairSigner();
+    const quoteVault = await generateKeyPairSigner();
+    const launch = address('8h4Nw2m3qPH4tB3x3fcQADkHDzWr7TjapfxnY4LuRk7w');
+    const launchAuthority = address(
+      '5hX6e1cyWUFHMzLM5VGuxFHXU8Gykqa5R2rsJqnyqkyU',
+    );
+    const launchFeeState = address(
+      '3x13Y2NkqGGLNxbh3Pcz9F4SNgtVtFU6fqfmbs36FxgY',
+    );
+
+    const prepared = await curveSwapExactIn({
+      launch,
+      launchAuthority,
+      baseVault: baseVault.address,
+      quoteVault: quoteVault.address,
+      launchFeeState,
+      baseMint: baseMint.address,
+      quoteMint: WSOL_MINT,
+      payer,
+      amountIn: 100_000n,
+      minAmountOut: 1n,
+      tradeDirection: initializer.TRADE_DIRECTION_BUY,
+      hookProgram: initializer.CPMM_HOOK_PROGRAM_ID,
+      remainingAccounts: [cosigner],
+    });
+
+    expect(prepared.setupInstructions).toHaveLength(4);
+    expect(prepared.instructions).toEqual([
+      ...prepared.setupInstructions,
+      prepared.swapInstruction,
+    ]);
+    expect(prepared.userIn).toBe(prepared.userQuoteAccount);
+    expect(prepared.userOut).toBe(prepared.userBaseAccount);
+    expect(prepared.swapInstruction.programAddress).toBe(
+      initializer.INITIALIZER_PROGRAM_ID,
+    );
+    expect(prepared.swapInstruction.accounts![4].address).toBe(
+      prepared.userBaseAccount,
+    );
+    expect(prepared.swapInstruction.accounts![5].address).toBe(
+      prepared.userQuoteAccount,
+    );
+    expect(prepared.swapInstruction.accounts!.at(-1)?.address).toBe(
+      cosigner.address,
+    );
+  });
+
+  it('prepares a CPMM exact-in swap with quote, slippage, and token ATAs', async () => {
+    const payer = await generateKeyPairSigner();
+    const token0Mint = await generateKeyPairSigner();
+    const token1Mint = await generateKeyPairSigner();
+    const poolAddress = address('3x13Y2NkqGGLNxbh3Pcz9F4SNgtVtFU6fqfmbs36FxgY');
+    const pool = createTestPool({
+      config: address('E45nSdnfANtYhCy6qZXo2a7qAWCU6pYjpqsby1bbkaiL'),
+      token0Mint: token0Mint.address,
+      token1Mint: token1Mint.address,
+      vault0: address('2y7VfY6FEteTm5NntQbXcp6BqkhZsd34z8gLT6Rp6g9T'),
+      vault1: address('5kWU9u4CuSNCvTzwUW6Wm4j9aigZFg3sLKzg4UFK2qwg'),
+      authority: address('5hX6e1cyWUFHMzLM5VGuxFHXU8Gykqa5R2rsJqnyqkyU'),
+    });
+
+    const prepared = await swapExactIn({
+      pool: { address: poolAddress, account: pool },
+      payer,
+      amountIn: 10_000n,
+      tradeDirection: 1,
+      slippageBps: 100n,
+      token0Program: TOKEN_2022_PROGRAM_ADDRESS,
+      token1Program: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    const expectedQuote = cpmm.getSwapQuote(pool, 10_000n, 1);
+    expect(prepared.quote).toEqual(expectedQuote);
+    expect(prepared.minAmountOut).toBe(
+      (expectedQuote.amountOut * 9_900n) / 10_000n,
+    );
+    expect(prepared.setupInstructions).toHaveLength(2);
+    expect(prepared.instructions).toEqual([
+      ...prepared.setupInstructions,
+      prepared.swapInstruction,
+    ]);
+    expect(prepared.userIn).toBe(prepared.userToken1);
+    expect(prepared.userOut).toBe(prepared.userToken0);
+    expect(prepared.swapInstruction.accounts![3].address).toBe(pool.vault1);
+    expect(prepared.swapInstruction.accounts![4].address).toBe(pool.vault0);
+  });
+
+  it('prepares migrateLaunch with compute budget, recipient ATAs, and CPMM metas', async () => {
+    const payer = await generateKeyPairSigner();
+    const recipient = await generateKeyPairSigner();
+    const baseMint = await generateKeyPairSigner();
+    const quoteMint = await generateKeyPairSigner();
+    const launch = address('8h4Nw2m3qPH4tB3x3fcQADkHDzWr7TjapfxnY4LuRk7w');
+    const launchAuthority = address(
+      '5hX6e1cyWUFHMzLM5VGuxFHXU8Gykqa5R2rsJqnyqkyU',
+    );
+    const recipientAta = address(
+      '4Ux8qqquRoLtMfXTrkVN1sRAz7E3BbFyyq1UFgdKpbXr',
+    );
+    const migrationAccounts =
+      await cpmmMigrator.buildCpmmMigrationRemainingAccounts({
+        launch,
+        baseMint: baseMint.address,
+        quoteMint: quoteMint.address,
+        launchAuthority,
+        adminBaseAta: address('2y7VfY6FEteTm5NntQbXcp6BqkhZsd34z8gLT6Rp6g9T'),
+        adminQuoteAta: address('5kWU9u4CuSNCvTzwUW6Wm4j9aigZFg3sLKzg4UFK2qwg'),
+        recipientAtas: [recipientAta],
+      });
+
+    const prepared = migrateLaunch({
+      deployment: {
+        initializerProgram: initializer.INITIALIZER_PROGRAM_ID,
+        initializerConfig: address(
+          'E45nSdnfANtYhCy6qZXo2a7qAWCU6pYjpqsby1bbkaiL',
+        ),
+        cpmmMigratorProgram: cpmmMigrator.CPMM_MIGRATOR_PROGRAM_ID,
+      },
+      launch,
+      launchAuthority,
+      baseMint: baseMint.address,
+      quoteMint: quoteMint.address,
+      baseVault: address('5M6Ko42FUVA4ovM7EMERuhRdT49yYRaYtLuQ7jnhkBhC'),
+      quoteVault: address('7ZAv1WfVd2k9TtPGC82ZxPwpE2L8YB4Y3dByQNCXc9NL'),
+      launchFeeState: address('3x13Y2NkqGGLNxbh3Pcz9F4SNgtVtFU6fqfmbs36FxgY'),
+      payer,
+      cpmmMigration: migrationAccounts,
+      recipients: [{ wallet: recipient.address }],
+    });
+
+    expect(prepared.computeUnitLimitInstruction?.programAddress).toBe(
+      COMPUTE_BUDGET_PROGRAM_ID,
+    );
+    expect(prepared.recipientAtaInstructions).toHaveLength(1);
+    expect(prepared.instructions).toEqual([
+      prepared.computeUnitLimitInstruction,
+      ...prepared.recipientAtaInstructions,
+      prepared.migrateInstruction,
+    ]);
+    expect(
+      prepared.migrateInstruction
+        .accounts!.slice(14)
+        .map(({ address }) => address),
+    ).toEqual(migrationAccounts.metas.map(({ address }) => address));
+  });
+
+  it('reports migration quote progress net of pending fees', async () => {
+    const rpc = {
+      getTokenAccountBalance: () => ({
+        send: async () => ({ value: { amount: '1000' } }),
+      }),
+    };
+
+    await expect(
+      assertMigrationQuoteThreshold({
+        rpc,
+        quoteVault: WSOL_MINT,
+        pendingQuoteFees: 200n,
+        minRaiseQuote: 900n,
+      }),
+    ).rejects.toThrow('below minRaiseQuote');
+
+    await expect(
+      getMigrationQuoteProgress({
+        rpc,
+        quoteVault: WSOL_MINT,
+        pendingQuoteFees: 200n,
+      }),
+    ).resolves.toEqual({
+      quoteVaultAmount: 1000n,
+      pendingQuoteFees: 200n,
+      migrationQuoteAmount: 800n,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add root-level Solana workflow helpers for pre-migration curve swaps, post-migration CPMM swaps, launch migration, and migration quote readiness checks.
- Refactor Solana swap, E2E, and cosigner examples to use the root helpers instead of manually wiring initializer/CPMM instruction internals.
- Add focused Solana unit tests for the new workflow helpers.

## Solana Areas

- Root SDK exports: `curveSwapExactIn`, `swapExactIn`, `migrateLaunch`, `getMigrationQuoteProgress`, `assertMigrationQuoteThreshold`.
- Examples now treat swaps and migration as high-level SDK flows while the lower-level initializer/CPMM builders remain available for advanced usage.

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test:solana`
- `pnpm build`
- `git diff --check`

Note: `pnpm typecheck:test` is still blocked by unrelated existing EVM test type errors in the repo.