### PR TITLE
fix(solana): align generated codecs with account allocations

### DIFF
--- a/scripts/codegen.ts
+++ b/scripts/codegen.ts
@@ -8,7 +8,7 @@
  * Usage:
  *   pnpm generate:codecs
  */
-import { createFromRoot } from 'codama';
+import { createFromRoot, fixedSizeTypeNode, type RootNode } from 'codama';
 import { rootNodeFromAnchor } from '@codama/nodes-from-anchor';
 import { renderVisitor } from '@codama/renderers-js';
 import * as fs from 'fs';
@@ -32,6 +32,52 @@ const PROGRAMS = [
   { idl_name: 'prediction_migrator', out_dir: 'predictionMigrator' },
   { idl_name: 'trusted_oracle', out_dir: 'trustedOracle' },
 ] as const;
+
+type ProgramIdlName = (typeof PROGRAMS)[number]['idl_name'];
+
+// InitConfig retains its original 2,123-byte allocation even though its typed
+// fields now occupy 2,122 bytes. Model that retained byte in the outer account
+// codec so every generated size API agrees with the on-chain allocation.
+const ACCOUNT_ALLOCATION_OVERRIDES: Partial<
+  Record<ProgramIdlName, Readonly<Record<string, number>>>
+> = {
+  cpmm_migrator: { initConfig: 2_123 },
+  initializer: { initConfig: 2_123 },
+  prediction_migrator: { initConfig: 2_123 },
+};
+
+function applyAccountAllocationOverrides(
+  root: RootNode,
+  overrides: Readonly<Record<string, number>> | undefined,
+): RootNode {
+  if (!overrides) return root;
+
+  const missingAccountNames = new Set(Object.keys(overrides));
+  const accounts = root.program.accounts.map((account) => {
+    const allocationSize = overrides[account.name];
+    if (allocationSize === undefined) return account;
+
+    missingAccountNames.delete(account.name);
+    return {
+      ...account,
+      size: allocationSize,
+      data: fixedSizeTypeNode(account.data, allocationSize),
+    };
+  });
+
+  if (missingAccountNames.size > 0) {
+    throw new Error(
+      `Account allocation overrides did not match generated accounts: ${[
+        ...missingAccountNames,
+      ].join(', ')}`,
+    );
+  }
+
+  return {
+    ...root,
+    program: { ...root.program, accounts },
+  };
+}
 
 fs.mkdirSync(IDL_DIR, { recursive: true });
 fs.rmSync(GENERATED_DIR, { recursive: true, force: true });
@@ -90,7 +136,11 @@ for (const program of PROGRAMS) {
       : raw_idl;
   const idl = flattenIdlInstructionArgs(sdk_idl);
 
-  const codama = createFromRoot(rootNodeFromAnchor(idl));
+  const root = applyAccountAllocationOverrides(
+    rootNodeFromAnchor(idl),
+    ACCOUNT_ALLOCATION_OVERRIDES[program.idl_name],
+  );
+  const codama = createFromRoot(root);
   await codama.accept(
     renderVisitor(output_dir, {
       deleteFolderBeforeRendering: true,
@@ -111,8 +161,7 @@ const generated_index = `/**
  */
 
 ${PROGRAMS.map(
-  ({ out_dir }) =>
-    `export * as ${out_dir} from './${out_dir}/index.js';`,
+  ({ out_dir }) => `export * as ${out_dir} from './${out_dir}/index.js';`,
 ).join('\n')}
 `;
 fs.writeFileSync(path.join(GENERATED_DIR, 'index.ts'), generated_index);
@@ -189,31 +238,6 @@ for (const { file, type, fns } of CONFLICTING_EVENTS) {
 fs.writeFileSync(cpmm_types_index_path, cpmm_types_index);
 console.log(
   '  ✓ patched cpmm/types/index.ts (resolved CPMM event/args naming collisions)',
-);
-
-// Anchor's IDL sizing does not include the trailing repr(C) padding byte on the
-// initializer InitConfig zero-copy account. Keep the public size helper aligned
-// with the on-chain account space used by the program.
-const init_config_paths = [
-  path.join(GENERATED_DIR, 'initializer', 'accounts', 'initConfig.ts'),
-  path.join(GENERATED_DIR, 'cpmmMigrator', 'accounts', 'initConfig.ts'),
-  path.join(GENERATED_DIR, 'predictionMigrator', 'accounts', 'initConfig.ts'),
-];
-for (const init_config_path of init_config_paths) {
-  let init_config = fs.readFileSync(init_config_path, 'utf-8');
-  init_config = init_config.replace(
-    /export function getInitConfigSize\(\): number {\n  return \d+;\n}/,
-    'export function getInitConfigSize(): number {\n  return 2123;\n}',
-  );
-  if (!init_config.includes('return 2123;')) {
-    throw new Error(
-      `Failed to patch InitConfig account size in ${init_config_path}`,
-    );
-  }
-  fs.writeFileSync(init_config_path, init_config);
-}
-console.log(
-  '  ✓ patched InitConfig account sizes (preserved on-chain zero-copy size)',
 );
 
 console.log('\nCodegen complete.');

--- a/src/solana/generated/cpmmMigrator/accounts/initConfig.ts
+++ b/src/solana/generated/cpmmMigrator/accounts/initConfig.ts
@@ -80,41 +80,50 @@ export type InitConfigArgs = {
 
 /** Gets the encoder for {@link InitConfigArgs} account data. */
 export function getInitConfigEncoder(): FixedSizeEncoder<InitConfigArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
-      ['admin', getAddressEncoder()],
-      ['migratorAllowlistLen', getU8Encoder()],
-      ['migratorAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
-      ['hookAllowlistLen', getU8Encoder()],
-      ['hookAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
-      ['bump', getU8Encoder()],
-      ['version', getU8Encoder()],
-      ['protocolFeeBps', getU16Encoder()],
-      ['minSwapFeeBps', getU16Encoder()],
-      ['maxSwapFeeBps', getU16Encoder()],
-      ['reserved', fixEncoderSize(getBytesEncoder(), 24)],
-    ]),
-    (value) => ({ ...value, discriminator: INIT_CONFIG_DISCRIMINATOR }),
+  return fixEncoderSize(
+    transformEncoder(
+      getStructEncoder([
+        ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+        ['admin', getAddressEncoder()],
+        ['migratorAllowlistLen', getU8Encoder()],
+        [
+          'migratorAllowlist',
+          getArrayEncoder(getAddressEncoder(), { size: 32 }),
+        ],
+        ['hookAllowlistLen', getU8Encoder()],
+        ['hookAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
+        ['bump', getU8Encoder()],
+        ['version', getU8Encoder()],
+        ['protocolFeeBps', getU16Encoder()],
+        ['minSwapFeeBps', getU16Encoder()],
+        ['maxSwapFeeBps', getU16Encoder()],
+        ['reserved', fixEncoderSize(getBytesEncoder(), 24)],
+      ]),
+      (value) => ({ ...value, discriminator: INIT_CONFIG_DISCRIMINATOR }),
+    ),
+    2123,
   );
 }
 
 /** Gets the decoder for {@link InitConfig} account data. */
 export function getInitConfigDecoder(): FixedSizeDecoder<InitConfig> {
-  return getStructDecoder([
-    ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
-    ['admin', getAddressDecoder()],
-    ['migratorAllowlistLen', getU8Decoder()],
-    ['migratorAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
-    ['hookAllowlistLen', getU8Decoder()],
-    ['hookAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
-    ['bump', getU8Decoder()],
-    ['version', getU8Decoder()],
-    ['protocolFeeBps', getU16Decoder()],
-    ['minSwapFeeBps', getU16Decoder()],
-    ['maxSwapFeeBps', getU16Decoder()],
-    ['reserved', fixDecoderSize(getBytesDecoder(), 24)],
-  ]);
+  return fixDecoderSize(
+    getStructDecoder([
+      ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+      ['admin', getAddressDecoder()],
+      ['migratorAllowlistLen', getU8Decoder()],
+      ['migratorAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
+      ['hookAllowlistLen', getU8Decoder()],
+      ['hookAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
+      ['bump', getU8Decoder()],
+      ['version', getU8Decoder()],
+      ['protocolFeeBps', getU16Decoder()],
+      ['minSwapFeeBps', getU16Decoder()],
+      ['maxSwapFeeBps', getU16Decoder()],
+      ['reserved', fixDecoderSize(getBytesDecoder(), 24)],
+    ]),
+    2123,
+  );
 }
 
 /** Gets the codec for {@link InitConfig} account data. */

--- a/src/solana/generated/initializer/accounts/initConfig.ts
+++ b/src/solana/generated/initializer/accounts/initConfig.ts
@@ -80,41 +80,50 @@ export type InitConfigArgs = {
 
 /** Gets the encoder for {@link InitConfigArgs} account data. */
 export function getInitConfigEncoder(): FixedSizeEncoder<InitConfigArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
-      ['admin', getAddressEncoder()],
-      ['migratorAllowlistLen', getU8Encoder()],
-      ['migratorAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
-      ['hookAllowlistLen', getU8Encoder()],
-      ['hookAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
-      ['bump', getU8Encoder()],
-      ['version', getU8Encoder()],
-      ['protocolFeeBps', getU16Encoder()],
-      ['minSwapFeeBps', getU16Encoder()],
-      ['maxSwapFeeBps', getU16Encoder()],
-      ['reserved', fixEncoderSize(getBytesEncoder(), 24)],
-    ]),
-    (value) => ({ ...value, discriminator: INIT_CONFIG_DISCRIMINATOR }),
+  return fixEncoderSize(
+    transformEncoder(
+      getStructEncoder([
+        ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+        ['admin', getAddressEncoder()],
+        ['migratorAllowlistLen', getU8Encoder()],
+        [
+          'migratorAllowlist',
+          getArrayEncoder(getAddressEncoder(), { size: 32 }),
+        ],
+        ['hookAllowlistLen', getU8Encoder()],
+        ['hookAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
+        ['bump', getU8Encoder()],
+        ['version', getU8Encoder()],
+        ['protocolFeeBps', getU16Encoder()],
+        ['minSwapFeeBps', getU16Encoder()],
+        ['maxSwapFeeBps', getU16Encoder()],
+        ['reserved', fixEncoderSize(getBytesEncoder(), 24)],
+      ]),
+      (value) => ({ ...value, discriminator: INIT_CONFIG_DISCRIMINATOR }),
+    ),
+    2123,
   );
 }
 
 /** Gets the decoder for {@link InitConfig} account data. */
 export function getInitConfigDecoder(): FixedSizeDecoder<InitConfig> {
-  return getStructDecoder([
-    ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
-    ['admin', getAddressDecoder()],
-    ['migratorAllowlistLen', getU8Decoder()],
-    ['migratorAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
-    ['hookAllowlistLen', getU8Decoder()],
-    ['hookAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
-    ['bump', getU8Decoder()],
-    ['version', getU8Decoder()],
-    ['protocolFeeBps', getU16Decoder()],
-    ['minSwapFeeBps', getU16Decoder()],
-    ['maxSwapFeeBps', getU16Decoder()],
-    ['reserved', fixDecoderSize(getBytesDecoder(), 24)],
-  ]);
+  return fixDecoderSize(
+    getStructDecoder([
+      ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+      ['admin', getAddressDecoder()],
+      ['migratorAllowlistLen', getU8Decoder()],
+      ['migratorAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
+      ['hookAllowlistLen', getU8Decoder()],
+      ['hookAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
+      ['bump', getU8Decoder()],
+      ['version', getU8Decoder()],
+      ['protocolFeeBps', getU16Decoder()],
+      ['minSwapFeeBps', getU16Decoder()],
+      ['maxSwapFeeBps', getU16Decoder()],
+      ['reserved', fixDecoderSize(getBytesDecoder(), 24)],
+    ]),
+    2123,
+  );
 }
 
 /** Gets the codec for {@link InitConfig} account data. */

--- a/src/solana/generated/predictionMigrator/accounts/initConfig.ts
+++ b/src/solana/generated/predictionMigrator/accounts/initConfig.ts
@@ -80,41 +80,50 @@ export type InitConfigArgs = {
 
 /** Gets the encoder for {@link InitConfigArgs} account data. */
 export function getInitConfigEncoder(): FixedSizeEncoder<InitConfigArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
-      ['admin', getAddressEncoder()],
-      ['migratorAllowlistLen', getU8Encoder()],
-      ['migratorAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
-      ['hookAllowlistLen', getU8Encoder()],
-      ['hookAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
-      ['bump', getU8Encoder()],
-      ['version', getU8Encoder()],
-      ['protocolFeeBps', getU16Encoder()],
-      ['minSwapFeeBps', getU16Encoder()],
-      ['maxSwapFeeBps', getU16Encoder()],
-      ['reserved', fixEncoderSize(getBytesEncoder(), 24)],
-    ]),
-    (value) => ({ ...value, discriminator: INIT_CONFIG_DISCRIMINATOR }),
+  return fixEncoderSize(
+    transformEncoder(
+      getStructEncoder([
+        ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+        ['admin', getAddressEncoder()],
+        ['migratorAllowlistLen', getU8Encoder()],
+        [
+          'migratorAllowlist',
+          getArrayEncoder(getAddressEncoder(), { size: 32 }),
+        ],
+        ['hookAllowlistLen', getU8Encoder()],
+        ['hookAllowlist', getArrayEncoder(getAddressEncoder(), { size: 32 })],
+        ['bump', getU8Encoder()],
+        ['version', getU8Encoder()],
+        ['protocolFeeBps', getU16Encoder()],
+        ['minSwapFeeBps', getU16Encoder()],
+        ['maxSwapFeeBps', getU16Encoder()],
+        ['reserved', fixEncoderSize(getBytesEncoder(), 24)],
+      ]),
+      (value) => ({ ...value, discriminator: INIT_CONFIG_DISCRIMINATOR }),
+    ),
+    2123,
   );
 }
 
 /** Gets the decoder for {@link InitConfig} account data. */
 export function getInitConfigDecoder(): FixedSizeDecoder<InitConfig> {
-  return getStructDecoder([
-    ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
-    ['admin', getAddressDecoder()],
-    ['migratorAllowlistLen', getU8Decoder()],
-    ['migratorAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
-    ['hookAllowlistLen', getU8Decoder()],
-    ['hookAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
-    ['bump', getU8Decoder()],
-    ['version', getU8Decoder()],
-    ['protocolFeeBps', getU16Decoder()],
-    ['minSwapFeeBps', getU16Decoder()],
-    ['maxSwapFeeBps', getU16Decoder()],
-    ['reserved', fixDecoderSize(getBytesDecoder(), 24)],
-  ]);
+  return fixDecoderSize(
+    getStructDecoder([
+      ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+      ['admin', getAddressDecoder()],
+      ['migratorAllowlistLen', getU8Decoder()],
+      ['migratorAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
+      ['hookAllowlistLen', getU8Decoder()],
+      ['hookAllowlist', getArrayDecoder(getAddressDecoder(), { size: 32 })],
+      ['bump', getU8Decoder()],
+      ['version', getU8Decoder()],
+      ['protocolFeeBps', getU16Decoder()],
+      ['minSwapFeeBps', getU16Decoder()],
+      ['maxSwapFeeBps', getU16Decoder()],
+      ['reserved', fixDecoderSize(getBytesDecoder(), 24)],
+    ]),
+    2123,
+  );
 }
 
 /** Gets the codec for {@link InitConfig} account data. */

--- a/src/solana/initializer/index.ts
+++ b/src/solana/initializer/index.ts
@@ -57,6 +57,7 @@ export {
   getInitConfigDecoder,
   getInitConfigEncoder,
   getInitConfigCodec,
+  getInitConfigSize,
   getLaunchDecoder,
   getLaunchEncoder,
   getLaunchCodec,

--- a/test/solana/unit/initializer/accountCodecSizes.test.ts
+++ b/test/solana/unit/initializer/accountCodecSizes.test.ts
@@ -1,0 +1,127 @@
+import { address } from '@solana/kit';
+import { describe, expect, it } from 'vitest';
+import * as cpmmAccounts from '@/solana/generated/cpmm/accounts/index.js';
+import * as cpmmHookAccounts from '@/solana/generated/cpmmHook/accounts/index.js';
+import * as cpmmMigratorAccounts from '@/solana/generated/cpmmMigrator/accounts/index.js';
+import * as initializerAccounts from '@/solana/generated/initializer/accounts/index.js';
+import * as predictionMigratorAccounts from '@/solana/generated/predictionMigrator/accounts/index.js';
+import * as trustedOracleAccounts from '@/solana/generated/trustedOracle/accounts/index.js';
+import { initializer } from '@/solana/index.js';
+import type { InitConfigArgs } from '@/solana/initializer/index.js';
+
+const GENERATED_ACCOUNT_MODULES = [
+  { name: 'cpmm', exports: cpmmAccounts },
+  { name: 'cpmmHook', exports: cpmmHookAccounts },
+  { name: 'cpmmMigrator', exports: cpmmMigratorAccounts },
+  { name: 'initializer', exports: initializerAccounts },
+  { name: 'predictionMigrator', exports: predictionMigratorAccounts },
+  { name: 'trustedOracle', exports: trustedOracleAccounts },
+] as const;
+
+const DEFAULT_ADDRESS = address('11111111111111111111111111111111');
+
+function callFactory(factory: unknown, exportName: string): unknown {
+  if (typeof factory !== 'function') {
+    throw new Error(`Missing generated factory: ${exportName}`);
+  }
+  return (factory as () => unknown)();
+}
+
+function readNumericProperty(
+  value: unknown,
+  property: 'fixedSize' | 'maxSize',
+  exportName: string,
+): number {
+  if (typeof value !== 'object' || value === null) {
+    throw new Error(
+      `Generated factory returned an invalid value: ${exportName}`,
+    );
+  }
+
+  const propertyValue = (value as Record<string, unknown>)[property];
+  if (typeof propertyValue !== 'number') {
+    throw new Error(`Missing ${property} on generated codec: ${exportName}`);
+  }
+  return propertyValue;
+}
+
+describe('generated Solana account codec sizes', () => {
+  for (const generatedModule of GENERATED_ACCOUNT_MODULES) {
+    const moduleExports = generatedModule.exports as Record<string, unknown>;
+
+    for (const [sizeExportName, sizeFactory] of Object.entries(moduleExports)) {
+      const match = /^get(.+)Size$/.exec(sizeExportName);
+      if (!match) continue;
+
+      const accountName = match[1];
+      const encoderExportName = `get${accountName}Encoder`;
+      const decoderExportName = `get${accountName}Decoder`;
+
+      it(`${generatedModule.name}.${accountName} aligns its fixed codec and account sizes`, () => {
+        const expectedSize = callFactory(sizeFactory, sizeExportName);
+        expect(typeof expectedSize).toBe('number');
+
+        expect(
+          readNumericProperty(
+            callFactory(moduleExports[encoderExportName], encoderExportName),
+            'fixedSize',
+            encoderExportName,
+          ),
+        ).toBe(expectedSize);
+        expect(
+          readNumericProperty(
+            callFactory(moduleExports[decoderExportName], decoderExportName),
+            'fixedSize',
+            decoderExportName,
+          ),
+        ).toBe(expectedSize);
+      });
+    }
+  }
+
+  it('tracks the variable CPMM migrator state allocation as its maximum size', () => {
+    expect(
+      readNumericProperty(
+        cpmmMigratorAccounts.getCpmmMigratorStateEncoder(),
+        'maxSize',
+        'getCpmmMigratorStateEncoder',
+      ),
+    ).toBe(269);
+    expect(
+      readNumericProperty(
+        cpmmMigratorAccounts.getCpmmMigratorStateDecoder(),
+        'maxSize',
+        'getCpmmMigratorStateDecoder',
+      ),
+    ).toBe(269);
+  });
+
+  it('round-trips the full retained InitConfig account allocation', () => {
+    const initConfigArgs: InitConfigArgs = {
+      admin: DEFAULT_ADDRESS,
+      migratorAllowlistLen: 0,
+      migratorAllowlist: Array.from({ length: 32 }, () => DEFAULT_ADDRESS),
+      hookAllowlistLen: 0,
+      hookAllowlist: Array.from({ length: 32 }, () => DEFAULT_ADDRESS),
+      bump: 255,
+      version: 1,
+      protocolFeeBps: 750,
+      minSwapFeeBps: 25,
+      maxSwapFeeBps: 500,
+      reserved: new Uint8Array(24),
+    };
+    const encoder = initializer.getInitConfigEncoder();
+    const decoder = initializer.getInitConfigDecoder();
+    const encoded = encoder.encode(initConfigArgs);
+
+    expect(initializer.getInitConfigSize()).toBe(2_123);
+    expect(initializer.getInitConfigCodec().fixedSize).toBe(2_123);
+    expect(encoded).toHaveLength(2_123);
+    expect(encoded.at(-1)).toBe(0);
+
+    const [decoded, offset] = decoder.read(encoded, 0);
+    expect(offset).toBe(2_123);
+    expect(decoded.protocolFeeBps).toBe(initConfigArgs.protocolFeeBps);
+    expect(() => decoder.decode(encoded.slice(0, -1))).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Generated Solana account codecs should represent the complete allocated account buffer, including compatibility bytes that are intentionally retained outside the current typed fields.

This adds declarative account-allocation overrides to the Codama generation pipeline and applies the mechanism wherever `InitConfig` is generated. Its encoder, decoder, codec, and size helper now agree on the complete account allocation without relying on post-generation text patches.

The initializer API now exposes the size helper directly, and regression coverage checks every generated Solana account module to ensure fixed-size encoders and decoders remain consistent with their reported account sizes. This gives integrations a reliable SDK source for validating raw account buffers and provides an explicit path for future layout-compatibility cases.

## Validation

- `pnpm generate:codecs`
- `pnpm test:solana`
- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`

`pnpm typecheck:test` continues to report unrelated existing EVM test type errors; none reference this change.