### PR TITLE
refactor: add shared Solana account and EVM contract parsers

### DIFF
--- a/src/evm/entities/auction/DynamicAuction.ts
+++ b/src/evm/entities/auction/DynamicAuction.ts
@@ -1,14 +1,13 @@
-import {
-  type Address,
-  type PublicClient,
-  type Hex,
-  keccak256,
-  encodeAbiParameters,
-  zeroAddress,
-} from 'viem';
+import { type Address, type PublicClient, type Hex, zeroAddress } from 'viem';
 import type { HookInfo, SupportedPublicClient } from '../../types';
 import { dopplerHookAbi, airlockAbi } from '../../abis';
 import { getAddresses } from '../../addresses';
+import { computePoolId, normalizePoolKey } from '../../utils/poolKey';
+import {
+  normalizeDynamicHookState,
+  parseAirlockLiquidityMigrator,
+  type DynamicHookState,
+} from './contractResults';
 
 /**
  * DynamicAuction class for interacting with dynamic auctions (Uniswap V4 hook based)
@@ -111,13 +110,13 @@ export class DynamicAuction {
       epochLength > 0n ? Number(elapsedTime / epochLength) : 0;
 
     // Determine token addresses from poolKey
-    const poolKey = this.normalizePoolKey(poolKeyRaw as any);
+    const poolKey = normalizePoolKey(poolKeyRaw);
     const isToken0 = poolKey.currency0 !== zeroAddress;
     const tokenAddress = isToken0 ? poolKey.currency0 : poolKey.currency1;
     const numeraireAddress = isToken0 ? poolKey.currency1 : poolKey.currency0;
 
     // Compute pool ID
-    const poolId = this.computePoolId(poolKey);
+    const poolId = computePoolId(poolKey);
 
     return {
       hookAddress: this.hookAddress,
@@ -125,8 +124,8 @@ export class DynamicAuction {
       numeraireAddress,
       poolId,
       currentEpoch,
-      totalProceeds: (state as any).totalProceeds,
-      totalTokensSold: (state as any).totalTokensSold,
+      totalProceeds: state.totalProceeds,
+      totalTokensSold: state.totalTokensSold,
       earlyExit,
       insufficientProceeds,
       startingTime,
@@ -146,7 +145,7 @@ export class DynamicAuction {
       abi: dopplerHookAbi,
       functionName: 'poolKey',
     });
-    const poolKey = this.normalizePoolKey(poolKeyRaw as any);
+    const poolKey = normalizePoolKey(poolKeyRaw);
 
     const isToken0 = await this.rpc.readContract({
       address: this.hookAddress,
@@ -166,8 +165,8 @@ export class DynamicAuction {
       abi: dopplerHookAbi,
       functionName: 'poolKey',
     });
-    const poolKey = this.normalizePoolKey(poolKeyRaw as any);
-    return this.computePoolId(poolKey);
+    const poolKey = normalizePoolKey(poolKeyRaw);
+    return computePoolId(poolKey);
   }
 
   /**
@@ -184,10 +183,7 @@ export class DynamicAuction {
       functionName: 'getAssetData',
       args: [tokenAddress],
     });
-    // Check if the asset is graduated (liquidityMigrator is zero)
-    const liquidityMigrator = Array.isArray(assetData)
-      ? (assetData as any)[3]
-      : (assetData as any)?.liquidityMigrator;
+    const liquidityMigrator = parseAirlockLiquidityMigrator(assetData);
     return liquidityMigrator === zeroAddress;
   }
 
@@ -276,7 +272,7 @@ export class DynamicAuction {
   async getTotalProceeds(): Promise<bigint> {
     const state = await this.readHookState();
 
-    return (state as any).totalProceeds;
+    return state.totalProceeds;
   }
 
   /**
@@ -290,84 +286,12 @@ export class DynamicAuction {
     });
   }
 
-  /**
-   * Compute V4 pool ID from pool key components
-   */
-  private computePoolId(poolKey: {
-    currency0: Address;
-    currency1: Address;
-    fee: number;
-    tickSpacing: number;
-    hooks: Address;
-  }): string {
-    // V4 pools are identified by the hash of their PoolKey
-    const encoded = encodeAbiParameters(
-      [
-        { type: 'address' },
-        { type: 'address' },
-        { type: 'uint24' },
-        { type: 'int24' },
-        { type: 'address' },
-      ],
-      [
-        poolKey.currency0,
-        poolKey.currency1,
-        poolKey.fee,
-        poolKey.tickSpacing,
-        poolKey.hooks,
-      ],
-    );
-    return keccak256(encoded);
-  }
-
-  /**
-   * Read hook state with backward-compatible decoding.
-   * Falls back to legacy state() ABI if the latest ABI fails to decode.
-   */
-  private async readHookState(): Promise<any> {
-    const result: any = await this.rpc.readContract({
+  private async readHookState(): Promise<DynamicHookState> {
+    const rawState = await this.rpc.readContract({
       address: this.hookAddress,
       abi: dopplerHookAbi,
       functionName: 'state',
     });
-    if (Array.isArray(result)) {
-      const [
-        lastEpoch,
-        tickAccumulator,
-        totalTokensSold,
-        totalProceeds,
-        totalTokensSoldLastEpoch,
-        feesAccrued,
-      ] = result as any[];
-      return {
-        lastEpoch,
-        tickAccumulator,
-        totalTokensSold,
-        totalProceeds,
-        totalTokensSoldLastEpoch,
-        feesAccrued,
-      };
-    }
-    return result;
-  }
-
-  private normalizePoolKey(value: any): {
-    currency0: Address;
-    currency1: Address;
-    fee: number;
-    tickSpacing: number;
-    hooks: Address;
-  } {
-    if (Array.isArray(value)) {
-      const [currency0, currency1, fee, tickSpacing, hooks] = value as [
-        Address,
-        Address,
-        number,
-        number,
-        Address,
-      ];
-      return { currency0, currency1, fee, tickSpacing, hooks };
-    }
-    return value as any;
+    return normalizeDynamicHookState(rawState);
   }
 }

--- a/src/evm/entities/auction/DynamicAuction.ts
+++ b/src/evm/entities/auction/DynamicAuction.ts
@@ -216,9 +216,8 @@ export class DynamicAuction {
    * Returns the current tick based on the epoch and gamma parameters
    */
   async getCurrentPrice(): Promise<bigint> {
-    const [_state, startingTick, endingTick, gamma, startingTime, epochLength] =
+    const [startingTick, endingTick, gamma, startingTime, epochLength] =
       await Promise.all([
-        this.readHookState(),
         this.rpc.readContract({
           address: this.hookAddress,
           abi: dopplerHookAbi,

--- a/src/evm/entities/auction/RehypeDopplerHook.ts
+++ b/src/evm/entities/auction/RehypeDopplerHook.ts
@@ -1,7 +1,19 @@
 import type { Address, Hash, Hex, PublicClient, WalletClient } from 'viem';
-import type { SupportedPublicClient } from '../../types';
+import type {
+  RehypeFeeDistributionInfo,
+  SupportedPublicClient,
+} from '../../types';
 import { rehypeDopplerHookAbi } from '../../abis';
 import { decodeBalanceDelta } from '../../utils';
+import {
+  normalizeRehypeFeeDistributionInfo,
+  normalizeRehypeFeeSchedule,
+  normalizeRehypeHookFees,
+  normalizeRehypePoolInfo,
+  type RehypeFeeSchedule,
+  type RehypeHookFees,
+  type RehypePoolInfo,
+} from './contractResults';
 
 export class RehypeDopplerHook {
   private client: SupportedPublicClient;
@@ -77,16 +89,9 @@ export class RehypeDopplerHook {
     return { fees0, fees1, transactionHash: hash };
   }
 
-  async getFeeDistributionInfo(poolId: Hex): Promise<{
-    assetFeesToAssetBuybackWad: bigint;
-    assetFeesToNumeraireBuybackWad: bigint;
-    assetFeesToBeneficiaryWad: bigint;
-    assetFeesToLpWad: bigint;
-    numeraireFeesToAssetBuybackWad: bigint;
-    numeraireFeesToNumeraireBuybackWad: bigint;
-    numeraireFeesToBeneficiaryWad: bigint;
-    numeraireFeesToLpWad: bigint;
-  }> {
+  async getFeeDistributionInfo(
+    poolId: Hex,
+  ): Promise<RehypeFeeDistributionInfo> {
     const result = await this.rpc.readContract({
       address: this.hookAddress,
       abi: rehypeDopplerHookAbi,
@@ -94,29 +99,7 @@ export class RehypeDopplerHook {
       args: [poolId],
     });
 
-    const info = result as any;
-    return {
-      assetFeesToAssetBuybackWad: BigInt(
-        info.assetFeesToAssetBuybackWad ?? info[0],
-      ),
-      assetFeesToNumeraireBuybackWad: BigInt(
-        info.assetFeesToNumeraireBuybackWad ?? info[1],
-      ),
-      assetFeesToBeneficiaryWad: BigInt(
-        info.assetFeesToBeneficiaryWad ?? info[2],
-      ),
-      assetFeesToLpWad: BigInt(info.assetFeesToLpWad ?? info[3]),
-      numeraireFeesToAssetBuybackWad: BigInt(
-        info.numeraireFeesToAssetBuybackWad ?? info[4],
-      ),
-      numeraireFeesToNumeraireBuybackWad: BigInt(
-        info.numeraireFeesToNumeraireBuybackWad ?? info[5],
-      ),
-      numeraireFeesToBeneficiaryWad: BigInt(
-        info.numeraireFeesToBeneficiaryWad ?? info[6],
-      ),
-      numeraireFeesToLpWad: BigInt(info.numeraireFeesToLpWad ?? info[7]),
-    };
+    return normalizeRehypeFeeDistributionInfo(result);
   }
 
   async getFeeRoutingMode(poolId: Hex): Promise<number> {
@@ -129,13 +112,7 @@ export class RehypeDopplerHook {
     return Number(mode);
   }
 
-  async getFeeSchedule(poolId: Hex): Promise<{
-    startingTime: number;
-    startFee: number;
-    endFee: number;
-    lastFee: number;
-    durationSeconds: number;
-  }> {
+  async getFeeSchedule(poolId: Hex): Promise<RehypeFeeSchedule> {
     const result = await this.rpc.readContract({
       address: this.hookAddress,
       abi: rehypeDopplerHookAbi,
@@ -143,25 +120,10 @@ export class RehypeDopplerHook {
       args: [poolId],
     });
 
-    const schedule = result as any;
-    return {
-      startingTime: Number(schedule.startingTime ?? schedule[0] ?? 0),
-      startFee: Number(schedule.startFee ?? schedule[1] ?? 0),
-      endFee: Number(schedule.endFee ?? schedule[2] ?? 0),
-      lastFee: Number(schedule.lastFee ?? schedule[3] ?? 0),
-      durationSeconds: Number(schedule.durationSeconds ?? schedule[4] ?? 0),
-    };
+    return normalizeRehypeFeeSchedule(result);
   }
 
-  async getHookFees(poolId: Hex): Promise<{
-    fees0: bigint;
-    fees1: bigint;
-    beneficiaryFees0: bigint;
-    beneficiaryFees1: bigint;
-    airlockOwnerFees0: bigint;
-    airlockOwnerFees1: bigint;
-    customFee: number;
-  }> {
+  async getHookFees(poolId: Hex): Promise<RehypeHookFees> {
     const result = await this.rpc.readContract({
       address: this.hookAddress,
       abi: rehypeDopplerHookAbi,
@@ -169,23 +131,10 @@ export class RehypeDopplerHook {
       args: [poolId],
     });
 
-    const fees = result as any;
-    return {
-      fees0: BigInt(fees.fees0 ?? fees[0] ?? 0),
-      fees1: BigInt(fees.fees1 ?? fees[1] ?? 0),
-      beneficiaryFees0: BigInt(fees.beneficiaryFees0 ?? fees[2] ?? 0),
-      beneficiaryFees1: BigInt(fees.beneficiaryFees1 ?? fees[3] ?? 0),
-      airlockOwnerFees0: BigInt(fees.airlockOwnerFees0 ?? fees[4] ?? 0),
-      airlockOwnerFees1: BigInt(fees.airlockOwnerFees1 ?? fees[5] ?? 0),
-      customFee: Number(fees.customFee ?? fees[6] ?? 0),
-    };
+    return normalizeRehypeHookFees(result);
   }
 
-  async getPoolInfo(poolId: Hex): Promise<{
-    asset: Address;
-    numeraire: Address;
-    buybackDst: Address;
-  }> {
+  async getPoolInfo(poolId: Hex): Promise<RehypePoolInfo> {
     const result = await this.rpc.readContract({
       address: this.hookAddress,
       abi: rehypeDopplerHookAbi,
@@ -193,11 +142,6 @@ export class RehypeDopplerHook {
       args: [poolId],
     });
 
-    const info = result as any;
-    return {
-      asset: (info.asset ?? info[0]) as Address,
-      numeraire: (info.numeraire ?? info[1]) as Address,
-      buybackDst: (info.buybackDst ?? info[2]) as Address,
-    };
+    return normalizeRehypePoolInfo(result);
   }
 }

--- a/src/evm/entities/auction/RehypeDopplerHookMigrator.ts
+++ b/src/evm/entities/auction/RehypeDopplerHookMigrator.ts
@@ -5,6 +5,15 @@ import type {
 } from '../../types';
 import { rehypeDopplerHookMigratorAbi } from '../../abis';
 import { decodeBalanceDelta } from '../../utils';
+import {
+  normalizeRehypeFeeDistributionInfo,
+  normalizeRehypeHookFees,
+  normalizeRehypePoolInfo,
+  normalizeRehypePosition,
+  type RehypeHookFees,
+  type RehypePoolInfo,
+  type RehypePosition,
+} from './contractResults';
 
 export class RehypeDopplerHookMigrator {
   private client: SupportedPublicClient;
@@ -121,29 +130,7 @@ export class RehypeDopplerHookMigrator {
       args: [poolId],
     });
 
-    const info = result as any;
-    return {
-      assetFeesToAssetBuybackWad: BigInt(
-        info.assetFeesToAssetBuybackWad ?? info[0],
-      ),
-      assetFeesToNumeraireBuybackWad: BigInt(
-        info.assetFeesToNumeraireBuybackWad ?? info[1],
-      ),
-      assetFeesToBeneficiaryWad: BigInt(
-        info.assetFeesToBeneficiaryWad ?? info[2],
-      ),
-      assetFeesToLpWad: BigInt(info.assetFeesToLpWad ?? info[3]),
-      numeraireFeesToAssetBuybackWad: BigInt(
-        info.numeraireFeesToAssetBuybackWad ?? info[4],
-      ),
-      numeraireFeesToNumeraireBuybackWad: BigInt(
-        info.numeraireFeesToNumeraireBuybackWad ?? info[5],
-      ),
-      numeraireFeesToBeneficiaryWad: BigInt(
-        info.numeraireFeesToBeneficiaryWad ?? info[6],
-      ),
-      numeraireFeesToLpWad: BigInt(info.numeraireFeesToLpWad ?? info[7]),
-    };
+    return normalizeRehypeFeeDistributionInfo(result);
   }
 
   async getFeeRoutingMode(poolId: Hex): Promise<number> {
@@ -156,15 +143,7 @@ export class RehypeDopplerHookMigrator {
     return Number(mode);
   }
 
-  async getHookFees(poolId: Hex): Promise<{
-    fees0: bigint;
-    fees1: bigint;
-    beneficiaryFees0: bigint;
-    beneficiaryFees1: bigint;
-    airlockOwnerFees0: bigint;
-    airlockOwnerFees1: bigint;
-    customFee: number;
-  }> {
+  async getHookFees(poolId: Hex): Promise<RehypeHookFees> {
     const result = await this.rpc.readContract({
       address: this.hookAddress,
       abi: rehypeDopplerHookMigratorAbi,
@@ -172,23 +151,10 @@ export class RehypeDopplerHookMigrator {
       args: [poolId],
     });
 
-    const fees = result as any;
-    return {
-      fees0: BigInt(fees.fees0 ?? fees[0] ?? 0),
-      fees1: BigInt(fees.fees1 ?? fees[1] ?? 0),
-      beneficiaryFees0: BigInt(fees.beneficiaryFees0 ?? fees[2] ?? 0),
-      beneficiaryFees1: BigInt(fees.beneficiaryFees1 ?? fees[3] ?? 0),
-      airlockOwnerFees0: BigInt(fees.airlockOwnerFees0 ?? fees[4] ?? 0),
-      airlockOwnerFees1: BigInt(fees.airlockOwnerFees1 ?? fees[5] ?? 0),
-      customFee: Number(fees.customFee ?? fees[6] ?? 0),
-    };
+    return normalizeRehypeHookFees(result);
   }
 
-  async getPoolInfo(poolId: Hex): Promise<{
-    asset: Address;
-    numeraire: Address;
-    buybackDst: Address;
-  }> {
+  async getPoolInfo(poolId: Hex): Promise<RehypePoolInfo> {
     const result = await this.rpc.readContract({
       address: this.hookAddress,
       abi: rehypeDopplerHookMigratorAbi,
@@ -196,20 +162,10 @@ export class RehypeDopplerHookMigrator {
       args: [poolId],
     });
 
-    const info = result as any;
-    return {
-      asset: (info.asset ?? info[0]) as Address,
-      numeraire: (info.numeraire ?? info[1]) as Address,
-      buybackDst: (info.buybackDst ?? info[2]) as Address,
-    };
+    return normalizeRehypePoolInfo(result);
   }
 
-  async getPosition(poolId: Hex): Promise<{
-    tickLower: number;
-    tickUpper: number;
-    liquidity: bigint;
-    salt: Hex;
-  }> {
+  async getPosition(poolId: Hex): Promise<RehypePosition> {
     const result = await this.rpc.readContract({
       address: this.hookAddress,
       abi: rehypeDopplerHookMigratorAbi,
@@ -217,12 +173,6 @@ export class RehypeDopplerHookMigrator {
       args: [poolId],
     });
 
-    const position = result as any;
-    return {
-      tickLower: Number(position.tickLower ?? position[0] ?? 0),
-      tickUpper: Number(position.tickUpper ?? position[1] ?? 0),
-      liquidity: BigInt(position.liquidity ?? position[2] ?? 0),
-      salt: (position.salt ?? position[3]) as Hex,
-    };
+    return normalizeRehypePosition(result);
   }
 }

--- a/src/evm/entities/auction/StaticAuction.ts
+++ b/src/evm/entities/auction/StaticAuction.ts
@@ -76,8 +76,7 @@ export class StaticAuction {
       functionName: 'getAssetData',
       args: [token0],
     });
-    const token0PoolOrHook = parseAirlockPoolOrHook(assetData);
-    const isToken0AuctionToken = token0PoolOrHook !== zeroAddress;
+    const isToken0AuctionToken = this.isRegisteredAirlockAsset(assetData);
 
     return {
       address: this.poolAddress,
@@ -159,5 +158,13 @@ export class StaticAuction {
       abi: uniswapV3PoolAbi,
       functionName: 'liquidity',
     });
+  }
+
+  private isRegisteredAirlockAsset(assetData: unknown): boolean {
+    try {
+      return parseAirlockPoolOrHook(assetData) !== zeroAddress;
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/evm/entities/auction/StaticAuction.ts
+++ b/src/evm/entities/auction/StaticAuction.ts
@@ -2,6 +2,10 @@ import { type Address, zeroAddress, type PublicClient } from 'viem';
 import type { PoolInfo, SupportedPublicClient } from '../../types';
 import { uniswapV3PoolAbi, airlockAbi } from '../../abis';
 import { getAddresses } from '../../addresses';
+import {
+  parseAirlockLiquidityMigrator,
+  parseAirlockPoolOrHook,
+} from './contractResults';
 
 /**
  * StaticAuction class for interacting with static auctions (Uniswap V3 based)
@@ -72,17 +76,8 @@ export class StaticAuction {
       functionName: 'getAssetData',
       args: [token0],
     });
-    // Determine whether token0 is the auction token.
-    // Handle both tuple and object return shapes from getAssetData.
-    // Tuple (legacy): [numeraire, timelock, governance, liquidityMigrator, poolInitializer, pool, ...]
-    // Object (unified): { poolOrHook, liquidityMigrator, numeraire, ... }
-    let poolOrHook0: any;
-    if (Array.isArray(assetData)) {
-      poolOrHook0 = assetData[5];
-    } else if (assetData && typeof assetData === 'object') {
-      poolOrHook0 = (assetData as any).poolOrHook ?? (assetData as any).pool;
-    }
-    const isToken0AuctionToken = poolOrHook0 && poolOrHook0 !== zeroAddress;
+    const token0PoolOrHook = parseAirlockPoolOrHook(assetData);
+    const isToken0AuctionToken = token0PoolOrHook !== zeroAddress;
 
     return {
       address: this.poolAddress,
@@ -116,10 +111,7 @@ export class StaticAuction {
       functionName: 'getAssetData',
       args: [tokenAddress],
     });
-    // Check if the asset is graduated (liquidityMigrator is zero)
-    const liquidityMigrator = Array.isArray(assetData)
-      ? (assetData as any)[3]
-      : (assetData as any)?.liquidityMigrator;
+    const liquidityMigrator = parseAirlockLiquidityMigrator(assetData);
     return liquidityMigrator === zeroAddress;
   }
 
@@ -130,19 +122,11 @@ export class StaticAuction {
   async getCurrentPrice(): Promise<bigint> {
     const poolInfo = await this.getPoolInfo();
 
-    // Get token ordering
-    const [token0] = await Promise.all([
-      this.rpc.readContract({
-        address: this.poolAddress,
-        abi: uniswapV3PoolAbi,
-        functionName: 'token0',
-      }),
-      this.rpc.readContract({
-        address: this.poolAddress,
-        abi: uniswapV3PoolAbi,
-        functionName: 'token1',
-      }),
-    ]);
+    const token0 = await this.rpc.readContract({
+      address: this.poolAddress,
+      abi: uniswapV3PoolAbi,
+      functionName: 'token0',
+    });
 
     // Calculate price from sqrtPriceX96
     // sqrtPriceX96 = sqrt(price) * 2^96

--- a/src/evm/entities/auction/contractResults.ts
+++ b/src/evm/entities/auction/contractResults.ts
@@ -2,12 +2,8 @@ import { isAddress, isHex, type Address, type Hex } from 'viem';
 import type { RehypeFeeDistributionInfo } from '../../types';
 
 export interface DynamicHookState {
-  lastEpoch: bigint;
-  tickAccumulator: bigint;
   totalTokensSold: bigint;
   totalProceeds: bigint;
-  totalTokensSoldLastEpoch: bigint;
-  feesAccrued: unknown;
 }
 
 export interface RehypeFeeSchedule {
@@ -72,17 +68,8 @@ export function normalizeDynamicHookState(
   context = 'DopplerHook state',
 ): DynamicHookState {
   return {
-    lastEpoch: parseBigIntField(rawState, 'lastEpoch', 0, context),
-    tickAccumulator: parseBigIntField(rawState, 'tickAccumulator', 1, context),
     totalTokensSold: parseBigIntField(rawState, 'totalTokensSold', 2, context),
     totalProceeds: parseBigIntField(rawState, 'totalProceeds', 3, context),
-    totalTokensSoldLastEpoch: parseBigIntField(
-      rawState,
-      'totalTokensSoldLastEpoch',
-      4,
-      context,
-    ),
-    feesAccrued: readContractResultField(rawState, ['feesAccrued'], 5, context),
   };
 }
 

--- a/src/evm/entities/auction/contractResults.ts
+++ b/src/evm/entities/auction/contractResults.ts
@@ -1,0 +1,339 @@
+import { isAddress, isHex, type Address, type Hex } from 'viem';
+import type { RehypeFeeDistributionInfo } from '../../types';
+
+export interface DynamicHookState {
+  lastEpoch: bigint;
+  tickAccumulator: bigint;
+  totalTokensSold: bigint;
+  totalProceeds: bigint;
+  totalTokensSoldLastEpoch: bigint;
+  feesAccrued: unknown;
+}
+
+export interface RehypeFeeSchedule {
+  startingTime: number;
+  startFee: number;
+  endFee: number;
+  lastFee: number;
+  durationSeconds: number;
+}
+
+export interface RehypeHookFees {
+  fees0: bigint;
+  fees1: bigint;
+  beneficiaryFees0: bigint;
+  beneficiaryFees1: bigint;
+  airlockOwnerFees0: bigint;
+  airlockOwnerFees1: bigint;
+  customFee: number;
+}
+
+export interface RehypePoolInfo {
+  asset: Address;
+  numeraire: Address;
+  buybackDst: Address;
+}
+
+export interface RehypePosition {
+  tickLower: number;
+  tickUpper: number;
+  liquidity: bigint;
+  salt: Hex;
+}
+
+export function parseAirlockPoolOrHook(
+  rawAssetData: unknown,
+  context = 'Airlock getAssetData',
+): Address {
+  const rawPoolOrHook = readContractResultField(
+    rawAssetData,
+    ['poolOrHook', 'pool'],
+    5,
+    context,
+  );
+  return parseAddress(rawPoolOrHook, context, 'poolOrHook');
+}
+
+export function parseAirlockLiquidityMigrator(
+  rawAssetData: unknown,
+  context = 'Airlock getAssetData',
+): Address {
+  const rawLiquidityMigrator = readContractResultField(
+    rawAssetData,
+    ['liquidityMigrator'],
+    3,
+    context,
+  );
+  return parseAddress(rawLiquidityMigrator, context, 'liquidityMigrator');
+}
+
+export function normalizeDynamicHookState(
+  rawState: unknown,
+  context = 'DopplerHook state',
+): DynamicHookState {
+  return {
+    lastEpoch: parseBigIntField(rawState, 'lastEpoch', 0, context),
+    tickAccumulator: parseBigIntField(rawState, 'tickAccumulator', 1, context),
+    totalTokensSold: parseBigIntField(rawState, 'totalTokensSold', 2, context),
+    totalProceeds: parseBigIntField(rawState, 'totalProceeds', 3, context),
+    totalTokensSoldLastEpoch: parseBigIntField(
+      rawState,
+      'totalTokensSoldLastEpoch',
+      4,
+      context,
+    ),
+    feesAccrued: readContractResultField(rawState, ['feesAccrued'], 5, context),
+  };
+}
+
+export function normalizeRehypeFeeDistributionInfo(
+  rawInfo: unknown,
+  context = 'Rehype getFeeDistributionInfo',
+): RehypeFeeDistributionInfo {
+  return {
+    assetFeesToAssetBuybackWad: parseBigIntField(
+      rawInfo,
+      'assetFeesToAssetBuybackWad',
+      0,
+      context,
+    ),
+    assetFeesToNumeraireBuybackWad: parseBigIntField(
+      rawInfo,
+      'assetFeesToNumeraireBuybackWad',
+      1,
+      context,
+    ),
+    assetFeesToBeneficiaryWad: parseBigIntField(
+      rawInfo,
+      'assetFeesToBeneficiaryWad',
+      2,
+      context,
+    ),
+    assetFeesToLpWad: parseBigIntField(rawInfo, 'assetFeesToLpWad', 3, context),
+    numeraireFeesToAssetBuybackWad: parseBigIntField(
+      rawInfo,
+      'numeraireFeesToAssetBuybackWad',
+      4,
+      context,
+    ),
+    numeraireFeesToNumeraireBuybackWad: parseBigIntField(
+      rawInfo,
+      'numeraireFeesToNumeraireBuybackWad',
+      5,
+      context,
+    ),
+    numeraireFeesToBeneficiaryWad: parseBigIntField(
+      rawInfo,
+      'numeraireFeesToBeneficiaryWad',
+      6,
+      context,
+    ),
+    numeraireFeesToLpWad: parseBigIntField(
+      rawInfo,
+      'numeraireFeesToLpWad',
+      7,
+      context,
+    ),
+  };
+}
+
+export function normalizeRehypeFeeSchedule(
+  rawSchedule: unknown,
+  context = 'Rehype getFeeSchedule',
+): RehypeFeeSchedule {
+  return {
+    startingTime: parseNumberField(rawSchedule, 'startingTime', 0, context),
+    startFee: parseNumberField(rawSchedule, 'startFee', 1, context),
+    endFee: parseNumberField(rawSchedule, 'endFee', 2, context),
+    lastFee: parseNumberField(rawSchedule, 'lastFee', 3, context),
+    durationSeconds: parseNumberField(
+      rawSchedule,
+      'durationSeconds',
+      4,
+      context,
+    ),
+  };
+}
+
+export function normalizeRehypeHookFees(
+  rawFees: unknown,
+  context = 'Rehype getHookFees',
+): RehypeHookFees {
+  return {
+    fees0: parseBigIntField(rawFees, 'fees0', 0, context),
+    fees1: parseBigIntField(rawFees, 'fees1', 1, context),
+    beneficiaryFees0: parseBigIntField(rawFees, 'beneficiaryFees0', 2, context),
+    beneficiaryFees1: parseBigIntField(rawFees, 'beneficiaryFees1', 3, context),
+    airlockOwnerFees0: parseBigIntField(
+      rawFees,
+      'airlockOwnerFees0',
+      4,
+      context,
+    ),
+    airlockOwnerFees1: parseBigIntField(
+      rawFees,
+      'airlockOwnerFees1',
+      5,
+      context,
+    ),
+    customFee: parseNumberField(rawFees, 'customFee', 6, context),
+  };
+}
+
+export function normalizeRehypePoolInfo(
+  rawInfo: unknown,
+  context = 'Rehype getPoolInfo',
+): RehypePoolInfo {
+  return {
+    asset: parseAddressField(rawInfo, 'asset', 0, context),
+    numeraire: parseAddressField(rawInfo, 'numeraire', 1, context),
+    buybackDst: parseAddressField(rawInfo, 'buybackDst', 2, context),
+  };
+}
+
+export function normalizeRehypePosition(
+  rawPosition: unknown,
+  context = 'Rehype getPosition',
+): RehypePosition {
+  return {
+    tickLower: parseNumberField(rawPosition, 'tickLower', 0, context),
+    tickUpper: parseNumberField(rawPosition, 'tickUpper', 1, context),
+    liquidity: parseBigIntField(rawPosition, 'liquidity', 2, context),
+    salt: parseHexField(rawPosition, 'salt', 3, context),
+  };
+}
+
+function parseAddressField(
+  rawResult: unknown,
+  fieldName: string,
+  tupleIndex: number,
+  context: string,
+): Address {
+  const rawField = readContractResultField(
+    rawResult,
+    [fieldName],
+    tupleIndex,
+    context,
+  );
+  return parseAddress(rawField, context, fieldName);
+}
+
+function parseBigIntField(
+  rawResult: unknown,
+  fieldName: string,
+  tupleIndex: number,
+  context: string,
+): bigint {
+  const rawField = readContractResultField(
+    rawResult,
+    [fieldName],
+    tupleIndex,
+    context,
+  );
+
+  if (typeof rawField === 'bigint') {
+    return rawField;
+  }
+
+  if (typeof rawField === 'number' && Number.isSafeInteger(rawField)) {
+    return BigInt(rawField);
+  }
+
+  if (typeof rawField === 'string' && rawField.trim() !== '') {
+    try {
+      return BigInt(rawField);
+    } catch {
+      throw new Error(`${context}: ${fieldName} must be bigint-compatible`);
+    }
+  }
+
+  throw new Error(`${context}: ${fieldName} must be bigint-compatible`);
+}
+
+function parseNumberField(
+  rawResult: unknown,
+  fieldName: string,
+  tupleIndex: number,
+  context: string,
+): number {
+  const rawField = readContractResultField(
+    rawResult,
+    [fieldName],
+    tupleIndex,
+    context,
+  );
+  const numericField =
+    typeof rawField === 'bigint' || typeof rawField === 'number'
+      ? Number(rawField)
+      : Number.NaN;
+
+  if (!Number.isSafeInteger(numericField)) {
+    throw new Error(`${context}: ${fieldName} must be a safe integer`);
+  }
+
+  return numericField;
+}
+
+function parseHexField(
+  rawResult: unknown,
+  fieldName: string,
+  tupleIndex: number,
+  context: string,
+): Hex {
+  const rawField = readContractResultField(
+    rawResult,
+    [fieldName],
+    tupleIndex,
+    context,
+  );
+
+  if (typeof rawField === 'string' && isHex(rawField)) {
+    return rawField as Hex;
+  }
+
+  throw new Error(`${context}: ${fieldName} must be hex`);
+}
+
+function parseAddress(
+  rawField: unknown,
+  context: string,
+  fieldName: string,
+): Address {
+  if (typeof rawField === 'string' && isAddress(rawField, { strict: false })) {
+    return rawField as Address;
+  }
+
+  throw new Error(`${context}: ${fieldName} must be an address`);
+}
+
+function readContractResultField(
+  rawResult: unknown,
+  fieldNames: readonly string[],
+  tupleIndex: number,
+  context: string,
+): unknown {
+  if (Array.isArray(rawResult)) {
+    if (tupleIndex < rawResult.length && rawResult[tupleIndex] !== undefined) {
+      return rawResult[tupleIndex];
+    }
+    throw new Error(
+      `${context}: missing tuple field ${fieldNames.join('/')} at index ${tupleIndex}`,
+    );
+  }
+
+  if (isRecord(rawResult)) {
+    for (const fieldName of fieldNames) {
+      const rawField = rawResult[fieldName];
+      if (rawField !== undefined) {
+        return rawField;
+      }
+    }
+    throw new Error(`${context}: missing field ${fieldNames.join('/')}`);
+  }
+
+  throw new Error(`${context}: expected tuple or object result`);
+}
+
+function isRecord(rawResult: unknown): rawResult is Record<string, unknown> {
+  return typeof rawResult === 'object' && rawResult !== null;
+}

--- a/src/evm/utils/gasEstimate.ts
+++ b/src/evm/utils/gasEstimate.ts
@@ -9,8 +9,17 @@ export async function resolveGasEstimate(
   request: unknown,
   fallback: () => Promise<bigint>,
 ): Promise<bigint> {
-  if (typeof (request as any)?.gas === 'bigint') {
-    return (request as any).gas as bigint;
+  if (isGasEstimateRequest(request)) {
+    return request.gas;
   }
   return await fallback();
+}
+
+function isGasEstimateRequest(request: unknown): request is { gas: bigint } {
+  return (
+    typeof request === 'object' &&
+    request !== null &&
+    'gas' in request &&
+    typeof request.gas === 'bigint'
+  );
 }

--- a/src/solana/client/config.ts
+++ b/src/solana/client/config.ts
@@ -8,16 +8,7 @@ import type { AmmConfig } from '../core/types.js';
 import { decodeAmmConfig } from '../core/codecs.js';
 import { CPMM_PROGRAM_ID } from '../core/constants.js';
 import { getConfigAddress } from '../core/pda.js';
-
-// Browser-compatible base64 decoding
-function base64ToBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
+import { base64ToBytes } from '../core/accounts.js';
 
 /**
  * Fetch and decode the AmmConfig account

--- a/src/solana/client/oracle.ts
+++ b/src/solana/client/oracle.ts
@@ -9,16 +9,7 @@ import { decodeOracleState } from '../core/codecs.js';
 import { CPMM_PROGRAM_ID } from '../core/constants.js';
 import { getOracleAddress } from '../core/pda.js';
 import { q64ToNumber } from '../core/math.js';
-
-// Browser-compatible base64 decoding
-function base64ToBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
+import { base64ToBytes } from '../core/accounts.js';
 
 /**
  * Configuration for fetching oracles

--- a/src/solana/client/pool.ts
+++ b/src/solana/client/pool.ts
@@ -4,30 +4,17 @@
 
 import type { Address } from '@solana/kit';
 import type { Rpc, GetAccountInfoApi } from '@solana/kit';
-import type { Base64EncodedBytes } from '@solana/kit';
 import type { GetProgramAccountsRpc } from '../core/rpc.js';
 import type { Pool } from '../core/types.js';
 import { decodePool } from '../core/codecs.js';
+import {
+  base64ToBytes,
+  bytesToBase64EncodedBytes,
+  normalizeProgramAccountsResponse,
+  warnAccountDecodeFailure,
+} from '../core/accounts.js';
 import { CPMM_PROGRAM_ID, ACCOUNT_DISCRIMINATORS } from '../core/constants.js';
 import { getPoolAddress, sortMints } from '../core/pda.js';
-
-// Browser-compatible base64 encoding/decoding utilities
-function bytesToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
-
-function base64ToBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
 
 /**
  * Configuration for fetching pools
@@ -46,11 +33,6 @@ export interface PoolWithAddress {
   address: Address;
   account: Pool;
 }
-
-type ProgramAccount = Readonly<{
-  pubkey: Address;
-  account: Readonly<{ data: [string, 'base64'] }>;
-}>;
 
 /**
  * Fetch and decode a single pool account
@@ -115,24 +97,19 @@ export async function fetchAllPools(
   const discriminatorFilter = {
     memcmp: {
       offset: 0n,
-      bytes: bytesToBase64(ACCOUNT_DISCRIMINATORS.Pool) as Base64EncodedBytes,
+      bytes: bytesToBase64EncodedBytes(ACCOUNT_DISCRIMINATORS.Pool),
       encoding: 'base64' as const,
     },
   };
 
-  const response = (await rpc
+  const response = await rpc
     .getProgramAccounts(programId, {
       encoding: 'base64',
       commitment: config?.commitment,
       filters: [discriminatorFilter],
     })
-    .send()) as unknown;
-
-  const accounts = (
-    Array.isArray(response)
-      ? response
-      : (response as { value: ProgramAccount[] }).value
-  ) as ProgramAccount[];
+    .send();
+  const accounts = normalizeProgramAccountsResponse(response);
 
   const pools: PoolWithAddress[] = [];
 
@@ -145,7 +122,7 @@ export async function fetchAllPools(
       });
     } catch {
       // Skip accounts that fail to decode (shouldn't happen with proper filter)
-      console.warn(`Failed to decode pool account: ${account.pubkey}`);
+      warnAccountDecodeFailure('pool', account.pubkey);
     }
   }
 

--- a/src/solana/client/position.ts
+++ b/src/solana/client/position.ts
@@ -5,30 +5,18 @@
 import type { Address } from '@solana/kit';
 import type { Rpc, GetAccountInfoApi } from '@solana/kit';
 import type { GetProgramAccountsRpc } from '../core/rpc.js';
-import type { Base58EncodedBytes, Base64EncodedBytes } from '@solana/kit';
 import type { Position, Pool } from '../core/types.js';
 import { decodePosition } from '../core/codecs.js';
+import {
+  addressToBase58EncodedBytes,
+  base64ToBytes,
+  bytesToBase64EncodedBytes,
+  normalizeProgramAccountsResponse,
+  warnAccountDecodeFailure,
+} from '../core/accounts.js';
 import { CPMM_PROGRAM_ID, ACCOUNT_DISCRIMINATORS } from '../core/constants.js';
 import { getPositionAddress } from '../core/pda.js';
 import { getPendingFees, ratioToNumber } from '../core/math.js';
-
-// Browser-compatible base64 encoding/decoding utilities
-function bytesToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
-
-function base64ToBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
 
 /**
  * Configuration for fetching positions
@@ -47,11 +35,6 @@ export interface PositionWithAddress {
   address: Address;
   account: Position;
 }
-
-type ProgramAccount = Readonly<{
-  pubkey: Address;
-  account: Readonly<{ data: [string, 'base64'] }>;
-}>;
 
 /**
  * Position value in underlying tokens
@@ -140,9 +123,7 @@ export async function fetchUserPositions(
     {
       memcmp: {
         offset: 0n,
-        bytes: bytesToBase64(
-          ACCOUNT_DISCRIMINATORS.Position,
-        ) as Base64EncodedBytes,
+        bytes: bytesToBase64EncodedBytes(ACCOUNT_DISCRIMINATORS.Position),
         encoding: 'base64' as const,
       },
     },
@@ -150,7 +131,7 @@ export async function fetchUserPositions(
     {
       memcmp: {
         offset: 40n,
-        bytes: owner as unknown as Base58EncodedBytes,
+        bytes: addressToBase58EncodedBytes(owner),
         encoding: 'base58' as const,
       },
     },
@@ -161,25 +142,20 @@ export async function fetchUserPositions(
     filters.push({
       memcmp: {
         offset: 8n,
-        bytes: pool as unknown as Base58EncodedBytes,
+        bytes: addressToBase58EncodedBytes(pool),
         encoding: 'base58' as const,
       },
     });
   }
 
-  const response = (await rpc
+  const response = await rpc
     .getProgramAccounts(programId, {
       encoding: 'base64',
       commitment: config?.commitment,
       filters,
     })
-    .send()) as unknown;
-
-  const accounts = (
-    Array.isArray(response)
-      ? response
-      : (response as { value: ProgramAccount[] }).value
-  ) as ProgramAccount[];
+    .send();
+  const accounts = normalizeProgramAccountsResponse(response);
 
   const positions: PositionWithAddress[] = [];
 
@@ -191,7 +167,7 @@ export async function fetchUserPositions(
         account: position,
       });
     } catch {
-      console.warn(`Failed to decode position account: ${account.pubkey}`);
+      warnAccountDecodeFailure('position', account.pubkey);
     }
   }
 
@@ -218,9 +194,7 @@ export async function fetchPoolPositions(
     {
       memcmp: {
         offset: 0n,
-        bytes: bytesToBase64(
-          ACCOUNT_DISCRIMINATORS.Position,
-        ) as Base64EncodedBytes,
+        bytes: bytesToBase64EncodedBytes(ACCOUNT_DISCRIMINATORS.Position),
         encoding: 'base64' as const,
       },
     },
@@ -228,25 +202,20 @@ export async function fetchPoolPositions(
     {
       memcmp: {
         offset: 8n,
-        bytes: pool as unknown as Base58EncodedBytes,
+        bytes: addressToBase58EncodedBytes(pool),
         encoding: 'base58' as const,
       },
     },
   ];
 
-  const response = (await rpc
+  const response = await rpc
     .getProgramAccounts(programId, {
       encoding: 'base64',
       commitment: config?.commitment,
       filters,
     })
-    .send()) as unknown;
-
-  const accounts = (
-    Array.isArray(response)
-      ? response
-      : (response as { value: ProgramAccount[] }).value
-  ) as ProgramAccount[];
+    .send();
+  const accounts = normalizeProgramAccountsResponse(response);
 
   const positions: PositionWithAddress[] = [];
 
@@ -258,7 +227,7 @@ export async function fetchPoolPositions(
         account: position,
       });
     } catch {
-      console.warn(`Failed to decode position account: ${account.pubkey}`);
+      warnAccountDecodeFailure('position', account.pubkey);
     }
   }
 

--- a/src/solana/core/accounts.ts
+++ b/src/solana/core/accounts.ts
@@ -1,0 +1,151 @@
+import type {
+  AccountMeta,
+  AccountSignerMeta,
+  Address,
+  Base58EncodedBytes,
+  Base64EncodedBytes,
+  ReadonlyUint8Array,
+  TransactionSigner,
+} from '@solana/kit';
+import { AccountRole } from '@solana/kit';
+
+export type AddressOrTransactionSigner = Address | TransactionSigner;
+
+export type RemainingAccount =
+  | Address
+  | AccountMeta
+  | AccountSignerMeta
+  | TransactionSigner;
+
+export type AccountMetaRole =
+  | typeof AccountRole.READONLY
+  | typeof AccountRole.WRITABLE
+  | typeof AccountRole.READONLY_SIGNER
+  | typeof AccountRole.WRITABLE_SIGNER;
+
+export type EncodedProgramAccount = Readonly<{
+  pubkey: Address;
+  account: Readonly<{ data: readonly [string, 'base64'] }>;
+}>;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function isTransactionSigner(
+  value: unknown,
+): value is TransactionSigner {
+  return isObject(value) && 'address' in value && 'signTransactions' in value;
+}
+
+export function getAddressFromAddressOrSigner(
+  value: AddressOrTransactionSigner,
+): Address {
+  return isTransactionSigner(value) ? value.address : value;
+}
+
+export function getAddressFromRemainingAccount(
+  account: RemainingAccount,
+): Address {
+  if (typeof account === 'string') {
+    return account;
+  }
+  return account.address;
+}
+
+export function createAccountMeta(
+  value: AddressOrTransactionSigner,
+  role: AccountMetaRole,
+): AccountMeta | AccountSignerMeta {
+  if (isTransactionSigner(value)) {
+    return { address: value.address, role, signer: value };
+  }
+  return { address: value, role };
+}
+
+export function createReadonlyRemainingAccountMeta(
+  account: RemainingAccount,
+): AccountMeta | AccountSignerMeta {
+  if (typeof account === 'string') {
+    return { address: account, role: AccountRole.READONLY };
+  }
+  if (isTransactionSigner(account)) {
+    return {
+      address: account.address,
+      role: AccountRole.READONLY_SIGNER,
+      signer: account,
+    };
+  }
+  return account;
+}
+
+export function bytesToBase64(bytes: ReadonlyUint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export function bytesToBase64EncodedBytes(
+  bytes: ReadonlyUint8Array,
+): Base64EncodedBytes {
+  return bytesToBase64(bytes) as Base64EncodedBytes;
+}
+
+export function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function addressToBase58EncodedBytes(
+  address: Address,
+): Base58EncodedBytes {
+  // Solana addresses are base58 strings; this brands them for RPC memcmp filters.
+  return address as unknown as Base58EncodedBytes;
+}
+
+function isEncodedProgramAccount(
+  account: unknown,
+): account is EncodedProgramAccount {
+  if (!isObject(account) || typeof account.pubkey !== 'string') {
+    return false;
+  }
+  const accountData = account.account;
+  if (!isObject(accountData) || !Array.isArray(accountData.data)) {
+    return false;
+  }
+  const [encodedData, encoding] = accountData.data;
+  return typeof encodedData === 'string' && encoding === 'base64';
+}
+
+export function normalizeProgramAccountsResponse(
+  response: unknown,
+): EncodedProgramAccount[] {
+  const accounts = Array.isArray(response)
+    ? response
+    : isObject(response) && Array.isArray(response.value)
+      ? response.value
+      : null;
+
+  if (!accounts) {
+    throw new Error('Unexpected getProgramAccounts response shape');
+  }
+
+  if (!accounts.every(isEncodedProgramAccount)) {
+    throw new Error('Unexpected getProgramAccounts account shape');
+  }
+
+  return accounts;
+}
+
+export function warnAccountDecodeFailure(
+  accountType: string,
+  accountAddress: Address,
+): void {
+  console.warn(`Failed to decode ${accountType} account: ${accountAddress}`);
+}

--- a/src/solana/core/index.ts
+++ b/src/solana/core/index.ts
@@ -84,6 +84,27 @@ export {
   decodeOracleState,
 } from './codecs.js';
 
+// Account and RPC boundary helpers
+export {
+  addressToBase58EncodedBytes,
+  base64ToBytes,
+  bytesToBase64,
+  bytesToBase64EncodedBytes,
+  createAccountMeta,
+  createReadonlyRemainingAccountMeta,
+  getAddressFromAddressOrSigner,
+  getAddressFromRemainingAccount,
+  isTransactionSigner,
+  normalizeProgramAccountsResponse,
+  warnAccountDecodeFailure,
+} from './accounts.js';
+export type {
+  AccountMetaRole,
+  AddressOrTransactionSigner,
+  EncodedProgramAccount,
+  RemainingAccount,
+} from './accounts.js';
+
 // Codecs - Instruction encoders
 export {
   encodeInstructionData,

--- a/src/solana/initializer/client/launch.ts
+++ b/src/solana/initializer/client/launch.ts
@@ -3,14 +3,18 @@
  */
 
 import { getAddressCodec, type Address } from '@solana/kit';
-import type { ReadonlyUint8Array } from '@solana/kit';
 import type { Rpc, GetAccountInfoApi } from '@solana/kit';
 import type { GetProgramAccountsRpc } from '../../core/rpc.js';
-import type { Base64EncodedBytes } from '@solana/kit';
 import {
   getLaunchDecoder,
   type Launch,
 } from '../../generated/initializer/index.js';
+import {
+  base64ToBytes,
+  bytesToBase64EncodedBytes,
+  normalizeProgramAccountsResponse,
+  warnAccountDecodeFailure,
+} from '../../core/accounts.js';
 import {
   INITIALIZER_PROGRAM_ID,
   INITIALIZER_ACCOUNT_DISCRIMINATORS,
@@ -18,23 +22,6 @@ import {
 import { getLaunchAddress } from '../pda.js';
 
 const addressCodec = getAddressCodec();
-
-function bytesToBase64(bytes: ReadonlyUint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
-
-function base64ToBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
 
 export interface FetchLaunchesConfig {
   programId?: Address;
@@ -45,11 +32,6 @@ export interface LaunchWithAddress {
   address: Address;
   account: Launch;
 }
-
-type ProgramAccount = Readonly<{
-  pubkey: Address;
-  account: Readonly<{ data: [string, 'base64'] }>;
-}>;
 
 export async function fetchLaunch(
   rpc: Rpc<GetAccountInfoApi>,
@@ -79,26 +61,21 @@ export async function fetchAllLaunches(
   const discriminatorFilter = {
     memcmp: {
       offset: 0n,
-      bytes: bytesToBase64(
+      bytes: bytesToBase64EncodedBytes(
         INITIALIZER_ACCOUNT_DISCRIMINATORS.Launch,
-      ) as Base64EncodedBytes,
+      ),
       encoding: 'base64' as const,
     },
   };
 
-  const response = (await rpc
+  const response = await rpc
     .getProgramAccounts(programId, {
       encoding: 'base64',
       commitment: config?.commitment,
       filters: [discriminatorFilter],
     })
-    .send()) as unknown;
-
-  const accounts = (
-    Array.isArray(response)
-      ? response
-      : (response as { value: ProgramAccount[] }).value
-  ) as ProgramAccount[];
+    .send();
+  const accounts = normalizeProgramAccountsResponse(response);
 
   const launches: LaunchWithAddress[] = [];
   const decoder = getLaunchDecoder();
@@ -108,7 +85,7 @@ export async function fetchAllLaunches(
       const launch = decoder.decode(base64ToBytes(account.account.data[0]));
       launches.push({ address: account.pubkey, account: launch });
     } catch {
-      console.warn(`Failed to decode launch account: ${account.pubkey}`);
+      warnAccountDecodeFailure('launch', account.pubkey);
     }
   }
 
@@ -129,9 +106,9 @@ export async function fetchLaunchesByAuthority(
   const discriminatorFilter = {
     memcmp: {
       offset: 0n,
-      bytes: bytesToBase64(
+      bytes: bytesToBase64EncodedBytes(
         INITIALIZER_ACCOUNT_DISCRIMINATORS.Launch,
-      ) as Base64EncodedBytes,
+      ),
       encoding: 'base64' as const,
     },
   };
@@ -139,26 +116,19 @@ export async function fetchLaunchesByAuthority(
   const authorityFilter = {
     memcmp: {
       offset: 8n,
-      bytes: bytesToBase64(
-        addressCodec.encode(authority),
-      ) as Base64EncodedBytes,
+      bytes: bytesToBase64EncodedBytes(addressCodec.encode(authority)),
       encoding: 'base64' as const,
     },
   };
 
-  const response = (await rpc
+  const response = await rpc
     .getProgramAccounts(programId, {
       encoding: 'base64',
       commitment: config?.commitment,
       filters: [discriminatorFilter, authorityFilter],
     })
-    .send()) as unknown;
-
-  const accounts = (
-    Array.isArray(response)
-      ? response
-      : (response as { value: ProgramAccount[] }).value
-  ) as ProgramAccount[];
+    .send();
+  const accounts = normalizeProgramAccountsResponse(response);
 
   const launches: LaunchWithAddress[] = [];
   const decoder = getLaunchDecoder();
@@ -168,7 +138,7 @@ export async function fetchLaunchesByAuthority(
       const launch = decoder.decode(base64ToBytes(account.account.data[0]));
       launches.push({ address: account.pubkey, account: launch });
     } catch {
-      console.warn(`Failed to decode launch account: ${account.pubkey}`);
+      warnAccountDecodeFailure('launch', account.pubkey);
     }
   }
 

--- a/src/solana/initializer/createLaunch.ts
+++ b/src/solana/initializer/createLaunch.ts
@@ -1,11 +1,7 @@
 import {
-  AccountRole,
-  type AccountMeta,
-  type AccountSignerMeta,
   type Address,
   type Instruction,
   type ReadonlyUint8Array,
-  type TransactionSigner,
 } from '@solana/kit';
 import { findAssociatedTokenPda } from '@solana-program/token';
 import {
@@ -54,13 +50,14 @@ import {
   getLaunchFeeStateAddress,
 } from './pda.js';
 import { computeRemainingAccountsHash } from './helpers.js';
+import {
+  createReadonlyRemainingAccountMeta,
+  getAddressFromAddressOrSigner,
+  getAddressFromRemainingAccount,
+  type RemainingAccount,
+} from '../core/accounts.js';
 
 type AddressOrSigner = InitializeLaunchAccounts['baseMint'];
-type RemainingAccount =
-  | Address
-  | AccountMeta
-  | AccountSignerMeta
-  | TransactionSigner;
 
 const DEFAULT_CPMM_MIGRATION_FEE_SPLIT_BPS = 10_000;
 
@@ -253,40 +250,8 @@ export function createLaunchId(): Uint8Array {
   return bytes;
 }
 
-function isTransactionSigner(value: unknown): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function getAccountAddress(account: RemainingAccount): Address {
-  if (typeof account === 'string') {
-    return account;
-  }
-  return account.address;
-}
-
 function getSignerAddress(value: AddressOrSigner): Address {
-  return isTransactionSigner(value) ? value.address : value;
-}
-
-function getRemainingAccountMeta(
-  account: RemainingAccount,
-): AccountMeta | AccountSignerMeta {
-  if (typeof account === 'string') {
-    return { address: account, role: AccountRole.READONLY };
-  }
-  if (isTransactionSigner(account)) {
-    return {
-      address: account.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer: account,
-    };
-  }
-  return account;
+  return getAddressFromAddressOrSigner(value);
 }
 
 function hasMetadata(metadata: LaunchMetadata | null | undefined): boolean {
@@ -315,7 +280,9 @@ function hashRemainingAccounts(
   if (!accounts) {
     return undefined;
   }
-  return computeRemainingAccountsHash(accounts.map(getAccountAddress));
+  return computeRemainingAccountsHash(
+    accounts.map(getAddressFromRemainingAccount),
+  );
 }
 
 function isCustomMigrationConfig(
@@ -704,7 +671,7 @@ export async function createLaunch(
         accounts: [
           ...(instruction.accounts ?? []),
           ...(migration?.initRemainingAccounts ?? []).map(
-            getRemainingAccountMeta,
+            createReadonlyRemainingAccountMeta,
           ),
         ],
       }

--- a/src/solana/initializer/instructions/curveSwapExactIn.ts
+++ b/src/solana/initializer/instructions/curveSwapExactIn.ts
@@ -1,62 +1,22 @@
 import type {
+  AccountMeta,
+  AccountSignerMeta,
   Address,
   Instruction,
-  AccountMeta,
-  TransactionSigner,
-  AccountSignerMeta,
 } from '@solana/kit';
 import { AccountRole } from '@solana/kit';
 import {
   SYSTEM_PROGRAM_ADDRESS,
   TOKEN_PROGRAM_ADDRESS,
 } from '../../core/constants.js';
+import {
+  createAccountMeta,
+  createReadonlyRemainingAccountMeta,
+  type AddressOrTransactionSigner,
+  type RemainingAccount,
+} from '../../core/accounts.js';
 import { INITIALIZER_PROGRAM_ID } from '../constants.js';
 import { getCurveSwapExactInInstructionDataEncoder } from '../../generated/initializer/index.js';
-
-type AddressOrSigner = Address | TransactionSigner;
-type RemainingAccount =
-  | Address
-  | AccountMeta
-  | AccountSignerMeta
-  | TransactionSigner;
-
-function isTransactionSigner(value: unknown): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function createAccountMeta(
-  value: AddressOrSigner,
-  role:
-    | typeof AccountRole.READONLY
-    | typeof AccountRole.WRITABLE
-    | typeof AccountRole.READONLY_SIGNER,
-): AccountMeta | AccountSignerMeta {
-  if (isTransactionSigner(value)) {
-    return { address: value.address, role, signer: value };
-  }
-  return { address: value, role };
-}
-
-function createRemainingAccountMeta(
-  value: RemainingAccount,
-): AccountMeta | AccountSignerMeta {
-  if (typeof value === 'string') {
-    return { address: value, role: AccountRole.READONLY };
-  }
-  if (isTransactionSigner(value)) {
-    return {
-      address: value.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer: value,
-    };
-  }
-  return value;
-}
 
 export interface CurveSwapExactInAccounts {
   launch: Address;
@@ -67,7 +27,7 @@ export interface CurveSwapExactInAccounts {
   userQuoteAccount: Address;
   baseMint: Address;
   quoteMint: Address;
-  user: AddressOrSigner;
+  user: AddressOrTransactionSigner;
   /** Pass the actual hook program address, or omit to use System Program as a no-op placeholder. */
   hookProgram?: Address;
   launchFeeState: Address;
@@ -115,7 +75,7 @@ export function createCurveSwapExactInInstruction(
     { address: launchFeeState, role: AccountRole.WRITABLE },
     { address: baseTokenProgram, role: AccountRole.READONLY },
     { address: quoteTokenProgram, role: AccountRole.READONLY },
-    ...remainingAccounts.map(createRemainingAccountMeta),
+    ...remainingAccounts.map(createReadonlyRemainingAccountMeta),
   ];
 
   const data = new Uint8Array(

--- a/src/solana/initializer/instructions/initializeConfig.ts
+++ b/src/solana/initializer/instructions/initializeConfig.ts
@@ -2,37 +2,19 @@ import type {
   Address,
   Instruction,
   AccountMeta,
-  TransactionSigner,
   AccountSignerMeta,
 } from '@solana/kit';
 import { AccountRole } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../../core/constants.js';
+import {
+  createAccountMeta,
+  type AddressOrTransactionSigner,
+} from '../../core/accounts.js';
 import { INITIALIZER_PROGRAM_ID } from '../constants.js';
 import type { InitializeConfigArgsArgs } from '../../generated/initializer/index.js';
 import { getInitializeConfigInstructionDataEncoder } from '../../generated/initializer/index.js';
 
-type AddressOrSigner = Address | TransactionSigner;
-
-function isTransactionSigner(
-  value: AddressOrSigner,
-): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function createSignerAccountMeta(
-  value: AddressOrSigner,
-  role: typeof AccountRole.WRITABLE_SIGNER,
-): AccountMeta | AccountSignerMeta {
-  if (isTransactionSigner(value)) {
-    return { address: value.address, role, signer: value };
-  }
-  return { address: value, role };
-}
+type AddressOrSigner = AddressOrTransactionSigner;
 
 export interface InitializeConfigAccounts {
   admin: AddressOrSigner;
@@ -54,7 +36,7 @@ export function createInitializeConfigInstruction(
   } = accounts;
 
   const keys: (AccountMeta | AccountSignerMeta)[] = [
-    createSignerAccountMeta(admin, AccountRole.WRITABLE_SIGNER),
+    createAccountMeta(admin, AccountRole.WRITABLE_SIGNER),
     { address: config, role: AccountRole.WRITABLE },
     { address: programData, role: AccountRole.READONLY },
     { address: systemProgram, role: AccountRole.READONLY },

--- a/src/solana/initializer/instructions/initializeLaunch.ts
+++ b/src/solana/initializer/instructions/initializeLaunch.ts
@@ -2,7 +2,6 @@ import type {
   Address,
   Instruction,
   AccountMeta,
-  TransactionSigner,
   AccountSignerMeta,
   ReadonlyUint8Array,
 } from '@solana/kit';
@@ -18,6 +17,12 @@ import {
   TOKEN_PROGRAM_ADDRESS,
   TOKEN_METADATA_PROGRAM_ID,
 } from '../../core/constants.js';
+import {
+  createAccountMeta,
+  getAddressFromAddressOrSigner,
+  isTransactionSigner,
+  type AddressOrTransactionSigner,
+} from '../../core/accounts.js';
 import {
   CURVE_KIND_XYK,
   CURVE_PARAMS_FORMAT_XYK_V0,
@@ -67,33 +72,8 @@ export type InitializeLaunchParams = Omit<
   hookCreateRemainingAccountsHash?: ReadonlyUint8Array;
 };
 
-type AddressOrSigner = Address | TransactionSigner;
+type AddressOrSigner = AddressOrTransactionSigner;
 type ReadonlyRemainingAccount = AddressOrSigner;
-
-function isTransactionSigner(
-  value: AddressOrSigner,
-): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function createAccountMeta(
-  value: AddressOrSigner,
-  role:
-    | typeof AccountRole.READONLY
-    | typeof AccountRole.WRITABLE
-    | typeof AccountRole.READONLY_SIGNER
-    | typeof AccountRole.WRITABLE_SIGNER,
-): AccountMeta | AccountSignerMeta {
-  if (isTransactionSigner(value)) {
-    return { address: value.address, role, signer: value };
-  }
-  return { address: value, role };
-}
 
 /**
  * Derive the Metaplex token metadata PDA for a given mint.
@@ -206,7 +186,7 @@ export async function createInitializeLaunchInstruction(
   const createHooksEnabled =
     (args.hookFlags & (HF_BEFORE_CREATE | HF_AFTER_CREATE)) !== 0;
   const hookCreateRemainingAccountAddresses = hookCreateRemainingAccounts.map(
-    (account) => (isTransactionSigner(account) ? account.address : account),
+    getAddressFromAddressOrSigner,
   );
   const swapFeeBps = args.swapFeeBps ?? args.curveFeeBps;
   if (swapFeeBps === undefined) {
@@ -326,9 +306,7 @@ export async function createInitializeLaunchInstruction(
   if (migratorProgram === PREDICTION_MIGRATOR_PROGRAM_ADDRESS) {
     const oracleState = args.namespace as Address;
     const entryId = args.launchId;
-    const baseMintAddress = isTransactionSigner(baseMint)
-      ? baseMint.address
-      : baseMint;
+    const baseMintAddress = getAddressFromAddressOrSigner(baseMint);
 
     const [market] = await getPredictionMarketAddress(oracleState, quoteMint);
     const [potVault] = await getPredictionPotVaultAddress(market);

--- a/src/solana/initializer/instructions/migrateLaunch.ts
+++ b/src/solana/initializer/instructions/migrateLaunch.ts
@@ -2,7 +2,6 @@ import type {
   Address,
   Instruction,
   AccountMeta,
-  TransactionSigner,
   AccountSignerMeta,
 } from '@solana/kit';
 import { AccountRole } from '@solana/kit';
@@ -11,33 +10,16 @@ import {
   TOKEN_PROGRAM_ADDRESS,
 } from '../../core/constants.js';
 import {
+  createAccountMeta,
+  type AddressOrTransactionSigner,
+} from '../../core/accounts.js';
+import {
   INITIALIZER_INSTRUCTION_DISCRIMINATORS,
   INITIALIZER_PROGRAM_ID,
 } from '../constants.js';
 import { encodeInstructionData } from '../../core/codecs.js';
 
-type AddressOrSigner = Address | TransactionSigner;
-
-function isTransactionSigner(
-  value: AddressOrSigner,
-): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function createSignerAccountMeta(
-  value: AddressOrSigner,
-  role: typeof AccountRole.WRITABLE_SIGNER,
-): AccountMeta | AccountSignerMeta {
-  if (isTransactionSigner(value)) {
-    return { address: value.address, role, signer: value };
-  }
-  return { address: value, role };
-}
+type AddressOrSigner = AddressOrTransactionSigner;
 
 export interface MigrateLaunchAccounts {
   config: Address;
@@ -87,7 +69,7 @@ export function createMigrateLaunchInstruction(
     { address: quoteVault, role: AccountRole.WRITABLE },
     { address: launchFeeState, role: AccountRole.READONLY },
     { address: migratorProgram, role: AccountRole.READONLY },
-    createSignerAccountMeta(payer, AccountRole.WRITABLE_SIGNER),
+    createAccountMeta(payer, AccountRole.WRITABLE_SIGNER),
     { address: baseTokenProgram, role: AccountRole.READONLY },
     { address: quoteTokenProgram, role: AccountRole.READONLY },
     { address: systemProgram, role: AccountRole.READONLY },

--- a/src/solana/initializer/instructions/previewSwapExactIn.ts
+++ b/src/solana/initializer/instructions/previewSwapExactIn.ts
@@ -1,44 +1,11 @@
-import type {
-  AccountMeta,
-  AccountSignerMeta,
-  Address,
-  Instruction,
-  TransactionSigner,
-} from '@solana/kit';
+import type { Address, Instruction } from '@solana/kit';
 import { getStructCodec, getU64Codec, AccountRole } from '@solana/kit';
+import {
+  createReadonlyRemainingAccountMeta,
+  type RemainingAccount,
+} from '../../core/accounts.js';
 import { INITIALIZER_PROGRAM_ID } from '../constants.js';
 import { getPreviewSwapExactInInstructionDataEncoder } from '../../generated/initializer/index.js';
-
-type RemainingAccount =
-  | Address
-  | AccountMeta
-  | AccountSignerMeta
-  | TransactionSigner;
-
-function isTransactionSigner(value: unknown): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function createRemainingAccountMeta(
-  value: RemainingAccount,
-): AccountMeta | AccountSignerMeta {
-  if (typeof value === 'string') {
-    return { address: value, role: AccountRole.READONLY };
-  }
-  if (isTransactionSigner(value)) {
-    return {
-      address: value.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer: value,
-    };
-  }
-  return value;
-}
 
 export interface PreviewSwapExactInResult {
   amountOut: bigint;
@@ -86,7 +53,7 @@ export function createPreviewSwapExactInInstruction(
 
   const accountsWithRemaining = [
     ...accountsList,
-    ...remainingAccounts.map(createRemainingAccountMeta),
+    ...remainingAccounts.map(createReadonlyRemainingAccountMeta),
   ];
 
   const data = new Uint8Array(

--- a/src/solana/initializer/instructions/setHookAllowlist.ts
+++ b/src/solana/initializer/instructions/setHookAllowlist.ts
@@ -2,36 +2,17 @@ import type {
   Address,
   Instruction,
   AccountMeta,
-  TransactionSigner,
   AccountSignerMeta,
 } from '@solana/kit';
 import { AccountRole } from '@solana/kit';
-import {} from '../../core/constants.js';
+import {
+  createAccountMeta,
+  type AddressOrTransactionSigner,
+} from '../../core/accounts.js';
 import { INITIALIZER_PROGRAM_ID } from '../constants.js';
 import { getSetHookAllowlistInstructionDataEncoder } from '../../generated/initializer/index.js';
 
-type AddressOrSigner = Address | TransactionSigner;
-
-function isTransactionSigner(
-  value: AddressOrSigner,
-): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function createSignerAccountMeta(
-  value: AddressOrSigner,
-  role: typeof AccountRole.WRITABLE_SIGNER,
-): AccountMeta | AccountSignerMeta {
-  if (isTransactionSigner(value)) {
-    return { address: value.address, role, signer: value };
-  }
-  return { address: value, role };
-}
+type AddressOrSigner = AddressOrTransactionSigner;
 
 export interface SetHookAllowlistAccounts {
   admin: AddressOrSigner;
@@ -46,7 +27,7 @@ export function createSetHookAllowlistInstruction(
   const { admin, config } = accounts;
 
   const keys: (AccountMeta | AccountSignerMeta)[] = [
-    createSignerAccountMeta(admin, AccountRole.WRITABLE_SIGNER),
+    createAccountMeta(admin, AccountRole.WRITABLE_SIGNER),
     { address: config, role: AccountRole.WRITABLE },
   ];
 

--- a/src/solana/initializer/instructions/setMigratorAllowlist.ts
+++ b/src/solana/initializer/instructions/setMigratorAllowlist.ts
@@ -2,36 +2,17 @@ import type {
   Address,
   Instruction,
   AccountMeta,
-  TransactionSigner,
   AccountSignerMeta,
 } from '@solana/kit';
 import { AccountRole } from '@solana/kit';
-import {} from '../../core/constants.js';
+import {
+  createAccountMeta,
+  type AddressOrTransactionSigner,
+} from '../../core/accounts.js';
 import { INITIALIZER_PROGRAM_ID } from '../constants.js';
 import { getSetMigratorAllowlistInstructionDataEncoder } from '../../generated/initializer/index.js';
 
-type AddressOrSigner = Address | TransactionSigner;
-
-function isTransactionSigner(
-  value: AddressOrSigner,
-): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function createSignerAccountMeta(
-  value: AddressOrSigner,
-  role: typeof AccountRole.WRITABLE_SIGNER,
-): AccountMeta | AccountSignerMeta {
-  if (isTransactionSigner(value)) {
-    return { address: value.address, role, signer: value };
-  }
-  return { address: value, role };
-}
+type AddressOrSigner = AddressOrTransactionSigner;
 
 export interface SetMigratorAllowlistAccounts {
   admin: AddressOrSigner;
@@ -46,7 +27,7 @@ export function createSetMigratorAllowlistInstruction(
   const { admin, config } = accounts;
 
   const keys: (AccountMeta | AccountSignerMeta)[] = [
-    createSignerAccountMeta(admin, AccountRole.WRITABLE_SIGNER),
+    createAccountMeta(admin, AccountRole.WRITABLE_SIGNER),
     { address: config, role: AccountRole.WRITABLE },
   ];
 

--- a/src/solana/instructions/initializePool.ts
+++ b/src/solana/instructions/initializePool.ts
@@ -2,10 +2,13 @@ import type {
   Address,
   Instruction,
   AccountMeta,
-  TransactionSigner,
   AccountSignerMeta,
 } from '@solana/kit';
 import { AccountRole } from '@solana/kit';
+import {
+  createAccountMeta,
+  type AddressOrTransactionSigner,
+} from '../core/accounts.js';
 import {
   CPMM_PROGRAM_ID,
   SYSTEM_PROGRAM_ADDRESS,
@@ -19,39 +22,12 @@ import {
 } from '../core/codecs.js';
 
 /** Type that can be either an Address or a TransactionSigner */
-type AddressOrSigner = Address | TransactionSigner;
+type AddressOrSigner = AddressOrTransactionSigner;
 type InitializePoolParams = Omit<
   InitializePoolArgs,
   'hookProgram' | 'hookFlags'
 > &
   Partial<Pick<InitializePoolArgs, 'hookProgram' | 'hookFlags'>>;
-
-/** Check if value is a TransactionSigner (duck typing) */
-function isTransactionSigner(
-  value: AddressOrSigner,
-): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-/** Create an account meta, embedding signer if provided */
-function createSignerAccountMeta(
-  value: AddressOrSigner,
-  role: typeof AccountRole.READONLY_SIGNER | typeof AccountRole.WRITABLE_SIGNER,
-): AccountMeta | AccountSignerMeta {
-  if (isTransactionSigner(value)) {
-    return {
-      address: value.address,
-      role,
-      signer: value,
-    };
-  }
-  return { address: value, role };
-}
 
 /**
  * Accounts required for initialize_pool instruction
@@ -76,7 +52,7 @@ export interface InitializePoolAccounts {
   /** Token1 mint (read-only, must be lexicographically larger) */
   token1Mint: Address;
   /** Payer for account creation (writable signer - pass TransactionSigner to include signer in instruction) */
-  payer: Address | TransactionSigner;
+  payer: AddressOrSigner;
   /** Token0 program; defaults to tokenProgram or classic SPL Token */
   token0Program?: Address;
   /** Token1 program; defaults to tokenProgram or classic SPL Token */
@@ -88,7 +64,7 @@ export interface InitializePoolAccounts {
   /** Rent sysvar */
   rent: Address;
   /** Migrator authority PDA signer authorizing pool initialization */
-  migrationAuthority: Address | TransactionSigner;
+  migrationAuthority: AddressOrSigner;
 }
 
 /**
@@ -169,12 +145,12 @@ export function createInitializePoolInstruction(
     { address: vault1, role: AccountRole.WRITABLE },
     { address: token0Mint, role: AccountRole.READONLY },
     { address: token1Mint, role: AccountRole.READONLY },
-    createSignerAccountMeta(payer, AccountRole.WRITABLE_SIGNER),
+    createAccountMeta(payer, AccountRole.WRITABLE_SIGNER),
     { address: resolvedToken0Program, role: AccountRole.READONLY },
     { address: resolvedToken1Program, role: AccountRole.READONLY },
     { address: systemProgram, role: AccountRole.READONLY },
     { address: rent, role: AccountRole.READONLY },
-    createSignerAccountMeta(migrationAuthority, AccountRole.READONLY_SIGNER),
+    createAccountMeta(migrationAuthority, AccountRole.READONLY_SIGNER),
   ];
 
   const data = encodeInstructionData(

--- a/src/solana/instructions/swapExactIn.ts
+++ b/src/solana/instructions/swapExactIn.ts
@@ -1,48 +1,13 @@
-import type {
-  AccountMeta,
-  AccountSignerMeta,
-  Address,
-  Instruction,
-  TransactionSigner,
-} from '@solana/kit';
-import { AccountRole, createNoopSigner } from '@solana/kit';
+import type { Address, Instruction, TransactionSigner } from '@solana/kit';
+import { createNoopSigner } from '@solana/kit';
 import { CPMM_PROGRAM_ADDRESS } from '../generated/cpmm/programs/index.js';
 import { getSwapExactInInstruction } from '../generated/cpmm/instructions/index.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../core/constants.js';
 import type { TradeDirection } from '../core/types.js';
-
-type RemainingAccount =
-  | Address
-  | AccountMeta
-  | AccountSignerMeta
-  | TransactionSigner;
-
-function isTransactionSigner(
-  value: RemainingAccount,
-): value is TransactionSigner {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'address' in value &&
-    'signTransactions' in value
-  );
-}
-
-function toRemainingAccountMeta(
-  account: RemainingAccount,
-): AccountMeta | AccountSignerMeta {
-  if (typeof account === 'string') {
-    return { address: account, role: AccountRole.READONLY };
-  }
-  if (isTransactionSigner(account)) {
-    return {
-      address: account.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer: account,
-    };
-  }
-  return account;
-}
+import {
+  createReadonlyRemainingAccountMeta,
+  type RemainingAccount,
+} from '../core/accounts.js';
 
 /**
  * Helper to create swap instruction with simplified parameters
@@ -126,7 +91,7 @@ export function createSwapInstruction(params: {
     ...instruction,
     accounts: [
       ...(instruction.accounts ?? []),
-      ...remainingAccounts.map(toRemainingAccountMeta),
+      ...remainingAccounts.map(createReadonlyRemainingAccountMeta),
     ],
   };
 }

--- a/src/solana/migrators/cpmmMigrator/client.ts
+++ b/src/solana/migrators/cpmmMigrator/client.ts
@@ -1,18 +1,10 @@
 import type { Address } from '@solana/kit';
 import type { Rpc, GetAccountInfoApi } from '@solana/kit';
+import { base64ToBytes } from '../../core/accounts.js';
 import {
   getCpmmMigratorStateDecoder,
   type CpmmMigratorState,
 } from '../../generated/cpmmMigrator/index.js';
-
-function base64ToBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
 
 export async function fetchCpmmMigratorState(
   rpc: Rpc<GetAccountInfoApi>,

--- a/test/evm/integration/sdk-workflows.test.ts
+++ b/test/evm/integration/sdk-workflows.test.ts
@@ -261,7 +261,6 @@ describe('SDK Workflows Integration Tests', () => {
       };
 
       vi.mocked(publicClient.readContract)
-        .mockResolvedValueOnce(mockState) // state
         .mockResolvedValueOnce(-92103) // startingTick
         .mockResolvedValueOnce(-69080) // endingTick
         .mockResolvedValueOnce(100) // gamma
@@ -289,7 +288,8 @@ describe('SDK Workflows Integration Tests', () => {
   describe('Token and Quoter Interactions', () => {
     it('should interact with token entities after auction creation', async () => {
       // 1. Get token entity
-      const { Derc20 } = await import('../../../src/evm/entities/token/derc20/Derc20');
+      const { Derc20 } =
+        await import('../../../src/evm/entities/token/derc20/Derc20');
       const derc20 = new Derc20(publicClient, walletClient, mockTokenAddress);
 
       // 2. Mock token info

--- a/test/evm/unit/entities/DynamicAuction.test.ts
+++ b/test/evm/unit/entities/DynamicAuction.test.ts
@@ -238,17 +238,7 @@ describe('DynamicAuction', () => {
 
   describe('getCurrentPrice', () => {
     it('should return the current tick from state', async () => {
-      const mockState = {
-        lastEpoch: 5n,
-        tickAccumulator: 1000000n,
-        totalTokensSold: 250000000000000000000000n,
-        totalProceeds: 50000000000000000000n,
-        totalTokensSoldLastEpoch: 50000000000000000000000n,
-        feesAccrued: { amount0: 100n, amount1: 200n },
-      };
-
       vi.mocked(publicClient.readContract)
-        .mockResolvedValueOnce(mockState) // state
         .mockResolvedValueOnce(-92103) // startingTick
         .mockResolvedValueOnce(-69080) // endingTick
         .mockResolvedValueOnce(100) // gamma
@@ -263,17 +253,7 @@ describe('DynamicAuction', () => {
     });
 
     it('should handle zero epochs', async () => {
-      const mockState = {
-        lastEpoch: 0n,
-        tickAccumulator: 0n,
-        totalTokensSold: 0n,
-        totalProceeds: 0n,
-        totalTokensSoldLastEpoch: 0n,
-        feesAccrued: { amount0: 0n, amount1: 0n },
-      };
-
       vi.mocked(publicClient.readContract)
-        .mockResolvedValueOnce(mockState) // state
         .mockResolvedValueOnce(-92103) // startingTick
         .mockResolvedValueOnce(-69080) // endingTick
         .mockResolvedValueOnce(100) // gamma

--- a/test/evm/unit/entities/StaticAuction.test.ts
+++ b/test/evm/unit/entities/StaticAuction.test.ts
@@ -105,6 +105,29 @@ describe('StaticAuction', () => {
       expect(poolInfo.tokenAddress).toBe(mockTokenAddress);
       expect(poolInfo.numeraireAddress).toBe(mockAddresses.weth);
     });
+
+    it('should treat an invalid token0 Airlock probe as token1 auction token', async () => {
+      vi.mocked(publicClient.readContract)
+        .mockResolvedValueOnce([
+          79228162514264337593543950336n, // sqrtPriceX96
+          0, // tick
+          0, // observationIndex
+          1, // observationCardinality
+          1, // observationCardinalityNext
+          0, // feeProtocol
+          true, // unlocked
+        ])
+        .mockResolvedValueOnce(1000000000000000000n)
+        .mockResolvedValueOnce(mockAddresses.weth) // token0
+        .mockResolvedValueOnce(mockTokenAddress) // token1
+        .mockResolvedValueOnce(3000)
+        .mockResolvedValueOnce(undefined); // getAssetData for token0 (not the asset)
+
+      const poolInfo = await auction.getPoolInfo();
+
+      expect(poolInfo.tokenAddress).toBe(mockTokenAddress);
+      expect(poolInfo.numeraireAddress).toBe(mockAddresses.weth);
+    });
   });
 
   describe('getTokenAddress', () => {

--- a/test/evm/unit/entities/contractResults.test.ts
+++ b/test/evm/unit/entities/contractResults.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { zeroAddress, type Address, type Hex } from 'viem';
+import {
+  normalizeDynamicHookState,
+  normalizeRehypeFeeDistributionInfo,
+  normalizeRehypeFeeSchedule,
+  normalizeRehypeHookFees,
+  normalizeRehypePoolInfo,
+  normalizeRehypePosition,
+  parseAirlockLiquidityMigrator,
+  parseAirlockPoolOrHook,
+} from '../../../../src/evm/entities/auction/contractResults';
+
+const asset = '0x0000000000000000000000000000000000000001' as Address;
+const numeraire = '0x0000000000000000000000000000000000000002' as Address;
+const buybackDst = '0x0000000000000000000000000000000000000003' as Address;
+const liquidityMigrator =
+  '0x0000000000000000000000000000000000000004' as Address;
+const poolOrHook = '0x0000000000000000000000000000000000000005' as Address;
+const positionSalt = `0x${'11'.repeat(32)}` as Hex;
+
+describe('contract result normalizers', () => {
+  it('parses Airlock asset data from object and tuple shapes', () => {
+    expect(
+      parseAirlockPoolOrHook({
+        poolOrHook,
+        liquidityMigrator,
+      }),
+    ).toBe(poolOrHook);
+    expect(
+      parseAirlockLiquidityMigrator({
+        poolOrHook,
+        liquidityMigrator,
+      }),
+    ).toBe(liquidityMigrator);
+
+    expect(
+      parseAirlockPoolOrHook([
+        numeraire,
+        zeroAddress,
+        zeroAddress,
+        liquidityMigrator,
+        zeroAddress,
+        poolOrHook,
+      ]),
+    ).toBe(poolOrHook);
+    expect(
+      parseAirlockLiquidityMigrator([
+        numeraire,
+        zeroAddress,
+        zeroAddress,
+        liquidityMigrator,
+      ]),
+    ).toBe(liquidityMigrator);
+  });
+
+  it('normalizes dynamic hook state from object and tuple shapes', () => {
+    expect(
+      normalizeDynamicHookState({
+        lastEpoch: 1,
+        tickAccumulator: -2n,
+        totalTokensSold: 3n,
+        totalProceeds: 4n,
+        totalTokensSoldLastEpoch: 5n,
+        feesAccrued: 6n,
+      }),
+    ).toEqual({
+      lastEpoch: 1n,
+      tickAccumulator: -2n,
+      totalTokensSold: 3n,
+      totalProceeds: 4n,
+      totalTokensSoldLastEpoch: 5n,
+      feesAccrued: 6n,
+    });
+
+    expect(normalizeDynamicHookState([1n, -2n, 3n, 4n, 5n, 6n])).toEqual({
+      lastEpoch: 1n,
+      tickAccumulator: -2n,
+      totalTokensSold: 3n,
+      totalProceeds: 4n,
+      totalTokensSoldLastEpoch: 5n,
+      feesAccrued: 6n,
+    });
+  });
+
+  it('normalizes rehype fee distribution from tuple shapes', () => {
+    expect(
+      normalizeRehypeFeeDistributionInfo([1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n]),
+    ).toEqual({
+      assetFeesToAssetBuybackWad: 1n,
+      assetFeesToNumeraireBuybackWad: 2n,
+      assetFeesToBeneficiaryWad: 3n,
+      assetFeesToLpWad: 4n,
+      numeraireFeesToAssetBuybackWad: 5n,
+      numeraireFeesToNumeraireBuybackWad: 6n,
+      numeraireFeesToBeneficiaryWad: 7n,
+      numeraireFeesToLpWad: 8n,
+    });
+  });
+
+  it('normalizes rehype fee schedule and preserves explicit zeros', () => {
+    expect(
+      normalizeRehypeFeeSchedule({
+        startingTime: 0,
+        startFee: 100,
+        endFee: 200,
+        lastFee: 0,
+        durationSeconds: 3600,
+      }),
+    ).toEqual({
+      startingTime: 0,
+      startFee: 100,
+      endFee: 200,
+      lastFee: 0,
+      durationSeconds: 3600,
+    });
+  });
+
+  it('normalizes rehype hook fees from object shapes', () => {
+    expect(
+      normalizeRehypeHookFees({
+        fees0: 1n,
+        fees1: 2n,
+        beneficiaryFees0: 3n,
+        beneficiaryFees1: 4n,
+        airlockOwnerFees0: 5n,
+        airlockOwnerFees1: 6n,
+        customFee: 3000,
+      }),
+    ).toEqual({
+      fees0: 1n,
+      fees1: 2n,
+      beneficiaryFees0: 3n,
+      beneficiaryFees1: 4n,
+      airlockOwnerFees0: 5n,
+      airlockOwnerFees1: 6n,
+      customFee: 3000,
+    });
+  });
+
+  it('normalizes rehype pool info and positions', () => {
+    expect(normalizeRehypePoolInfo([asset, numeraire, buybackDst])).toEqual({
+      asset,
+      numeraire,
+      buybackDst,
+    });
+
+    expect(
+      normalizeRehypePosition({
+        tickLower: -120,
+        tickUpper: 120,
+        liquidity: 123n,
+        salt: positionSalt,
+      }),
+    ).toEqual({
+      tickLower: -120,
+      tickUpper: 120,
+      liquidity: 123n,
+      salt: positionSalt,
+    });
+  });
+
+  it('throws when required result fields are missing', () => {
+    expect(() =>
+      normalizeRehypeFeeSchedule({
+        startingTime: 0,
+        startFee: 100,
+        endFee: 200,
+        lastFee: 0,
+      }),
+    ).toThrow(/durationSeconds/);
+
+    expect(() => normalizeRehypePoolInfo([asset, numeraire])).toThrow(
+      /buybackDst/,
+    );
+  });
+});

--- a/test/evm/unit/entities/contractResults.test.ts
+++ b/test/evm/unit/entities/contractResults.test.ts
@@ -57,29 +57,17 @@ describe('contract result normalizers', () => {
   it('normalizes dynamic hook state from object and tuple shapes', () => {
     expect(
       normalizeDynamicHookState({
-        lastEpoch: 1,
-        tickAccumulator: -2n,
         totalTokensSold: 3n,
         totalProceeds: 4n,
-        totalTokensSoldLastEpoch: 5n,
-        feesAccrued: 6n,
       }),
     ).toEqual({
-      lastEpoch: 1n,
-      tickAccumulator: -2n,
       totalTokensSold: 3n,
       totalProceeds: 4n,
-      totalTokensSoldLastEpoch: 5n,
-      feesAccrued: 6n,
     });
 
     expect(normalizeDynamicHookState([1n, -2n, 3n, 4n, 5n, 6n])).toEqual({
-      lastEpoch: 1n,
-      tickAccumulator: -2n,
       totalTokensSold: 3n,
       totalProceeds: 4n,
-      totalTokensSoldLastEpoch: 5n,
-      feesAccrued: 6n,
     });
   });
 

--- a/test/solana/unit/core/accounts.test.ts
+++ b/test/solana/unit/core/accounts.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AccountRole, address } from '@solana/kit';
+import { generateKeyPairSigner } from '@solana/signers';
+import {
+  addressToBase58EncodedBytes,
+  base64ToBytes,
+  bytesToBase64,
+  bytesToBase64EncodedBytes,
+  createAccountMeta,
+  createReadonlyRemainingAccountMeta,
+  getAddressFromRemainingAccount,
+  normalizeProgramAccountsResponse,
+  warnAccountDecodeFailure,
+  type EncodedProgramAccount,
+} from '@/solana/core/accounts.js';
+
+const TEST_ADDRESS = address('11111111111111111111111111111111');
+
+describe('Solana account boundary helpers', () => {
+  it('round-trips bytes through base64 helpers', () => {
+    const bytes = new Uint8Array([0, 1, 2, 253, 254, 255]);
+
+    const encoded = bytesToBase64(bytes);
+
+    expect([...base64ToBytes(encoded)]).toEqual([...bytes]);
+    expect(bytesToBase64EncodedBytes(bytes)).toBe(encoded);
+  });
+
+  it('brands addresses for base58 RPC memcmp filters', () => {
+    expect(addressToBase58EncodedBytes(TEST_ADDRESS)).toBe(TEST_ADDRESS);
+  });
+
+  it('normalizes raw getProgramAccounts array responses', () => {
+    const account = createEncodedProgramAccount();
+
+    expect(normalizeProgramAccountsResponse([account])).toEqual([account]);
+  });
+
+  it('normalizes wrapped getProgramAccounts value responses', () => {
+    const account = createEncodedProgramAccount();
+
+    expect(normalizeProgramAccountsResponse({ value: [account] })).toEqual([
+      account,
+    ]);
+  });
+
+  it('rejects unexpected getProgramAccounts response shapes', () => {
+    expect(() => normalizeProgramAccountsResponse({ value: {} })).toThrow(
+      'Unexpected getProgramAccounts response shape',
+    );
+  });
+
+  it('rejects unexpected getProgramAccounts account shapes', () => {
+    expect(() =>
+      normalizeProgramAccountsResponse([
+        { pubkey: TEST_ADDRESS, account: { data: ['abc', 'base58'] } },
+      ]),
+    ).toThrow('Unexpected getProgramAccounts account shape');
+  });
+
+  it('creates readonly metas for remaining account addresses', () => {
+    expect(createReadonlyRemainingAccountMeta(TEST_ADDRESS)).toEqual({
+      address: TEST_ADDRESS,
+      role: AccountRole.READONLY,
+    });
+    expect(getAddressFromRemainingAccount(TEST_ADDRESS)).toBe(TEST_ADDRESS);
+  });
+
+  it('creates readonly signer metas for remaining account signers', async () => {
+    const signer = await generateKeyPairSigner();
+
+    const meta = createReadonlyRemainingAccountMeta(signer);
+
+    expect(meta.address).toBe(signer.address);
+    expect(meta.role).toBe(AccountRole.READONLY_SIGNER);
+    expect((meta as { signer?: unknown }).signer).toBe(signer);
+    expect(getAddressFromRemainingAccount(signer)).toBe(signer.address);
+  });
+
+  it('preserves existing account metas', () => {
+    const existingMeta = {
+      address: TEST_ADDRESS,
+      role: AccountRole.WRITABLE,
+    };
+
+    expect(createReadonlyRemainingAccountMeta(existingMeta)).toBe(existingMeta);
+    expect(getAddressFromRemainingAccount(existingMeta)).toBe(TEST_ADDRESS);
+  });
+
+  it('creates signer account metas with caller-provided roles', async () => {
+    const signer = await generateKeyPairSigner();
+
+    const meta = createAccountMeta(signer, AccountRole.WRITABLE_SIGNER);
+
+    expect(meta.address).toBe(signer.address);
+    expect(meta.role).toBe(AccountRole.WRITABLE_SIGNER);
+    expect((meta as { signer?: unknown }).signer).toBe(signer);
+  });
+
+  it('logs decode failures with account type and address', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    warnAccountDecodeFailure('pool', TEST_ADDRESS);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Failed to decode pool account: ${TEST_ADDRESS}`,
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+function createEncodedProgramAccount(): EncodedProgramAccount {
+  return {
+    pubkey: TEST_ADDRESS,
+    account: {
+      data: [bytesToBase64(new Uint8Array([1, 2, 3])), 'base64'],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

This PR tightens the TypeScript SDK boundaries in two places where examples and SDK internals had accumulated repeated parsing and account-shaping code.

### Solana SDK helpers

- Adds shared Solana account helpers for address/signer extraction, account meta creation, remaining-account conversion, base64/base58 conversions, program account response normalization, and account decode warning behavior.
- Refactors Solana clients, initializer instructions, pool instructions, and CPMM migrator code to use those helpers instead of repeating low-level boilerplate at each call site.
- Adds focused unit coverage for the shared account helpers, including signer/address handling, program-account response shapes, encoding roundtrips, and decode failure warnings.

### EVM contract result parsing

- Adds shared EVM contract result normalizers for Airlock asset data, dynamic hook state totals, Rehype fee distribution, fee schedule, hook fees, pool info, and position results.
- Refactors `StaticAuction`, `DynamicAuction`, `RehypeDopplerHook`, and `RehypeDopplerHookMigrator` to consume typed parsed values instead of local `any` casts and silent zero defaults.
- Keeps token-order probing tolerant for `StaticAuction` when token0 is not an Airlock asset, while preserving strict parsing for actual asset lookups.
- Reuses the existing pool key utilities in `DynamicAuction` rather than keeping a private duplicate parser/PoolId implementation.
- Removes a small `any` cast from gas estimate extraction by using a local type guard.

## Impact

The public API behavior is intended to remain unchanged. The main improvement is that SDK internals now validate contract/read response shapes at the boundary, reduce duplicate low-level account/result handling, and fail with contextual errors when required fields are missing in paths that require complete data.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:solana`
- focused EVM entity/helper tests
- `ANVIL_FORK_ENABLED=true pnpm exec vitest run --config vitest.fork.config.ts test/evm/integration/sdk-workflows.test.ts`
- `pnpm test:unit`
- `pnpm build`
- `pnpm format:check`
- `git diff --check`

Note: `pnpm typecheck:test` still fails on the existing test typing baseline unrelated to this PR, including fork/live viem request typing, `publicClient` as `unknown`, and existing opening-auction test shape drift.