### PR TITLE
feat(solana): add mainnet deployment addresses

### DIFF
--- a/src/solana/deployment.ts
+++ b/src/solana/deployment.ts
@@ -1,4 +1,4 @@
-import { type Address } from '@solana/kit';
+import { address, type Address } from '@solana/kit';
 
 import {
   CPMM_PROGRAM_ID,
@@ -29,6 +29,16 @@ export const DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES: SolanaCpmmProgramAddresses
     initializerProgram: INITIALIZER_PROGRAM_ID,
     cpmmMigratorProgram: CPMM_MIGRATOR_PROGRAM_ID,
     cpmmHookProgram: CPMM_HOOK_PROGRAM_ID,
+  };
+
+export const DOPPLER_SOLANA_MAINNET_PROGRAM_ADDRESSES: SolanaCpmmProgramAddresses =
+  {
+    cpmmProgram: address('5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK'),
+    initializerProgram: address('4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1'),
+    cpmmMigratorProgram: address(
+      'H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o',
+    ),
+    cpmmHookProgram: address('BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr'),
   };
 
 export async function deriveSolanaCpmmDeployment(

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -46,6 +46,7 @@ export {
 
 export {
   DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
+  DOPPLER_SOLANA_MAINNET_PROGRAM_ADDRESSES,
   deriveSolanaCpmmDeployment,
   type SolanaCpmmDeployment,
   type SolanaCpmmProgramAddresses,

--- a/test/solana/deployment.test.ts
+++ b/test/solana/deployment.test.ts
@@ -6,6 +6,7 @@ import {
   cpmmHook,
   cpmmMigrator,
   DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
+  DOPPLER_SOLANA_MAINNET_PROGRAM_ADDRESSES,
   deriveSolanaCpmmDeployment,
   initializer,
   type SolanaCpmmProgramAddresses,
@@ -40,6 +41,19 @@ describe('Solana deployment helpers', () => {
     expect(deployment).toMatchObject(CUSTOM_PROGRAMS);
     expect(deployment.cpmmConfig).toBe(expectedCpmmConfig);
     expect(deployment.initializerConfig).toBe(expectedInitializerConfig);
+  });
+
+  it('exports the mainnet CPMM deployment program IDs', () => {
+    expect(DOPPLER_SOLANA_MAINNET_PROGRAM_ADDRESSES).toEqual({
+      cpmmProgram: address('5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK'),
+      initializerProgram: address(
+        '4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1',
+      ),
+      cpmmMigratorProgram: address(
+        'H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o',
+      ),
+      cpmmHookProgram: address('BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr'),
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- export the canonical Solana mainnet CPMM deployment addresses
- expose the mainnet registry from the Solana package entrypoint
- cover the public address mapping with a deployment unit test

## Why

Solana production addresses were only available through custom deployment configuration and were missing from the SDK's public deployment registry. The SDK now exposes the supported mainnet CPMM, initializer, migrator, and consolidated CPMM hook programs alongside the existing devnet registry.

The canonical CPMM hook address follows the consolidated hook model introduced in #168, which combines static fees, cosigning, and dynamic fees behind one program.

## Validation

- verified all four program accounts are executable on Solana mainnet and owned by the upgradeable BPF loader
- `pnpm test:solana` (131 tests)
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`
- `git diff --check`

Generation: not applicable; these addresses are maintained in `src/solana/deployment.ts`.