### PR TITLE
feat: update defaults and do more cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Use network-specific entrypoints:
 
 ```typescript
 import { DopplerSDK } from '@whetstone-research/doppler-sdk/evm';
-import { initializer, cpmm, cpmmMigrator } from '@whetstone-research/doppler-sdk/solana';
+import {
+  initializer,
+  cpmm,
+  cpmmMigrator,
+} from '@whetstone-research/doppler-sdk/solana';
 import { DopplerSolanaProvider } from '@whetstone-research/doppler-sdk/solana/react';
 ```
 
@@ -136,6 +140,7 @@ import { base } from 'viem/chains';
 
 const params = new StaticAuctionBuilder(base.id)
   .tokenConfig({
+    type: 'standard',
     name: 'My Token',
     symbol: 'MTK',
     tokenURI: 'https://example.com/metadata.json',
@@ -179,7 +184,7 @@ console.log('Pool address:', result.poolAddress);
 console.log('Token address:', result.tokenAddress);
 ```
 
-If you set `cliffDuration > 0` or provide `allocations`, the SDK automatically uses the DERC20 V2 factory and exposes schedule-aware token reads via `sdk.getDerc20V2(tokenAddress)`. When `allocations` is provided, the SDK dedupes identical schedules internally and maps each recipient to the correct on-chain schedule.
+Explicit `type: 'standard'` tokens with `cliffDuration > 0` or `allocations` use the legacy DERC20 V2 factory and expose schedule-aware reads via `sdk.getDerc20V2(tokenAddress)`. When `allocations` is provided, the SDK dedupes identical schedules internally and maps each recipient to the correct onchain schedule.
 
 For a runnable example, see [examples/multicurve-per-beneficiary-vesting.ts](./examples/multicurve-per-beneficiary-vesting.ts).
 
@@ -316,6 +321,7 @@ console.log('Token address:', result.tokenAddress);
 ### Opening Auction (Lifecycle + Bid Management)
 
 Support includes:
+
 - `sdk.buildOpeningAuction()` for `CreateOpeningAuctionParams`
 - `sdk.factory.simulateCreateOpeningAuction(params)` and `sdk.factory.createOpeningAuction(params)`
 - `sdk.getOpeningAuction(hookAddress)` for hook reads + `settleAuction()` / `claimIncentives()`
@@ -359,21 +365,21 @@ const params = sdk
   .withMigration({ type: 'uniswapV4', fee: 3000, tickSpacing: 60 })
   .withUserAddress('0x...')
   .withOpeningAuctionInitializer('0x...') // required on Base until deployed
-  .build()
+  .build();
 
-const sim = await sdk.factory.simulateCreateOpeningAuction(params)
-const created = await sim.execute()
+const sim = await sdk.factory.simulateCreateOpeningAuction(params);
+const created = await sim.execute();
 
-const opening = await sdk.getOpeningAuction(created.openingAuctionHookAddress)
-await opening.getPhase()
+const opening = await sdk.getOpeningAuction(created.openingAuctionHookAddress);
+await opening.getPhase();
 
-const lifecycle = await sdk.getOpeningAuctionLifecycle('0x...')
-await lifecycle.getState(created.tokenAddress)
+const lifecycle = await sdk.getOpeningAuctionLifecycle('0x...');
+await lifecycle.getState(created.tokenAddress);
 
 await sdk.factory.completeOpeningAuction({
   asset: created.tokenAddress,
   initializerAddress: '0x...',
-})
+});
 ```
 
 `completeOpeningAuction` auto-settles and auto-mines `dopplerSalt` when omitted; because completion mining can race with block timestamps/state changes, the SDK may re-mine and retry a few times if needed. `simulateCompleteOpeningAuction` requires the opening auction to already be settled.
@@ -384,9 +390,9 @@ See [examples/opening-auction-lifecycle.ts](./examples/opening-auction-lifecycle
 
 ### Multicurve Auction (V4 Multicurve Initializer)
 
-Multicurve auctions use a Uniswap V4-style initializer that seeds liquidity across multiple curves in a single pool. This enables richer distributions and can be combined with any supported migration path (V2, V3, V4, or NoOp). Multicurve initializer modes are modeled as a typed variant (`standard`, `scheduled`, `decay`, `rehype`) so new hook/initializer variations can be added without breaking existing integrations.
+Multicurve auctions use `DopplerHookInitializer` by default to seed liquidity across multiple curves in a single Uniswap V4 pool. The typed initializer modes are `dopplerHookInitializer`, `standard`, `scheduled`, `decay`, and `rehype`; use `withV4MulticurveInitializer(address)` when explicitly targeting the legacy standard initializer.
 
-**Standard Multicurve with Migration:**
+**Multicurve with Migration:**
 
 ```typescript
 import { MulticurveBuilder } from '@whetstone-research/doppler-sdk/evm';
@@ -436,7 +442,10 @@ console.log('Token address:', result.tokenAddress);
 **Market Cap Presets (Low / Medium / High):**
 
 ```typescript
-import { MulticurveBuilder, FEE_TIERS } from '@whetstone-research/doppler-sdk/evm';
+import {
+  MulticurveBuilder,
+  FEE_TIERS,
+} from '@whetstone-research/doppler-sdk/evm';
 import { parseEther } from 'viem';
 import { base } from 'viem/chains';
 
@@ -942,7 +951,7 @@ For a runnable release-focused example covering legacy DERC20, DERC20 V2 schedul
 
 ### DopplerERC20V1 Tokens
 
-Use the newer DopplerERC20V1 token template by either setting `type: 'dopplerERC20V1'` explicitly or by passing fields such as `maxBalanceLimit` with `balanceLimitEnd`, `controller`, or `excludedFromBalanceLimit`. When selected, the SDK uses the configured `dopplerERC20V1Factory` by default. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. `controller` is optional and defaults to the zero address, set it only if early balance-limit disable should be possible. Standard configs without the specific fields still use the legacy `standard` path, where cliff/allocation vesting routes to legacy DERC20 V2. Keep explicit `type: 'dopplerERC20V1'` when you want its behavior but have no specific fields to infer from.
+DopplerERC20V1 is the default token template when `type` is omitted. Set `type: 'dopplerERC20V1'` to make that choice explicit, or set `type: 'standard'` to use the legacy token path, where cliff/allocation vesting routes to the legacy DERC20 template. The SDK uses the configured `dopplerERC20V1Factory` by default; `withTokenFactory(address)` takes precedence but must point to a factory compatible with the selected token path and token data ABI. `controller` is optional and defaults to the zero address, so set it only if early balance-limit disable should be possible.
 
 When balance limiting is enabled on the default DopplerERC20V1 integration, the SDK encodes user exclusions plus determinable protocol recipients for the selected auction path into deployment-time `excludedFromBalanceLimit`, including initializers, hooks, PoolManager, migrators, known migration pools, no-op governance, launchpad governance multisigs, and standard GovernanceFactory timelocks for `default` or `custom` governance. Custom `withTokenFactory(address)` paths receive only the `excludedFromBalanceLimit` entries supplied in `tokenConfig`, so custom token factory users must provide any required deployment-time exclusions themselves. Custom `withGovernanceFactory(address)` paths skip standard-governance timelock auto-exclusion, so custom governance factory users must provide any required timelock exclusions themselves. Exclusions cannot be added later through the controller or governance.
 
@@ -1321,7 +1330,7 @@ const params = sdk
     tickSpacing: 10,
   })
   .withMigration({
-    type: 'dopplerHook',
+    type: 'dopplerHookMigrator',
     fee: 3000,
     tickSpacing: 10,
     lockDuration: 30 * 24 * 60 * 60,
@@ -1349,14 +1358,19 @@ const params = sdk
   .build();
 ```
 
-Note: `dopplerHook` migrator beneficiaries must include the current Airlock owner
+Note: `dopplerHookMigrator` beneficiaries must include the current Airlock owner
 with at least 5% shares, and total shares must sum to `1e18`.
 Unlike initializer-side Rehype pools, migrator-side Rehype uses a static
 `customFee`; there is no fee decay schedule in this mode.
+For backwards compatibility, the deprecated `DopplerHookMigrationConfig` type
+and its `type: 'dopplerHook'` discriminator remain accepted. New code should use
+`DopplerHookMigratorConfig` with `type: 'dopplerHookMigrator'`. Multicurve
+initializer params similarly accept the deprecated `type: 'dopplerHook'`
+discriminator, which resolves to `dopplerHookInitializer`.
 
 ```typescript
 migration: {
-  type: 'dopplerHook',
+  type: 'dopplerHookMigrator',
   fee: 3000,
   useDynamicFee: false,
   tickSpacing: 10,

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -11,8 +11,8 @@ All types referenced are exported from `src/types.ts`.
 ## Common Concepts
 
 - Token specification:
-  - `standard` (default): legacy DERC20 factory path with optional vesting and yearly mint rate
-  - `dopplerERC20V1`: newer DopplerERC20V1 template with schedule vesting and balance-limit settings; selected explicitly with `type: 'dopplerERC20V1'` or automatically when template-specific fields are present
+  - `dopplerERC20V1` (default): DopplerERC20V1 template with schedule vesting and balance-limit settings; selected when `type` is omitted or explicitly set to `'dopplerERC20V1'`
+  - `standard`: legacy DERC20 factory path with optional vesting and yearly mint rate; requires explicit `type: 'standard'`
 - Governance is required:
   - Call `withGovernance(...)` in all cases.
   - Use `withGovernance({ type: 'default' })` for standard governance defaults.
@@ -20,6 +20,9 @@ All types referenced are exported from `src/types.ts`.
   - Use `withGovernance({ type: 'launchpad', multisig })` on launchpad-enabled chains.
   - Or provide `withGovernance({ type: 'custom', initialVotingDelay, initialVotingPeriod, initialProposalThreshold })`.
 - Fee tiers and tick spacing: 100→1, 500→10, 3000→60, 10000→200
+- DopplerHook compatibility:
+  - Migration config should use `DopplerHookMigratorConfig` with `type: 'dopplerHookMigrator'`; the deprecated `DopplerHookMigrationConfig` and `type: 'dopplerHook'` remain accepted.
+  - Multicurve initializer params should use `type: 'dopplerHookInitializer'`; the deprecated initializer discriminator `type: 'dopplerHook'` remains accepted.
 
 Price → Ticks conversion used by builders:
 ```
@@ -36,10 +39,10 @@ Recommended for fixed price range launches with Uniswap V3.
 Methods (chainable):
 
 - tokenConfig(params)
-  - Standard: `{ name, symbol, tokenURI, yearlyMintRate? }`
-    - Defaults: `yearlyMintRate = DEFAULT_V3_YEARLY_MINT_RATE (0.02e18)`
+  - Standard: `{ type: 'standard', name, symbol, tokenURI, yearlyMintRate? }`
+    - Legacy opt-in. Defaults: `yearlyMintRate = DEFAULT_V3_YEARLY_MINT_RATE (0.02e18)`
   - DopplerERC20V1: `{ type?: 'dopplerERC20V1', name, symbol, tokenURI, maxBalanceLimit?, balanceLimitEnd?, controller?, excludedFromBalanceLimit? }`
-    - Uses `dopplerERC20V1Factory` by default when `type: 'dopplerERC20V1'` is explicit or when specific fields (`maxBalanceLimit`, `balanceLimitEnd`, `controller`, `excludedFromBalanceLimit`) are present. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address, so set it only if early balance-limit disable should be possible. Keep explicit `type: 'dopplerERC20V1'` when there are no template-specific fields.
+    - Default when `type` is omitted or explicitly set to `dopplerERC20V1`. Uses `dopplerERC20V1Factory`; `withTokenFactory(address)` takes precedence but must point to a compatible factory. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address.
     - `excludedFromBalanceLimit` is encoded only at deployment. On the default DopplerERC20V1 path, `simulateCreate*` and `create*` add user-supplied exclusions plus determinable protocol recipients for the selected auction path, and standard GovernanceFactory timelocks are auto-excluded when governance is `default` or `custom`. Custom `withTokenFactory(address)` paths receive only the `excludedFromBalanceLimit` entries supplied in `tokenConfig`, while `withGovernanceFactory(address)` skips standard-governance timelock auto-exclusion. If you submit encoded params manually via `encodeCreate*Params`, simulation-derived timelocks are not included; use `simulateCreate*`/`create*` or pass explicit exclusions yourself.
 - saleConfig({ initialSupply, numTokensToSell, numeraire })
 - Price specification methods (use one, not multiple):
@@ -57,7 +60,7 @@ Methods (chainable):
     - @deprecated: Use `withMarketCapRange()` instead for more intuitive configuration
 - withVesting({ duration?, cliffDuration?, recipients?, amounts?, allocations? } | undefined)
   - Omit to disable vesting. Default duration if provided but undefined is `DEFAULT_V3_VESTING_DURATION`.
-  - `cliffDuration > 0` or `allocations` automatically routes standard tokens through the legacy DERC20 V2 factory (`CloneDERC20VotesV2Factory`). With explicit `type: 'dopplerERC20V1'` or template-specific fields, shared schedules using `duration` plus `cliffDuration` and per-beneficiary `allocations` stay on the DopplerERC20V1 factory path.
+  - Explicit `type: 'standard'` tokens with `cliffDuration > 0` or `allocations` route through the legacy DERC20 V2 factory (`CloneDERC20VotesV2Factory`).
   - Cliff vesting requires `duration >= 1 day` and `cliffDuration <= duration`.
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
@@ -85,7 +88,7 @@ Validation highlights:
 - `initialSupply > 0`, `numTokensToSell > 0`, and `numTokensToSell <= initialSupply`
 - If vesting set, there must be tokens reserved (`initialSupply - numTokensToSell > 0`)
 - For V4 migration config (if chosen), beneficiary percentages must sum to 10000
-- Use `sdk.getDerc20V2(tokenAddress)` for schedule-aware reads and release flows on cliffed / multi-schedule tokens
+- Use `sdk.getDerc20V2(tokenAddress)` for schedule-aware reads and release flows on explicit `type: 'standard'` cliffed or multi-schedule tokens
 
 Examples:
 ```ts
@@ -105,7 +108,7 @@ const params = sdk.buildStaticAuction()
 
 // Example 2: Single vesting beneficiary with price range (legacy)
 const paramsLegacy = new StaticAuctionBuilder(chainId)
-  .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
+  .tokenConfig({ type: 'standard', name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000_000'), numTokensToSell: parseEther('900_000_000'), numeraire: weth })
   .poolByPriceRange({ priceRange: { startPrice: 0.0001, endPrice: 0.001 }, fee: 3000 })
   .withVesting({ duration: BigInt(365*24*60*60) }) // All unsold tokens vest to userAddress
@@ -135,7 +138,7 @@ const paramsMultiVest = new StaticAuctionBuilder(chainId)
 
 // Example 4: Per-beneficiary vesting schedules (DERC20 V2)
 const paramsPerSchedule = new StaticAuctionBuilder(chainId)
-  .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
+  .tokenConfig({ type: 'standard', name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/mtk.json' })
   .saleConfig({ initialSupply: parseEther('1_000_000_000'), numTokensToSell: parseEther('900_000_000'), numeraire: weth })
   .withMarketCapRange({
     marketCap: { start: 50_000, end: 5_000_000 },
@@ -175,10 +178,10 @@ Recommended for Dutch auctions where price moves over epochs using Uniswap V4 ho
 Methods (chainable):
 
 - tokenConfig(params)
-  - Standard: `{ name, symbol, tokenURI, yearlyMintRate? }`
-    - Defaults: `yearlyMintRate = DEFAULT_V4_YEARLY_MINT_RATE (0.02e18)`
+  - Standard: `{ type: 'standard', name, symbol, tokenURI, yearlyMintRate? }`
+    - Legacy opt-in. Defaults: `yearlyMintRate = DEFAULT_V4_YEARLY_MINT_RATE (0.02e18)`
   - DopplerERC20V1: `{ type?: 'dopplerERC20V1', name, symbol, tokenURI, maxBalanceLimit?, balanceLimitEnd?, controller?, excludedFromBalanceLimit? }`
-    - Uses `dopplerERC20V1Factory` by default when `type: 'dopplerERC20V1'` is explicit or when specific fields (`maxBalanceLimit`, `balanceLimitEnd`, `controller`, `excludedFromBalanceLimit`) are present. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address, so set it only if early balance-limit disable should be possible. Keep explicit `type: 'dopplerERC20V1'` when there are no template-specific fields.
+    - Default when `type` is omitted or explicitly set to `dopplerERC20V1`. Uses `dopplerERC20V1Factory`; `withTokenFactory(address)` takes precedence but must point to a compatible factory. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address.
     - `excludedFromBalanceLimit` is encoded only at deployment. On the default DopplerERC20V1 path, `simulateCreate*` and `create*` add user-supplied exclusions plus determinable protocol recipients for the selected auction path, and standard GovernanceFactory timelocks are auto-excluded when governance is `default` or `custom`. Custom `withTokenFactory(address)` paths receive only the `excludedFromBalanceLimit` entries supplied in `tokenConfig`, while `withGovernanceFactory(address)` skips standard-governance timelock auto-exclusion. If you submit encoded params manually via `encodeCreate*Params`, simulation-derived timelocks are not included; use `simulateCreate*`/`create*` or pass explicit exclusions yourself.
 - saleConfig({ initialSupply, numTokensToSell, numeraire? })
   - Defaults: `numeraire = ZERO_ADDRESS` (token is paired against ETH)
@@ -201,7 +204,7 @@ Methods (chainable):
     - @deprecated: Use `withMarketCapRange()` instead for more intuitive configuration
 - withVesting({ duration?, cliffDuration?, recipients?, amounts?, allocations? } | undefined)
   - Omit to disable vesting. Default duration if provided but undefined is `0` for dynamic auctions.
-  - Standard tokens with `cliffDuration > 0` or `allocations` route through legacy DERC20 V2. With explicit `type: 'dopplerERC20V1'` or template-specific fields, shared schedules using `duration` plus `cliffDuration` and per-beneficiary `allocations` stay on the DopplerERC20V1 factory path.
+  - Explicit `type: 'standard'` tokens with `cliffDuration > 0` or `allocations` route through legacy DERC20 V2.
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
 - withGovernance(GovernanceOption)
@@ -274,10 +277,10 @@ Recommended when you want to seed a Uniswap V4 pool with multiple curves in a si
 Methods (chainable):
 
 - tokenConfig(params)
-  - Standard: `{ name, symbol, tokenURI, yearlyMintRate? }`
-    - Defaults: `yearlyMintRate = DEFAULT_V4_YEARLY_MINT_RATE (0.02e18)`
+  - Standard: `{ type: 'standard', name, symbol, tokenURI, yearlyMintRate? }`
+    - Legacy opt-in. Defaults: `yearlyMintRate = DEFAULT_V4_YEARLY_MINT_RATE (0.02e18)`
   - DopplerERC20V1: `{ type?: 'dopplerERC20V1', name, symbol, tokenURI, maxBalanceLimit?, balanceLimitEnd?, controller?, excludedFromBalanceLimit? }`
-    - Uses `dopplerERC20V1Factory` by default when `type: 'dopplerERC20V1'` is explicit or when specific fields (`maxBalanceLimit`, `balanceLimitEnd`, `controller`, `excludedFromBalanceLimit`) are present. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address, so set it only if early balance-limit disable should be possible. Keep explicit `type: 'dopplerERC20V1'` when there are no template-specific fields.
+    - Default when `type` is omitted or explicitly set to `dopplerERC20V1`. Uses `dopplerERC20V1Factory`; `withTokenFactory(address)` takes precedence but must point to a compatible factory. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address.
     - `excludedFromBalanceLimit` is encoded only at deployment. On the default DopplerERC20V1 path, `simulateCreate*` and `create*` add user-supplied exclusions plus determinable protocol recipients for the selected auction path, and standard GovernanceFactory timelocks are auto-excluded when governance is `default` or `custom`. Custom `withTokenFactory(address)` paths receive only the `excludedFromBalanceLimit` entries supplied in `tokenConfig`, while `withGovernanceFactory(address)` skips standard-governance timelock auto-exclusion. If you submit encoded params manually via `encodeCreate*Params`, simulation-derived timelocks are not included; use `simulateCreate*`/`create*` or pass explicit exclusions yourself.
 - saleConfig({ initialSupply, numTokensToSell, numeraire })
 - Curve configuration methods (use one, not multiple):
@@ -298,6 +301,8 @@ Methods (chainable):
     - Defaults: `fee = FEE_TIERS.LOW (500)`, `tickSpacing` inferred, and all three presets selected
     - `overrides` (per preset) let you tweak ticks, numPositions, or shares while preserving tier ordering
     - Automatically appends a filler curve when the selected presets sum to < 100%, keeping total shares at exactly 1e18
+- Initializer configuration defaults to `{ type: 'dopplerHookInitializer' }`.
+  - Use `withV4MulticurveInitializer(address)` to select the legacy `{ type: 'standard' }` initializer.
 - withVesting({ duration?, cliffDuration?, recipients?, amounts?, allocations? } | undefined)
   - `recipients`: Optional array of addresses to receive vested tokens. Defaults to `[userAddress]` if not provided.
   - `amounts`: Optional array of token amounts corresponding to each recipient. Must match `recipients` length if provided. Defaults to all unsold tokens to `userAddress` if not provided.
@@ -406,9 +411,9 @@ Use this builder when launch liquidity starts in an OpeningAuction hook and then
 Methods (chainable):
 
 - tokenConfig(params)
-  - Standard: `{ name, symbol, tokenURI, yearlyMintRate? }`
+  - Standard: `{ type: 'standard', name, symbol, tokenURI, yearlyMintRate? }`
   - DopplerERC20V1: `{ type?: 'dopplerERC20V1', name, symbol, tokenURI, maxBalanceLimit?, balanceLimitEnd?, controller?, excludedFromBalanceLimit? }`
-    - Uses `dopplerERC20V1Factory` by default when `type: 'dopplerERC20V1'` is explicit or when specific fields (`maxBalanceLimit`, `balanceLimitEnd`, `controller`, `excludedFromBalanceLimit`) are present. `withTokenFactory(address)` is a generic factory override and takes precedence, but it must point to a factory compatible with the selected token path and token data ABI. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address, so set it only if early balance-limit disable should be possible. Keep explicit `type: 'dopplerERC20V1'` when there are no template-specific fields.
+    - Default when `type` is omitted or explicitly set to `dopplerERC20V1`. Uses `dopplerERC20V1Factory`; `withTokenFactory(address)` takes precedence but must point to a compatible factory. DopplerERC20V1 does not encode `yearlyMintRate`; `controller` defaults to the zero address.
     - `excludedFromBalanceLimit` is encoded only at deployment. On the default DopplerERC20V1 path, `simulateCreate*` and `create*` add user-supplied exclusions plus determinable protocol recipients for the selected auction path, and standard GovernanceFactory timelocks are auto-excluded when governance is `default` or `custom`. Custom `withTokenFactory(address)` paths receive only the `excludedFromBalanceLimit` entries supplied in `tokenConfig`, while `withGovernanceFactory(address)` skips standard-governance timelock auto-exclusion. If you submit encoded params manually via `encodeCreate*Params`, simulation-derived timelocks are not included; use `simulateCreate*`/`create*` or pass explicit exclusions yourself.
   - Doppler404: `{ type: 'doppler404', name, symbol, baseURI, unit? }`
 - saleConfig({ initialSupply, numTokensToSell, numeraire })

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,9 +96,9 @@ Create a multicurve auction whose vesting beneficiaries use different cliff and 
 
 Create a `dopplerERC20V1` token selected automatically from template-specific balance-limit fields, enumerate vesting schedules, release a partial vested amount by schedule or across schedules, and read max-balance-limit state. The default DopplerERC20V1 integration adds protocol balance-limit exclusions; custom `withTokenFactory(address)` paths must provide any required exclusions explicitly. This implementation does not configure or expose yearly mint inflation.
 
-### 12c. [Latest Robinhood Multicurve DopplerERC20V1](./multicurve-latest.ts)
+### 12c. [Latest Multicurve Example](./multicurve-latest.ts)
 
-Create and simulate a Robinhood Chain multicurve launch using `dopplerERC20V1`, max-balance limits, the deployed DopplerHookInitializer path, no-op governance, no-op migration, fee beneficiaries, and multiple vesting distributions for one address. Falls back to Robinhood's public RPC when `RPC_URL` is unset. Optionally broadcasts, previews/claims pool fees, and partially or fully releases vested tokens.
+Create and simulate a Base multicurve launch using the default DopplerERC20V1 and DopplerHookInitializer paths, max-balance limits, Rehype fee routing, no-op governance and migration, fee beneficiaries, and multiple vesting distributions for one address. Falls back to Base's public RPC when `RPC_URL` is unset. Optionally broadcasts, previews or claims pool fees, and partially or fully releases vested tokens.
 
 ### 12d. [Multicurve DopplerERC20V1 Multi-Schedule Vesting + Governance](./multicurve-derc20v1-multi-vesting-governance.ts)
 

--- a/examples/custom-migration-encoder.ts
+++ b/examples/custom-migration-encoder.ts
@@ -45,7 +45,7 @@ const customMigrationEncoder: MigrationEncoder = (config: MigrationConfig) => {
 
     case 'uniswapV2Split':
     case 'uniswapV4Split':
-    case 'dopplerHook':
+    case 'dopplerHookMigrator':
     case 'noOp':
       throw new Error(`This example encoder does not handle ${config.type}`);
 

--- a/examples/custom-migration-encoder.ts
+++ b/examples/custom-migration-encoder.ts
@@ -45,6 +45,7 @@ const customMigrationEncoder: MigrationEncoder = (config: MigrationConfig) => {
 
     case 'uniswapV2Split':
     case 'uniswapV4Split':
+    case 'dopplerHook':
     case 'dopplerHookMigrator':
     case 'noOp':
       throw new Error(`This example encoder does not handle ${config.type}`);

--- a/examples/doppler-erc20-v1.ts
+++ b/examples/doppler-erc20-v1.ts
@@ -79,7 +79,7 @@ const params = StaticAuctionBuilder.forChain(baseSepolia.id)
 const simulation = await sdk.factory.simulateCreateStaticAuction(params);
 console.log('Predicted token:', simulation.asset);
 console.log('Predicted pool:', simulation.pool);
-console.log('Template-specific fields selected dopplerERC20V1 automatically.');
+console.log('Using the default DopplerERC20V1 token template.');
 
 if (process.env.EXECUTE === '1') {
   if (!walletClient) {

--- a/examples/multicurve-latest.ts
+++ b/examples/multicurve-latest.ts
@@ -1,7 +1,5 @@
 /**
- * Example: Multicurve launch with DopplerERC20V1 using intended configuration
- * This example also showcases manually defining the Robinhood chain as it is
- * not yet supported by viem.
+ * Example: Base multicurve launch using the current SDK defaults.
  *
  * Simulates by default. Set EXECUTE=1 to deploy, or ASSET_ADDRESS=0x...
  * to run post-launch reads/claims against an existing token.
@@ -16,7 +14,6 @@
 import './env';
 
 import {
-  CHAIN_IDS,
   DAY_SECONDS,
   DopplerSDK,
   WAD,
@@ -26,7 +23,6 @@ import {
 import {
   createPublicClient,
   createWalletClient,
-  defineChain,
   formatUnits,
   getAddress,
   http,
@@ -36,26 +32,19 @@ import {
   type Address,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
 
 const tokenDecimals = 18;
-const defaultRobinhoodRpcUrl = 'https://rpc.mainnet.chain.robinhood.com';
-
-const robinhoodChain = defineChain({
-  id: CHAIN_IDS.ROBINHOOD,
-  name: 'Robinhood Chain',
-  nativeCurrency: { decimals: tokenDecimals, name: 'Ether', symbol: 'ETH' },
-  rpcUrls: { default: { http: [defaultRobinhoodRpcUrl] } },
-});
 
 async function main(): Promise<void> {
   const privateKey = process.env.PRIVATE_KEY;
   if (!privateKey || !isHex(privateKey)) {
     throw new Error('PRIVATE_KEY must be a 0x-prefixed hex string');
   }
-  const rpcUrl = process.env.RPC_URL || defaultRobinhoodRpcUrl;
+  const rpcUrl = process.env.RPC_URL ?? base.rpcUrls.default.http[0];
 
   const account = privateKeyToAccount(privateKey);
-  const chainId = CHAIN_IDS.ROBINHOOD;
+  const chainId = base.id;
   const addresses = getAddresses(chainId);
   const rehypeDopplerHookInitializer = addresses.rehypeDopplerHookInitializer;
   if (!rehypeDopplerHookInitializer) {
@@ -88,11 +77,11 @@ async function main(): Promise<void> {
   }
 
   const publicClient = createPublicClient({
-    chain: robinhoodChain,
+    chain: base,
     transport: http(rpcUrl),
   });
   const walletClient = createWalletClient({
-    chain: robinhoodChain,
+    chain: base,
     transport: http(rpcUrl),
     account,
   });
@@ -100,8 +89,7 @@ async function main(): Promise<void> {
 
   const poolFeeBeneficiaries = [await sdk.getAirlockBeneficiary(WAD)];
   const rehypeFeeBeneficiaries: [BeneficiaryData, ...BeneficiaryData[]] = [
-    // Airlock owner is not included in rehype fee beneficiaries, unlike pool beneficiaries
-    // Airlock's 5% fee is applied automatically within the rehype hook, before routing to the beneficiaries
+    // Airlock's protocol fee is applied before Rehype routes the remaining fees.
     { beneficiary: account.address, shares: WAD / 5n },
     {
       beneficiary:
@@ -138,7 +126,6 @@ async function main(): Promise<void> {
   const params = sdk
     .buildMulticurveAuction()
     .tokenConfig({
-      type: 'dopplerERC20V1',
       name: 'Multicurve Latest',
       symbol: 'MLT',
       tokenURI: 'ipfs://multicurve-latest.json',
@@ -182,7 +169,7 @@ async function main(): Promise<void> {
       startFee: 12_000,
       endFee: 12_000,
       durationSeconds: 0,
-      // Send all fees to beneficiaries in numeraire
+      // Convert asset fees to numeraire, then route all numeraire fees.
       feeDistributionInfo: {
         assetFeesToAssetBuybackWad: 0n,
         assetFeesToNumeraireBuybackWad: WAD,

--- a/examples/multicurve-per-beneficiary-vesting.ts
+++ b/examples/multicurve-per-beneficiary-vesting.ts
@@ -83,6 +83,7 @@ async function main() {
   const params = sdk
     .buildMulticurveAuction()
     .tokenConfig({
+      type: 'standard',
       name: 'Per Schedule Vesting Token',
       symbol: 'PSVT',
       tokenURI: 'ipfs://per-schedule-vesting.json',

--- a/examples/multicurve-scheduled-eth-sepolia.ts
+++ b/examples/multicurve-scheduled-eth-sepolia.ts
@@ -71,6 +71,7 @@ async function main() {
   const params = sdk
     .buildMulticurveAuction()
     .tokenConfig({
+      type: 'standard',
       name: 'Scheduled ETH Sepolia Token',
       symbol: 'SETS',
       tokenURI: 'ipfs://scheduled-eth-sepolia.json',

--- a/examples/rehype/dynamic-auction-rehype-migrator.ts
+++ b/examples/rehype/dynamic-auction-rehype-migrator.ts
@@ -73,7 +73,7 @@ async function main() {
       maxProceeds: parseEther('0.0002'),
     })
     .withMigration({
-      type: 'dopplerHook',
+      type: 'dopplerHookMigrator',
       fee: 3000,
       useDynamicFee: false,
       tickSpacing: 10,
@@ -107,7 +107,7 @@ async function main() {
     .build();
 
   console.log(
-    'Creating dynamic auction with dopplerHook migration (onchain tx)...',
+    'Creating dynamic auction with dopplerHookMigrator migration (onchain tx)...',
   );
   console.log('Token:', params.token.name, `(${params.token.symbol})`);
   console.log('Selling:', formatEther(params.sale.numTokensToSell), 'tokens');

--- a/src/evm/addresses.ts
+++ b/src/evm/addresses.ts
@@ -162,6 +162,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .UniswapV4Migrator as Address,
     v4MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .UniswapV4MigratorSplit as Address,
+    v4MigratorHook: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
+      .UniswapV4MigratorHook as Address,
     dopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
       .DopplerHookMigrator as Address,
     rehypeDopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MAINNET]
@@ -286,11 +288,12 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     dopplerDeployer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .DopplerDeployer as Address,
     poolManager: '0x498581ff718922c3f8e6a244956af099b2652b2b' as Address,
-    rehypeDopplerHookInitializer:
-      '0xBF4195ab0B03e1eB3345dd1e83BeD7650b1ed123' as Address,
-    rehypeDopplerHook: '0xBF4195ab0B03e1eB3345dd1e83BeD7650b1ed123' as Address,
-    dopplerHookInitializer:
-      '0xBDF938149ac6a781F94FAa0ed45E6A0e984c6544' as Address,
+    rehypeDopplerHookInitializer: getRehypeDopplerHookInitializerAddress(
+      CHAIN_IDS.BASE,
+    ),
+    rehypeDopplerHook: getRehypeDopplerHookInitializerAddress(CHAIN_IDS.BASE),
+    dopplerHookInitializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
+      .DopplerHookInitializer as Address,
     v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .UniswapV2Migrator as Address,
     v2MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
@@ -299,6 +302,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .UniswapV4Migrator as Address,
     v4MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .UniswapV4MigratorSplit as Address,
+    v4MigratorHook: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
+      .UniswapV4MigratorHook as Address,
     dopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
       .DopplerHookMigrator as Address,
     rehypeDopplerHookMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE]
@@ -349,10 +354,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       CHAIN_IDS.BASE_SEPOLIA,
       'DopplerERC20V1',
     ),
-    doppler404Factory: getGeneratedAddress(
-      CHAIN_IDS.BASE_SEPOLIA,
-      'DN404Factory',
-    ),
+    doppler404Factory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
+      .DN404Factory as Address,
     v3Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
       .UniswapV3Initializer as Address,
     v3Quoter: '0xC5290058841028F1614F3A6F0F5816cAd0df5E27' as Address,
@@ -407,8 +410,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .NoOpMigrator as Address,
     governanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
       .GovernanceFactory as Address,
-    noOpGovernanceFactory:
-      '0x916b8987e4ad325c10d58ed8dc2036a6ff5eb228' as Address,
+    noOpGovernanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
+      .NoOpGovernanceFactory as Address,
     launchpadGovernanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[
       CHAIN_IDS.BASE_SEPOLIA
     ].LaunchpadGovernanceFactory as Address,
@@ -424,7 +427,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     univ2Router02: '0x1689E7B1F10000AE47eBfE339a4f69dECd19F602' as Address,
     uniswapV2Factory: '0x7Ae58f10f7849cA6F5fB71b7f45CB416c9204b1e' as Address,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address,
-    bundler: '0x69DB7c20cDdA49Bed2bFb21e16Fa218330C50661' as Address,
+    bundler: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.BASE_SEPOLIA]
+      .Bundler as Address,
     weth: '0x4200000000000000000000000000000000000006' as Address,
     uniswapV3Factory: '0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24' as Address,
     uniswapV4Quoter: '0x4A6513c898fe1B2d0E78d3b0e0A4a151589B1cBa' as Address,
@@ -677,7 +681,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     v4Initializer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
       .UniswapV4Initializer as Address,
     dopplerLens: ZERO_ADDRESS,
-    dopplerDeployer: ZERO_ADDRESS,
+    dopplerDeployer: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
+      .DopplerDeployer as Address,
     poolManager: '0x188d586ddcf52439676ca21a244753fa19f9ea8e' as Address,
     v2Migrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
       .UniswapV2Migrator as Address,
@@ -687,6 +692,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
       .UniswapV4Migrator as Address,
     v4MigratorSplit: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
       .UniswapV4MigratorSplit as Address,
+    v4MigratorHook: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
+      .UniswapV4MigratorHook as Address,
     noOpMigrator: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
       .NoOpMigrator as Address,
     governanceFactory: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
@@ -711,7 +718,8 @@ export const ADDRESSES: Record<SupportedChainId, ChainAddresses> = {
     rehypeDopplerHook: getRehypeDopplerHookInitializerAddress(
       CHAIN_IDS.MONAD_MAINNET,
     ),
-    streamableFeesLocker: ZERO_ADDRESS, // Not yet deployed
+    streamableFeesLocker: GENERATED_DOPPLER_DEPLOYMENTS[CHAIN_IDS.MONAD_MAINNET]
+      .StreamableFeesLocker as Address,
     streamableFeesLockerV2: getGeneratedAddress(
       CHAIN_IDS.MONAD_MAINNET,
       'StreamableFeesLockerV2',

--- a/src/evm/builders/DynamicAuctionBuilder.ts
+++ b/src/evm/builders/DynamicAuctionBuilder.ts
@@ -511,7 +511,7 @@ export class DynamicAuctionBuilder<
     if (this.migration.type === 'noOp') {
       throw new Error(
         'noOp migration is not supported for dynamic auctions. ' +
-          'Use uniswapV2, uniswapV4, or dopplerHook migration instead.',
+          'Use uniswapV2, uniswapV4, or dopplerHookMigrator migration instead.',
       );
     }
 

--- a/src/evm/builders/MulticurveBuilder.ts
+++ b/src/evm/builders/MulticurveBuilder.ts
@@ -496,8 +496,8 @@ export class MulticurveBuilder<
     const currentType = this.initializer?.type;
     if (
       currentType === undefined ||
-      currentType === 'standard' ||
-      currentType === nextType
+      currentType === nextType ||
+      (currentType === 'dopplerHookInitializer' && nextType === 'rehype')
     ) {
       return;
     }
@@ -520,7 +520,7 @@ export class MulticurveBuilder<
   }): this {
     if (!params) {
       if (this.initializer?.type === 'decay') {
-        this.initializer = { type: 'standard' };
+        this.initializer = undefined;
       }
       return this;
     }
@@ -569,7 +569,7 @@ export class MulticurveBuilder<
   withSchedule(params?: { startTime: number | bigint | Date }): this {
     if (!params) {
       if (this.initializer?.type === 'scheduled') {
-        this.initializer = { type: 'standard' };
+        this.initializer = undefined;
       }
       this.schedule = undefined;
       return this;
@@ -628,6 +628,8 @@ export class MulticurveBuilder<
     return this.overrideModule('airlock', address);
   }
   withV4MulticurveInitializer(address: Address): this {
+    this.assertCanSetInitializer('standard');
+    this.initializer = { type: 'standard' };
     return this.overrideModule('v4MulticurveInitializer', address);
   }
   withV4ScheduledMulticurveInitializer(address: Address): this {
@@ -657,6 +659,10 @@ export class MulticurveBuilder<
     return this.overrideModule('noOpMigrator', address);
   }
   withDopplerHookInitializer(address: Address): this {
+    if (this.initializer?.type !== 'rehype') {
+      this.assertCanSetInitializer('dopplerHookInitializer');
+      this.initializer = { type: 'dopplerHookInitializer' };
+    }
     return this.overrideModule('dopplerHookInitializer', address);
   }
 
@@ -844,7 +850,7 @@ export class MulticurveBuilder<
             ? { type: 'rehype', config: dopplerHook }
             : this.schedule
               ? { type: 'scheduled', startTime: this.schedule.startTime }
-              : { type: 'standard' }));
+              : { type: 'dopplerHookInitializer' }));
 
     if (initializer.type === 'scheduled' && dopplerHook) {
       throw new Error(

--- a/src/evm/builders/shared.ts
+++ b/src/evm/builders/shared.ts
@@ -48,10 +48,21 @@ export type BuilderVestingInput =
       allocations: BuilderVestingAllocationInput[];
     };
 
+export function assertTokenConfigSupportsYearlyMintRate(
+  params: TokenConfig,
+): void {
+  if ('yearlyMintRate' in params && params.type !== 'standard') {
+    throw new Error(
+      "yearlyMintRate is only supported with token type 'standard'; DopplerERC20V1 does not support yearly minting.",
+    );
+  }
+}
+
 export function normalizeBuilderTokenConfig(
   params: TokenConfig,
   defaultYearlyMintRate: bigint,
 ): TokenConfig {
+  assertTokenConfigSupportsYearlyMintRate(params);
   if (params.type === 'doppler404') {
     const token = params as Doppler404TokenConfig;
     return {

--- a/src/evm/builders/shared.ts
+++ b/src/evm/builders/shared.ts
@@ -11,7 +11,6 @@ import {
 import { MAX_TICK, MIN_TICK } from '../utils';
 import type {
   Doppler404TokenConfig,
-  DopplerERC20V1TokenConfig,
   PriceRange,
   TickRange,
   MulticurveMarketCapPreset,
@@ -49,43 +48,10 @@ export type BuilderVestingInput =
       allocations: BuilderVestingAllocationInput[];
     };
 
-export function hasDopplerERC20V1OnlyTokenConfigFields(
-  params: object,
-): boolean {
-  return (
-    'maxBalanceLimit' in params ||
-    'balanceLimitEnd' in params ||
-    'controller' in params ||
-    'excludedFromBalanceLimit' in params
-  );
-}
-
-export function isDopplerERC20V1TokenConfig(
-  params: TokenConfig,
-): params is DopplerERC20V1TokenConfig {
-  return (
-    params.type === 'dopplerERC20V1' ||
-    hasDopplerERC20V1OnlyTokenConfigFields(params)
-  );
-}
-
 export function normalizeBuilderTokenConfig(
   params: TokenConfig,
   defaultYearlyMintRate: bigint,
 ): TokenConfig {
-  if (isDopplerERC20V1TokenConfig(params)) {
-    return {
-      type: 'dopplerERC20V1',
-      name: params.name,
-      symbol: params.symbol,
-      tokenURI: params.tokenURI,
-      maxBalanceLimit: params.maxBalanceLimit,
-      balanceLimitEnd: params.balanceLimitEnd,
-      controller: params.controller,
-      excludedFromBalanceLimit: params.excludedFromBalanceLimit,
-    };
-  }
-
   if (params.type === 'doppler404') {
     const token = params as Doppler404TokenConfig;
     return {
@@ -97,13 +63,26 @@ export function normalizeBuilderTokenConfig(
     };
   }
 
-  const token = params as StandardTokenConfig;
+  if (params.type === 'standard') {
+    const token = params as StandardTokenConfig;
+    return {
+      type: 'standard',
+      name: token.name,
+      symbol: token.symbol,
+      tokenURI: token.tokenURI,
+      yearlyMintRate: token.yearlyMintRate ?? defaultYearlyMintRate,
+    };
+  }
+
   return {
-    type: 'standard',
-    name: token.name,
-    symbol: token.symbol,
-    tokenURI: token.tokenURI,
-    yearlyMintRate: token.yearlyMintRate ?? defaultYearlyMintRate,
+    type: 'dopplerERC20V1',
+    name: params.name,
+    symbol: params.symbol,
+    tokenURI: params.tokenURI,
+    maxBalanceLimit: params.maxBalanceLimit,
+    balanceLimitEnd: params.balanceLimitEnd,
+    controller: params.controller,
+    excludedFromBalanceLimit: params.excludedFromBalanceLimit,
   };
 }
 
@@ -155,7 +134,7 @@ export interface BaseAuctionBuilder<C extends SupportedChainId> {
 
   /**
    * Configure post-auction liquidity migration.
-   * @param migration - Migration target (uniswapV2, uniswapV4, dopplerHook, or noOp)
+   * @param migration - Migration target (uniswapV2, uniswapV4, dopplerHookMigrator, or noOp)
    */
   withMigration(migration: MigrationConfig): this;
 

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -43,6 +43,7 @@ import type {
   StreamableFeesConfig,
 } from '../types';
 import type { ModuleAddressOverrides } from '../types';
+import { assertTokenConfigSupportsYearlyMintRate } from '../builders/shared';
 import { getAddresses } from '../addresses';
 import {
   ZERO_ADDRESS,
@@ -3743,6 +3744,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
   private isDopplerERC20V1Token(
     token: TokenConfig,
   ): token is DopplerERC20V1TokenConfig | InferredDopplerERC20V1TokenConfig {
+    assertTokenConfigSupportsYearlyMintRate(token);
     return token.type !== 'standard' && token.type !== 'doppler404';
   }
 

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -18,6 +18,7 @@ import type {
   CreateDynamicAuctionParams,
   CreateOpeningAuctionParams,
   CreateMulticurveParams,
+  DopplerHookMigratorConfig,
   DopplerHookMigrationConfig,
   MigrationConfig,
   SupportedPublicClient,
@@ -41,7 +42,6 @@ import type {
   ProceedsSplitConfig,
   StreamableFeesConfig,
 } from '../types';
-import { hasDopplerERC20V1OnlyTokenConfigFields } from '../builders/shared';
 import type { ModuleAddressOverrides } from '../types';
 import { getAddresses } from '../addresses';
 import {
@@ -102,6 +102,12 @@ export type MigrationEncoder = (config: MigrationConfig) => Hex;
 
 const MAX_UINT128 = (1n << 128n) - 1n;
 const MAX_PROCEEDS_SPLIT_SHARE = WAD / 2n;
+
+function isDopplerHookMigratorConfig(
+  config: MigrationConfig,
+): config is DopplerHookMigratorConfig | DopplerHookMigrationConfig {
+  return config.type === 'dopplerHookMigrator' || config.type === 'dopplerHook';
+}
 const DERC20_V1_MAX_PREMINT_WAD = (WAD * 8n) / 10n;
 const ONE_MILLION = 1_000_000n;
 // Auto-mined completion can race with on-chain state changes; keep retries bounded.
@@ -574,7 +580,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       return [addresses.streamableFeesLocker];
     }
 
-    if (migration.type === 'dopplerHook') {
+    if (isDopplerHookMigratorConfig(migration)) {
       return [
         addresses.streamableFeesLockerV2 ?? addresses.streamableFeesLocker,
       ];
@@ -3737,10 +3743,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
   private isDopplerERC20V1Token(
     token: TokenConfig,
   ): token is DopplerERC20V1TokenConfig | InferredDopplerERC20V1TokenConfig {
-    return (
-      token.type === 'dopplerERC20V1' ||
-      hasDopplerERC20V1OnlyTokenConfigFields(token)
-    );
+    return token.type !== 'standard' && token.type !== 'doppler404';
   }
 
   /**
@@ -3757,6 +3760,16 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     // Use custom encoder if available
     if (this.customMigrationEncoder) {
       return this.customMigrationEncoder(config);
+    }
+
+    if (
+      config.type === 'uniswapV2' &&
+      this.resolveUniswapV2Migrator(options?.overrides).isSplit
+    ) {
+      return encodeAbiParameters(
+        [{ type: 'address' }, { type: 'uint256' }],
+        [ZERO_ADDRESS, 0n],
+      );
     }
 
     switch (config.type) {
@@ -3850,31 +3863,35 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         );
       }
 
-      case 'dopplerHook': {
-        const dopplerHookConfig = config as DopplerHookMigrationConfig;
+      case 'dopplerHook':
+      case 'dopplerHookMigrator': {
+        const dopplerHookMigratorConfig = config;
 
-        if (dopplerHookConfig.hook && dopplerHookConfig.rehype) {
+        if (
+          dopplerHookMigratorConfig.hook &&
+          dopplerHookMigratorConfig.rehype
+        ) {
           throw new Error(
-            'dopplerHook migration cannot set both hook and rehype config. Use exactly one hook mode.',
+            'dopplerHookMigrator migration cannot set both hook and rehype config. Use exactly one hook mode.',
           );
         }
 
         // Copy beneficiaries, sort by address ascending and reject duplicates (required by contract)
         const beneficiaries = sortBeneficiaries(
-          dopplerHookConfig.beneficiaries,
+          dopplerHookMigratorConfig.beneficiaries,
         );
 
         let dopplerHookAddress: Address = ZERO_ADDRESS;
         let onInitializationCalldata: Hex = '0x';
 
-        if (dopplerHookConfig.hook) {
-          dopplerHookAddress = dopplerHookConfig.hook.hookAddress;
+        if (dopplerHookMigratorConfig.hook) {
+          dopplerHookAddress = dopplerHookMigratorConfig.hook.hookAddress;
           onInitializationCalldata =
-            dopplerHookConfig.hook.onInitializationCalldata ?? '0x';
-        } else if (dopplerHookConfig.rehype) {
+            dopplerHookMigratorConfig.hook.onInitializationCalldata ?? '0x';
+        } else if (dopplerHookMigratorConfig.rehype) {
           const addresses = getAddresses(this.chainId);
           const resolvedRehypeHookAddress =
-            dopplerHookConfig.rehype.hookAddress ??
+            dopplerHookMigratorConfig.rehype.hookAddress ??
             options?.overrides?.rehypeDopplerHookMigrator ??
             addresses.rehypeDopplerHookMigrator;
 
@@ -3886,20 +3903,21 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
 
           if (!options?.numeraire) {
             throw new Error(
-              'numeraire is required to encode rehype dopplerHook migration data',
+              'numeraire is required to encode rehype dopplerHookMigrator migration data',
             );
           }
 
           dopplerHookAddress = resolvedRehypeHookAddress;
           onInitializationCalldata = encodeRehypeDopplerHookMigratorCalldata({
             numeraire: options.numeraire,
-            config: dopplerHookConfig.rehype,
+            config: dopplerHookMigratorConfig.rehype,
           });
         }
 
         const proceedsRecipient =
-          dopplerHookConfig.proceedsSplit?.recipient ?? ZERO_ADDRESS;
-        const proceedsShare = dopplerHookConfig.proceedsSplit?.share ?? 0n;
+          dopplerHookMigratorConfig.proceedsSplit?.recipient ?? ZERO_ADDRESS;
+        const proceedsShare =
+          dopplerHookMigratorConfig.proceedsSplit?.share ?? 0n;
 
         return encodeAbiParameters(
           [
@@ -3920,10 +3938,10 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
             { type: 'uint256' },
           ],
           [
-            dopplerHookConfig.fee,
-            dopplerHookConfig.useDynamicFee ?? false,
-            dopplerHookConfig.tickSpacing,
-            dopplerHookConfig.lockDuration,
+            dopplerHookMigratorConfig.fee,
+            dopplerHookMigratorConfig.useDynamicFee ?? false,
+            dopplerHookMigratorConfig.tickSpacing,
+            dopplerHookMigratorConfig.lockDuration,
             beneficiaries,
             dopplerHookAddress,
             onInitializationCalldata,
@@ -4057,10 +4075,20 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
           hookConfig: legacyHook,
         };
       } else {
-        mode = { type: 'standard' };
+        mode = { type: 'rehype' };
       }
     } else {
       switch (initializer.type) {
+        case 'dopplerHook':
+        case 'dopplerHookInitializer': {
+          if (hasLegacySchedule || hasLegacyHook) {
+            throw new Error(
+              "Initializer type 'dopplerHookInitializer' cannot be combined with legacy schedule or RehypeDopplerHookInitializer configuration",
+            );
+          }
+          mode = { type: 'rehype' };
+          break;
+        }
         case 'standard': {
           if (hasLegacySchedule || hasLegacyHook) {
             throw new Error(
@@ -4166,7 +4194,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         mode = { type: 'rehype' };
       } else if (mode.type !== 'rehype') {
         throw new Error(
-          'modules.dopplerHookInitializer can only be used with the rehype or standard multicurve initializer mode',
+          'modules.dopplerHookInitializer can only be used with the dopplerHookInitializer, rehype, or standard multicurve initializer mode',
         );
       }
     }
@@ -5056,9 +5084,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     this.validateVestingConfig(params.sale, params.vesting);
 
     // Validate migration config
-    if (params.migration.type === 'dopplerHook') {
+    if (isDopplerHookMigratorConfig(params.migration)) {
       throw new Error(
-        'dopplerHook migration is only supported for dynamic auctions',
+        'dopplerHookMigrator migration is only supported for dynamic auctions',
       );
     }
 
@@ -5209,7 +5237,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       );
     }
 
-    if (params.migration.type === 'dopplerHook') {
+    if (isDopplerHookMigratorConfig(params.migration)) {
       const migration = params.migration;
 
       if (!Number.isInteger(migration.fee) || migration.fee < 0) {
@@ -5232,7 +5260,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
 
       if (migration.beneficiaries.length === 0) {
         throw new Error(
-          'At least one beneficiary is required for dopplerHook migration',
+          'At least one beneficiary is required for dopplerHookMigrator migration',
         );
       }
 
@@ -5260,7 +5288,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
 
       if (migration.hook && migration.rehype) {
         throw new Error(
-          'dopplerHook migration cannot set both hook and rehype config. Use exactly one hook mode.',
+          'dopplerHookMigrator migration cannot set both hook and rehype config. Use exactly one hook mode.',
         );
       }
 
@@ -5402,9 +5430,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       throw new Error('doppler.gamma must be divisible by doppler.tickSpacing');
     }
 
-    if (params.migration.type === 'dopplerHook') {
+    if (isDopplerHookMigratorConfig(params.migration)) {
       throw new Error(
-        'dopplerHook migration type is not supported for opening auctions',
+        'dopplerHookMigrator migration type is not supported for opening auctions',
       );
     }
 
@@ -5480,9 +5508,9 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     }
 
     // Validate migration config for V4
-    if (params.migration.type === 'dopplerHook') {
+    if (isDopplerHookMigratorConfig(params.migration)) {
       throw new Error(
-        'dopplerHook migration is only supported for dynamic auctions',
+        'dopplerHookMigrator migration is only supported for dynamic auctions',
       );
     }
 
@@ -5530,6 +5558,27 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
    * Get the appropriate migrator address based on migration config
    * Allows override via ModuleAddressOverrides when provided in params.
    */
+  private resolveUniswapV2Migrator(overrides?: ModuleAddressOverrides): {
+    address: Address;
+    isSplit: boolean;
+  } {
+    const addresses = getAddresses(this.chainId);
+    const v2Address = overrides?.v2Migrator ?? addresses.v2Migrator;
+    if (v2Address && v2Address !== ZERO_ADDRESS) {
+      return { address: v2Address, isSplit: false };
+    }
+
+    const v2SplitAddress =
+      overrides?.v2MigratorSplit ?? addresses.v2MigratorSplit;
+    if (v2SplitAddress && v2SplitAddress !== ZERO_ADDRESS) {
+      return { address: v2SplitAddress, isSplit: true };
+    }
+
+    throw new Error(
+      'Neither UniswapV2Migrator nor UniswapV2MigratorSplit is deployed on this chain. Provide an override via modules.v2Migrator or modules.v2MigratorSplit.',
+    );
+  }
+
   private getMigratorAddress(
     config: MigrationConfig,
     overrides?: ModuleAddressOverrides,
@@ -5537,15 +5586,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     const addresses = getAddresses(this.chainId);
 
     switch (config.type) {
-      case 'uniswapV2': {
-        const v2Address = overrides?.v2Migrator ?? addresses.v2Migrator;
-        if (!v2Address || v2Address === ZERO_ADDRESS) {
-          throw new Error(
-            'UniswapV2Migrator not deployed on this chain. Use uniswapV2Split migration or provide override via modules.v2Migrator.',
-          );
-        }
-        return v2Address;
-      }
+      case 'uniswapV2':
+        return this.resolveUniswapV2Migrator(overrides).address;
       case 'uniswapV2Split': {
         const v2SplitAddress =
           overrides?.v2MigratorSplit ?? addresses.v2MigratorSplit;
@@ -5575,7 +5617,8 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         }
         return v4SplitAddress;
       }
-      case 'dopplerHook': {
+      case 'dopplerHook':
+      case 'dopplerHookMigrator': {
         const dopplerHookMigratorAddress =
           overrides?.dopplerHookMigrator ?? addresses.dopplerHookMigrator;
         if (

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -126,6 +126,7 @@ export type {
   UniswapV2SplitMigrationConfig,
   UniswapV4MigrationConfig,
   UniswapV4SplitMigrationConfig,
+  DopplerHookMigratorConfig,
   DopplerHookMigrationConfig,
   BeneficiaryData,
 

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -24,7 +24,7 @@ export type SupportedPublicClient = unknown;
 // Core configuration types
 // Token configuration
 export interface StandardTokenConfig {
-  type?: 'standard'; // default behavior (backwards compatible)
+  type: 'standard';
   name: string;
   symbol: string;
   tokenURI: string;
@@ -37,10 +37,6 @@ export type DopplerERC20V1OnlyTokenConfigFields = {
   controller?: Address;
   excludedFromBalanceLimit?: Address[];
 };
-
-type RequireAtLeastOne<T> = {
-  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Omit<T, K>>;
-}[keyof T];
 
 export interface Doppler404TokenConfig {
   type: 'doppler404';
@@ -63,7 +59,7 @@ export type InferredDopplerERC20V1TokenConfig = {
   name: string;
   symbol: string;
   tokenURI: string;
-} & RequireAtLeastOne<DopplerERC20V1OnlyTokenConfigFields>;
+} & DopplerERC20V1OnlyTokenConfigFields;
 
 export type TokenConfig =
   | StandardTokenConfig
@@ -310,8 +306,8 @@ export interface RehypeDopplerHookMigratorConfig {
   lpPercentWad?: bigint;
 }
 
-export interface DopplerHookMigrationConfig {
-  type: 'dopplerHook';
+export interface DopplerHookMigratorConfig {
+  type: 'dopplerHookMigrator';
   // Fee for fixed-fee pools, or initial LP fee when useDynamicFee=true.
   fee: number;
   // Use dynamic LP fees on the migrated V4 pool.
@@ -335,6 +331,17 @@ export interface DopplerHookMigrationConfig {
     share: bigint;
   };
 }
+
+/**
+ * @deprecated Use DopplerHookMigratorConfig with
+ * `type: 'dopplerHookMigrator'` instead.
+ */
+export type DopplerHookMigrationConfig = Omit<
+  DopplerHookMigratorConfig,
+  'type'
+> & {
+  type: 'dopplerHook';
+};
 
 export interface ProceedsSplitConfig {
   recipient: Address;
@@ -382,7 +389,8 @@ export type MigrationConfig =
   | UniswapV2SplitMigrationConfig // V2 migration with proceeds split + TopUpDistributor support
   | UniswapV4MigrationConfig
   | UniswapV4SplitMigrationConfig
-  | DopplerHookMigrationConfig // Dynamic-only: migration via DopplerHookMigrator
+  | DopplerHookMigratorConfig // Dynamic-only: migration via DopplerHookMigrator
+  | DopplerHookMigrationConfig // Deprecated DopplerHookMigrator discriminator
   | { type: 'noOp' }; // No migration - used with lockable beneficiaries
 
 // Create Static Auction parameters
@@ -1038,6 +1046,11 @@ export interface MulticurveDecayFeeSchedule {
 }
 
 export type MulticurveInitializerConfig =
+  | { type: 'dopplerHookInitializer' }
+  | {
+      /** @deprecated Use 'dopplerHookInitializer' instead. */
+      type: 'dopplerHook';
+    }
   | { type: 'standard' }
   | { type: 'scheduled'; startTime: number }
   | {
@@ -1068,7 +1081,7 @@ export interface CreateMulticurveParams<
     beneficiaries?: BeneficiaryData[];
   };
 
-  // Preferred initializer configuration. Defaults to { type: 'standard' }.
+  // Preferred initializer configuration. Defaults to DopplerHookInitializer.
   initializer?: MulticurveInitializerConfig;
 
   /**

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -52,6 +52,11 @@ export type DopplerERC20V1TokenConfig = {
   name: string;
   symbol: string;
   tokenURI: string;
+  /**
+   * DopplerERC20V1 does not support yearly minting.
+   * Set `type: 'standard'` to configure `yearlyMintRate`.
+   */
+  yearlyMintRate?: never;
 } & DopplerERC20V1OnlyTokenConfigFields;
 
 export type InferredDopplerERC20V1TokenConfig = {
@@ -59,6 +64,11 @@ export type InferredDopplerERC20V1TokenConfig = {
   name: string;
   symbol: string;
   tokenURI: string;
+  /**
+   * DopplerERC20V1 does not support yearly minting.
+   * Set `type: 'standard'` to configure `yearlyMintRate`.
+   */
+  yearlyMintRate?: never;
 } & DopplerERC20V1OnlyTokenConfigFields;
 
 export type TokenConfig =

--- a/test/evm/fork/base-sepolia/dynamic-auction-rehype-migrator.base-sepolia.test.ts
+++ b/test/evm/fork/base-sepolia/dynamic-auction-rehype-migrator.base-sepolia.test.ts
@@ -139,7 +139,7 @@ describe('Dynamic auction with RehypeDopplerHookMigrator (Base Sepolia fork)', (
       })
       .withGovernance({ type: 'default' })
       .withMigration({
-        type: 'dopplerHook',
+        type: 'dopplerHookMigrator',
         fee: 3000,
         useDynamicFee: false,
         tickSpacing: 10,

--- a/test/evm/setup/fixtures/addresses.ts
+++ b/test/evm/setup/fixtures/addresses.ts
@@ -41,8 +41,14 @@ export const mockAddresses: ChainAddresses = {
   v4MulticurveInitializer: getAddress(
     '0x7100000000000000000000000000000000000007',
   ) as Address,
+  v4ScheduledMulticurveInitializer: getAddress(
+    '0x7150000000000000000000000000000000000007',
+  ) as Address,
   v4DecayMulticurveInitializer: getAddress(
     '0x7200000000000000000000000000000000000007',
+  ) as Address,
+  dopplerHookInitializer: getAddress(
+    '0x7250000000000000000000000000000000000007',
   ) as Address,
   rehypeDopplerHookInitializer: getAddress(
     '0x7300000000000000000000000000000000000007',

--- a/test/evm/unit/addresses.test.ts
+++ b/test/evm/unit/addresses.test.ts
@@ -1,15 +1,81 @@
 import { describe, expect, it } from 'vitest';
 import { isAddress, type Address, zeroAddress } from 'viem';
-import { ADDRESSES, CHAIN_IDS, getAddresses } from '../../../src/evm/addresses';
+import {
+  ADDRESSES,
+  CHAIN_IDS,
+  getAddresses,
+  type ChainAddresses,
+} from '../../../src/evm/addresses';
 import { GENERATED_DOPPLER_DEPLOYMENTS } from '../../../src/evm/deployments.generated';
 
-const dopplerERC20V1TargetChains = [
+const generatedAddressTargetChains = [
   { name: 'mainnet', chainId: CHAIN_IDS.MAINNET },
   { name: 'base', chainId: CHAIN_IDS.BASE },
   { name: 'base-sepolia', chainId: CHAIN_IDS.BASE_SEPOLIA },
   { name: 'robinhood', chainId: CHAIN_IDS.ROBINHOOD },
   { name: 'monad-mainnet', chainId: CHAIN_IDS.MONAD_MAINNET },
 ] as const;
+
+const generatedTokenFactoryTargetChains = [
+  {
+    name: 'mainnet',
+    chainId: CHAIN_IDS.MAINNET,
+    deploymentKey: 'CloneERC20Factory',
+  },
+  {
+    name: 'base',
+    chainId: CHAIN_IDS.BASE,
+    deploymentKey: 'TokenFactory80',
+  },
+  {
+    name: 'base-sepolia',
+    chainId: CHAIN_IDS.BASE_SEPOLIA,
+    deploymentKey: 'TokenFactory80',
+  },
+  {
+    name: 'monad-mainnet',
+    chainId: CHAIN_IDS.MONAD_MAINNET,
+    deploymentKey: 'TokenFactory80',
+  },
+] as const;
+
+const generatedAddressMappings = [
+  ['airlock', 'Airlock'],
+  ['derc20V2Factory', 'CloneDERC20VotesV2Factory'],
+  ['derc20V2Implementation', 'CloneDERC20VotesV2'],
+  ['dopplerERC20V1Factory', 'DopplerERC20V1Factory'],
+  ['dopplerERC20V1Implementation', 'DopplerERC20V1'],
+  ['doppler404Factory', 'DN404Factory'],
+  ['v3Initializer', 'UniswapV3Initializer'],
+  ['lockableV3Initializer', 'LockableUniswapV3Initializer'],
+  ['v4Initializer', 'UniswapV4Initializer'],
+  ['v4MulticurveInitializer', 'UniswapV4MulticurveInitializer'],
+  [
+    'v4ScheduledMulticurveInitializer',
+    'UniswapV4ScheduledMulticurveInitializer',
+  ],
+  ['v4DecayMulticurveInitializer', 'DecayMulticurveInitializer'],
+  ['dopplerHookInitializer', 'DopplerHookInitializer'],
+  ['rehypeDopplerHookInitializer', 'RehypeDopplerHookInitializer'],
+  ['rehypeDopplerHook', 'RehypeDopplerHookInitializer'],
+  ['dopplerLens', 'DopplerLensQuoter'],
+  ['dopplerDeployer', 'DopplerDeployer'],
+  ['v2Migrator', 'UniswapV2Migrator'],
+  ['v2MigratorSplit', 'UniswapV2MigratorSplit'],
+  ['v4Migrator', 'UniswapV4Migrator'],
+  ['v4MigratorSplit', 'UniswapV4MigratorSplit'],
+  ['v4MigratorHook', 'UniswapV4MigratorHook'],
+  ['dopplerHookMigrator', 'DopplerHookMigrator'],
+  ['rehypeDopplerHookMigrator', 'RehypeDopplerHookMigrator'],
+  ['noOpMigrator', 'NoOpMigrator'],
+  ['governanceFactory', 'GovernanceFactory'],
+  ['noOpGovernanceFactory', 'NoOpGovernanceFactory'],
+  ['launchpadGovernanceFactory', 'LaunchpadGovernanceFactory'],
+  ['streamableFeesLocker', 'StreamableFeesLocker'],
+  ['streamableFeesLockerV2', 'StreamableFeesLockerV2'],
+  ['topUpDistributor', 'TopUpDistributor'],
+  ['bundler', 'Bundler'],
+] as const satisfies readonly (readonly [keyof ChainAddresses, string])[];
 
 function expectConfiguredAddress(address: Address | undefined): Address {
   expect(address).toBeDefined();
@@ -22,7 +88,7 @@ function expectConfiguredAddress(address: Address | undefined): Address {
 }
 
 describe('address configuration', () => {
-  it.each(dopplerERC20V1TargetChains)(
+  it.each(generatedAddressTargetChains)(
     'returns generated DopplerERC20V1 addresses for $name',
     ({ chainId }) => {
       const addresses = getAddresses(chainId);
@@ -39,6 +105,34 @@ describe('address configuration', () => {
       expect(ADDRESSES[chainId].dopplerERC20V1Implementation).toBe(
         implementation,
       );
+    },
+  );
+
+  it.each(generatedTokenFactoryTargetChains)(
+    'returns the generated token factory for $name',
+    ({ chainId, deploymentKey }) => {
+      const generated = GENERATED_DOPPLER_DEPLOYMENTS[
+        chainId
+      ] as unknown as Record<string, Address>;
+
+      expect(getAddresses(chainId).tokenFactory).toBe(generated[deploymentKey]);
+    },
+  );
+
+  it.each(generatedAddressTargetChains)(
+    'uses generated Doppler contract addresses for $name',
+    ({ chainId }) => {
+      const addresses = getAddresses(chainId);
+      const generated = GENERATED_DOPPLER_DEPLOYMENTS[
+        chainId
+      ] as unknown as Record<string, Address | undefined>;
+
+      for (const [property, deploymentKey] of generatedAddressMappings) {
+        const generatedAddress = generated[deploymentKey];
+        if (generatedAddress !== undefined) {
+          expect(addresses[property]).toBe(generatedAddress);
+        }
+      }
     },
   );
 });

--- a/test/evm/unit/builders/MulticurveBuilder.test.ts
+++ b/test/evm/unit/builders/MulticurveBuilder.test.ts
@@ -14,6 +14,7 @@ import {
   WAD,
   ZERO_ADDRESS,
 } from '../../../../src/evm/constants';
+import type { TokenConfig } from '../../../../src/evm/types';
 
 // WETH on Base - token will be token1
 const WETH_BASE: Address = '0x4200000000000000000000000000000000000006';
@@ -73,6 +74,19 @@ describe('MulticurveBuilder', () => {
 
     expect(params.token.type).toBe('standard');
     expect(params.initializer).toEqual({ type: 'dopplerHookInitializer' });
+  });
+
+  it('rejects yearlyMintRate without an explicit standard token type', () => {
+    const token = {
+      name: 'InvalidToken',
+      symbol: 'INVALID',
+      tokenURI: 'ipfs://invalid',
+      yearlyMintRate: 0n,
+    } as unknown as TokenConfig;
+
+    expect(() => createDefaultBuilder().tokenConfig(token)).toThrow(
+      "yearlyMintRate is only supported with token type 'standard'",
+    );
   });
 
   it('preserves an explicit DopplerHookInitializer override', () => {

--- a/test/evm/unit/builders/MulticurveBuilder.test.ts
+++ b/test/evm/unit/builders/MulticurveBuilder.test.ts
@@ -18,7 +18,99 @@ import {
 // WETH on Base - token will be token1
 const WETH_BASE: Address = '0x4200000000000000000000000000000000000006';
 
+const USER_ADDRESS = '0x00000000000000000000000000000000000000AA' as Address;
+const DOPPLER_HOOK_INITIALIZER =
+  '0x00000000000000000000000000000000000000BB' as Address;
+const LEGACY_MULTICURVE_INITIALIZER =
+  '0x00000000000000000000000000000000000000CC' as Address;
+
+function createDefaultBuilder() {
+  return MulticurveBuilder.forChain(CHAIN_IDS.BASE)
+    .tokenConfig({
+      name: 'DefaultToken',
+      symbol: 'DFT',
+      tokenURI: 'ipfs://default',
+    })
+    .saleConfig({
+      initialSupply: 1_000n * WAD,
+      numTokensToSell: 500n * WAD,
+      numeraire: WETH_BASE,
+    })
+    .poolConfig({
+      fee: 3000,
+      tickSpacing: 60,
+      curves: [
+        {
+          tickLower: -120_000,
+          tickUpper: -90_000,
+          numPositions: 8,
+          shares: WAD,
+        },
+      ],
+    })
+    .withGovernance({ type: 'noOp' })
+    .withMigration({ type: 'uniswapV2' })
+    .withUserAddress(USER_ADDRESS);
+}
+
 describe('MulticurveBuilder', () => {
+  it('defaults to DopplerERC20V1 and DopplerHookInitializer', () => {
+    const params = createDefaultBuilder().build();
+
+    expect(params.token.type).toBe('dopplerERC20V1');
+    expect(params.initializer).toEqual({ type: 'dopplerHookInitializer' });
+  });
+
+  it('requires an explicit standard token type', () => {
+    const params = createDefaultBuilder()
+      .tokenConfig({
+        type: 'standard',
+        name: 'LegacyToken',
+        symbol: 'LEG',
+        tokenURI: 'ipfs://legacy',
+      })
+      .build();
+
+    expect(params.token.type).toBe('standard');
+    expect(params.initializer).toEqual({ type: 'dopplerHookInitializer' });
+  });
+
+  it('preserves an explicit DopplerHookInitializer override', () => {
+    const params = createDefaultBuilder()
+      .withDopplerHookInitializer(DOPPLER_HOOK_INITIALIZER)
+      .build();
+
+    expect(params.initializer).toEqual({ type: 'dopplerHookInitializer' });
+    expect(params.modules?.dopplerHookInitializer).toBe(
+      DOPPLER_HOOK_INITIALIZER,
+    );
+  });
+
+  it('selects the legacy initializer with withV4MulticurveInitializer', () => {
+    const params = createDefaultBuilder()
+      .withV4MulticurveInitializer(LEGACY_MULTICURVE_INITIALIZER)
+      .build();
+
+    expect(params.initializer).toEqual({ type: 'standard' });
+    expect(params.modules?.v4MulticurveInitializer).toBe(
+      LEGACY_MULTICURVE_INITIALIZER,
+    );
+  });
+
+  it('rejects conflicting explicit initializer overrides in either order', () => {
+    expect(() =>
+      createDefaultBuilder()
+        .withV4MulticurveInitializer(LEGACY_MULTICURVE_INITIALIZER)
+        .withDopplerHookInitializer(DOPPLER_HOOK_INITIALIZER),
+    ).toThrow('Cannot set multicurve initializer');
+
+    expect(() =>
+      createDefaultBuilder()
+        .withDopplerHookInitializer(DOPPLER_HOOK_INITIALIZER)
+        .withV4MulticurveInitializer(LEGACY_MULTICURVE_INITIALIZER),
+    ).toThrow('Cannot set multicurve initializer');
+  });
+
   it('sorts lockable beneficiaries by address during build', () => {
     const beneficiaries = [
       {
@@ -243,6 +335,16 @@ describe('MulticurveBuilder', () => {
         );
     }
 
+    it('builds scheduled initializer config', () => {
+      const startTime = Math.floor(Date.now() / 1000) + 600;
+      const params = buildBaseBuilder().withSchedule({ startTime }).build();
+
+      expect(params.initializer).toEqual({
+        type: 'scheduled',
+        startTime,
+      });
+    });
+
     it('builds decay initializer config and keeps pool.fee as terminal fee', () => {
       const startTime = Math.floor(Date.now() / 1000) + 600;
       const params = buildBaseBuilder()
@@ -275,6 +377,31 @@ describe('MulticurveBuilder', () => {
         startTime: 0,
         startFee: 3000,
         durationSeconds: 3600,
+      });
+    });
+
+    it('returns to the default initializer after clearing decay', () => {
+      const params = buildBaseBuilder()
+        .withDecay({
+          startFee: 3000,
+          durationSeconds: 3600,
+        })
+        .withDecay(undefined)
+        .build();
+
+      expect(params.initializer).toEqual({
+        type: 'dopplerHookInitializer',
+      });
+    });
+
+    it('returns to the default initializer after clearing a schedule', () => {
+      const params = buildBaseBuilder()
+        .withSchedule({ startTime: 1 })
+        .withSchedule(undefined)
+        .build();
+
+      expect(params.initializer).toEqual({
+        type: 'dopplerHookInitializer',
       });
     });
 
@@ -319,12 +446,11 @@ describe('MulticurveBuilder', () => {
     });
 
     it('prevents combining decay and scheduled initializers', () => {
-      const builder = buildBaseBuilder()
-        .withDecay({
-          startTime: Math.floor(Date.now() / 1000) + 600,
-          startFee: 3000,
-          durationSeconds: 3600,
-        });
+      const builder = buildBaseBuilder().withDecay({
+        startTime: Math.floor(Date.now() / 1000) + 600,
+        startFee: 3000,
+        durationSeconds: 3600,
+      });
 
       expect(() =>
         builder.withSchedule({
@@ -346,7 +472,9 @@ describe('MulticurveBuilder', () => {
         .withV4DecayMulticurveInitializer(decayInitializer)
         .build();
 
-      expect(params.modules?.v4DecayMulticurveInitializer).toBe(decayInitializer);
+      expect(params.modules?.v4DecayMulticurveInitializer).toBe(
+        decayInitializer,
+      );
     });
 
     it('builds rehype initializer config with fee schedule and distribution matrix', () => {
@@ -374,7 +502,8 @@ describe('MulticurveBuilder', () => {
         .build();
 
       expect(params.initializer?.type).toBe('rehype');
-      const rehype = (params.initializer as { type: 'rehype'; config: any }).config;
+      const rehype = (params.initializer as { type: 'rehype'; config: any })
+        .config;
       expect(rehype.startFee).toBe(6000);
       expect(rehype.endFee).toBe(3000);
       expect(rehype.durationSeconds).toBe(3600);
@@ -401,7 +530,8 @@ describe('MulticurveBuilder', () => {
 
         const params = buildBaseBuilder()
           .withRehypeDopplerHook({
-            hookAddress: '0x9999999999999999999999999999999999999999' as Address,
+            hookAddress:
+              '0x9999999999999999999999999999999999999999' as Address,
             buybackDestination:
               '0x8888888888888888888888888888888888888888' as Address,
             startFee: 3000,
@@ -421,7 +551,12 @@ describe('MulticurveBuilder', () => {
           })
           .build();
 
-        const rehype = (params.initializer as { type: 'rehype'; config: { startingTime: number } }).config;
+        const rehype = (
+          params.initializer as {
+            type: 'rehype';
+            config: { startingTime: number };
+          }
+        ).config;
         expect(rehype.startingTime).toBe(expectedStartingTime);
       },
     );
@@ -570,7 +705,8 @@ describe('MulticurveBuilder', () => {
         })
         .build();
 
-      const rehype = (params.initializer as { type: 'rehype'; config: any }).config;
+      const rehype = (params.initializer as { type: 'rehype'; config: any })
+        .config;
       expect(rehype.startFee).toBe(3000);
       expect(rehype.endFee).toBe(3000);
       expect(rehype.durationSeconds).toBe(0);

--- a/test/evm/unit/entities/DopplerFactory.customEncoder.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.customEncoder.test.ts
@@ -5,8 +5,11 @@ import {
   DopplerFactory,
   type MigrationEncoder,
 } from '../../../../src/evm/entities/DopplerFactory';
-import { CHAIN_IDS } from '../../../../src/evm/addresses';
-import type { MigrationConfig, CreateStaticAuctionParams } from '../../../../src/evm/types';
+import { CHAIN_IDS, getAddresses } from '../../../../src/evm/addresses';
+import type {
+  MigrationConfig,
+  CreateStaticAuctionParams,
+} from '../../../../src/evm/types';
 import type { SupportedPublicClient } from '../../../../src/evm/types';
 import { TICK_SPACINGS } from '../../../../src/evm/constants';
 
@@ -78,6 +81,27 @@ describe('DopplerFactory Custom Migration Encoder', () => {
     expect(customEncoder).toHaveBeenCalledTimes(1);
 
     // Verify the result contains our custom migration data
+    expect(result.liquidityMigratorData).toBe(`0x${'custom'.padEnd(64, '0')}`);
+  });
+
+  it('preserves custom encoding when uniswapV2 resolves to V2Split', async () => {
+    const robinhoodFactory = new DopplerFactory(
+      publicClient,
+      undefined,
+      CHAIN_IDS.ROBINHOOD,
+    ).withCustomMigrationEncoder(customEncoder);
+
+    const result = await robinhoodFactory.encodeCreateStaticAuctionParams({
+      ...mockCreateParams,
+      modules: {
+        v3Initializer: getAddresses(CHAIN_IDS.BASE_SEPOLIA).v3Initializer,
+      },
+    });
+
+    expect(customEncoder).toHaveBeenCalledWith(mockCreateParams.migration);
+    expect(result.liquidityMigrator).toBe(
+      getAddresses(CHAIN_IDS.ROBINHOOD).v2MigratorSplit,
+    );
     expect(result.liquidityMigratorData).toBe(`0x${'custom'.padEnd(64, '0')}`);
   });
 

--- a/test/evm/unit/entities/DopplerFactory.dopplerERC20V1.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.dopplerERC20V1.test.ts
@@ -350,7 +350,9 @@ describe('DopplerFactory DopplerERC20V1 token routing', () => {
     const createParams = await factory.encodeCreateStaticAuctionParams(params);
     const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
 
-    expect(createParams.governanceFactory).toBe(mockAddresses.governanceFactory);
+    expect(createParams.governanceFactory).toBe(
+      mockAddresses.governanceFactory,
+    );
     expect(decoded[10]).toContain(mockTimelockAddress);
   });
 
@@ -383,7 +385,9 @@ describe('DopplerFactory DopplerERC20V1 token routing', () => {
     const createParams = await factory.encodeCreateStaticAuctionParams(params);
     const decoded = decodeV1TokenFactoryData(createParams.tokenFactoryData);
 
-    expect(createParams.governanceFactory).toBe(mockAddresses.governanceFactory);
+    expect(createParams.governanceFactory).toBe(
+      mockAddresses.governanceFactory,
+    );
     expect(decoded[10]).toContain(mockTimelockAddress);
   });
 
@@ -459,6 +463,7 @@ describe('DopplerFactory DopplerERC20V1 token routing', () => {
   it('keeps standard cliff vesting on the DERC20 V2 route without DopplerERC20V1-specific fields', async () => {
     const params = StaticAuctionBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Static Cliff',
         symbol: 'STCL',
         tokenURI: 'ipfs://static-cliff',
@@ -742,7 +747,7 @@ describe('DopplerFactory DopplerERC20V1 token routing', () => {
       })
       .withGovernance({ type: 'noOp' })
       .withMigration({
-        type: 'dopplerHook',
+        type: 'dopplerHookMigrator',
         fee: 3000,
         tickSpacing: 10,
         lockDuration: 30 * DAY_SECONDS,

--- a/test/evm/unit/entities/DopplerFactory.splitMigrators.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.splitMigrators.test.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { privateKeyToAccount } from 'viem/accounts';
-import { decodeAbiParameters, parseEther, type Address } from 'viem';
+import {
+  decodeAbiParameters,
+  parseEther,
+  zeroAddress,
+  type Address,
+} from 'viem';
 import { DopplerFactory } from '../../../../src/evm/entities/DopplerFactory';
 import { CHAIN_IDS, getAddresses } from '../../../../src/evm/addresses';
 import type {
   CreateDynamicAuctionParams,
   CreateStaticAuctionParams,
   SupportedPublicClient,
+  CreateMulticurveParams,
 } from '../../../../src/evm/types';
 import { isToken0Expected } from '../../../../src/evm/utils';
 
@@ -79,6 +85,51 @@ describe('DopplerFactory split migrator support', () => {
 
     expect(decoded[0]).toBe(proceedsRecipient);
     expect(decoded[1]).toBe(parseEther('0.1'));
+  });
+
+  it('falls back to V2Split when V2 is unavailable', () => {
+    const addresses = getAddresses(CHAIN_IDS.ROBINHOOD);
+    const robinhoodFactory = new DopplerFactory(
+      publicClient,
+      undefined,
+      CHAIN_IDS.ROBINHOOD,
+    );
+    const params: CreateMulticurveParams<typeof CHAIN_IDS.ROBINHOOD> = {
+      token: {
+        name: 'Robinhood LTS Token',
+        symbol: 'RHLTS',
+        tokenURI: 'https://example.com/robinhood-lts.json',
+      },
+      sale: {
+        initialSupply: parseEther('1000000'),
+        numTokensToSell: parseEther('900000'),
+        numeraire: addresses.weth,
+      },
+      pool: {
+        fee: 3000,
+        tickSpacing: 60,
+        curves: [
+          {
+            tickLower: -120000,
+            tickUpper: -90000,
+            numPositions: 8,
+            shares: parseEther('1'),
+          },
+        ],
+      },
+      governance: { type: 'noOp' },
+      migration: { type: 'uniswapV2' },
+      userAddress: account.address,
+    };
+
+    const result = robinhoodFactory.encodeCreateMulticurveParams(params);
+    const decoded = decodeAbiParameters(
+      [{ type: 'address' }, { type: 'uint256' }],
+      result.liquidityMigratorData,
+    );
+
+    expect(result.liquidityMigrator).toBe(addresses.v2MigratorSplit);
+    expect(decoded).toEqual([zeroAddress, 0n]);
   });
 
   it('encodes uniswapV4Split migration and sorts beneficiaries', async () => {

--- a/test/evm/unit/entities/DopplerFactory.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.test.ts
@@ -17,6 +17,7 @@ import type {
   CreateStaticAuctionParams,
   CreateDynamicAuctionParams,
   CreateMulticurveParams,
+  TokenConfig,
 } from '../../../../src/evm/types';
 import type {
   DopplerHookMigrationConfig,
@@ -151,6 +152,20 @@ describe('DopplerFactory', () => {
       );
       expect(createParams.poolInitializer).toBe(
         mockAddresses.dopplerHookInitializer,
+      );
+    });
+
+    it('rejects yearlyMintRate on the inferred DopplerERC20V1 path', () => {
+      const params = multicurveParams();
+      params.token = {
+        name: 'Invalid LTS Token',
+        symbol: 'INVALID',
+        tokenURI: 'https://example.com/invalid-lts-token',
+        yearlyMintRate: 0n,
+      } as unknown as TokenConfig;
+
+      expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
+        "yearlyMintRate is only supported with token type 'standard'",
       );
     });
 

--- a/test/evm/unit/entities/DopplerFactory.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.test.ts
@@ -18,6 +18,10 @@ import type {
   CreateDynamicAuctionParams,
   CreateMulticurveParams,
 } from '../../../../src/evm/types';
+import type {
+  DopplerHookMigrationConfig,
+  DopplerHookMigratorConfig,
+} from '../../../../src/evm';
 import {
   parseEther,
   decodeAbiParameters,
@@ -97,6 +101,7 @@ describe('DopplerFactory', () => {
   describe('encodeCreateMulticurveParams', () => {
     const multicurveParams = (): CreateMulticurveParams => ({
       token: {
+        type: 'standard',
         name: 'MC Token',
         symbol: 'MCT',
         tokenURI: 'https://example.com/mc-token',
@@ -124,9 +129,40 @@ describe('DopplerFactory', () => {
           },
         ],
       },
+      initializer: { type: 'standard' },
       governance: { type: 'default' },
       migration: { type: 'uniswapV2' },
       userAddress: '0x1234567890123456789012345678901234567890' as Address,
+    });
+
+    it('uses LTS token and multicurve initializer defaults', () => {
+      const params = multicurveParams();
+      params.token = {
+        name: 'Default LTS Token',
+        symbol: 'LTS',
+        tokenURI: 'https://example.com/lts-token',
+      };
+      params.initializer = undefined;
+
+      const createParams = factory.encodeCreateMulticurveParams(params);
+
+      expect(createParams.tokenFactory).toBe(
+        mockAddresses.dopplerERC20V1Factory,
+      );
+      expect(createParams.poolInitializer).toBe(
+        mockAddresses.dopplerHookInitializer,
+      );
+    });
+
+    it('accepts the legacy dopplerHook initializer discriminator', () => {
+      const params = multicurveParams();
+      params.initializer = { type: 'dopplerHook' };
+
+      const createParams = factory.encodeCreateMulticurveParams(params);
+
+      expect(createParams.poolInitializer).toBe(
+        mockAddresses.dopplerHookInitializer,
+      );
     });
 
     it('appends a fallback curve when shares total less than 100%', () => {
@@ -249,6 +285,20 @@ describe('DopplerFactory', () => {
 
       // Non-positive ticks are valid - tick sign depends on price ratio
       expect(() => factory.encodeCreateMulticurveParams(params)).not.toThrow();
+    });
+
+    it('uses the scheduled multicurve initializer contract', () => {
+      const params = multicurveParams();
+      params.initializer = {
+        type: 'scheduled',
+        startTime: 1_800_000_000,
+      };
+
+      const createParams = factory.encodeCreateMulticurveParams(params);
+
+      expect(createParams.poolInitializer).toBe(
+        mockAddresses.v4ScheduledMulticurveInitializer,
+      );
     });
 
     it('encodes decay multicurve params with decay initializer', () => {
@@ -747,10 +797,10 @@ describe('DopplerFactory', () => {
       );
     });
 
-    it('rejects dopplerHook migration for multicurve auctions', () => {
+    it('rejects dopplerHookMigrator migration for multicurve auctions', () => {
       const params = multicurveParams();
       params.migration = {
-        type: 'dopplerHook',
+        type: 'dopplerHookMigrator',
         fee: 3000,
         tickSpacing: 60,
         lockDuration: 30 * DAY_SECONDS,
@@ -764,7 +814,7 @@ describe('DopplerFactory', () => {
       };
 
       expect(() => factory.encodeCreateMulticurveParams(params)).toThrow(
-        'dopplerHook migration is only supported for dynamic auctions',
+        'dopplerHookMigrator migration is only supported for dynamic auctions',
       );
     });
 
@@ -849,11 +899,11 @@ describe('DopplerFactory', () => {
       );
     });
 
-    it('rejects dopplerHook migration for static auctions', async () => {
+    it('rejects dopplerHookMigrator migration for static auctions', async () => {
       const invalidParams = {
         ...validParams,
         migration: {
-          type: 'dopplerHook' as const,
+          type: 'dopplerHookMigrator' as const,
           fee: 3000,
           tickSpacing: 60,
           lockDuration: 30 * DAY_SECONDS,
@@ -868,7 +918,7 @@ describe('DopplerFactory', () => {
       };
 
       await expect(factory.createStaticAuction(invalidParams)).rejects.toThrow(
-        'dopplerHook migration is only supported for dynamic auctions',
+        'dopplerHookMigrator migration is only supported for dynamic auctions',
       );
     });
 
@@ -1189,39 +1239,41 @@ describe('DopplerFactory', () => {
       expect(gasEstimate).toBe(12_250_000n);
     });
 
-    it('encodes dopplerHook migration with rehype helper for dynamic auctions', async () => {
-      const marketCapParams = DynamicAuctionBuilder.forChain(1)
-        .tokenConfig({
-          name: 'Test Token',
-          symbol: 'TEST',
-          tokenURI: 'https://example.com/token',
-        })
-        .saleConfig({
-          initialSupply: parseEther('1000000'),
-          numTokensToSell: parseEther('500000'),
-          numeraire: mockAddresses.weth,
-        })
-        .withMarketCapRange({
-          marketCap: { start: 500_000, min: 50_000 },
-          numerairePrice: 3000,
-          minProceeds: parseEther('100'),
-          maxProceeds: parseEther('10000'),
-          fee: 3000,
-          tickSpacing: 10,
-          duration: 7 * DAY_SECONDS,
-          epochLength: 3600,
-        })
-        .withGovernance({ type: 'noOp' })
-        .withMigration({ type: 'uniswapV4', fee: 3000, tickSpacing: 10 })
-        .withUserAddress(
-          '0x1234567890123456789012345678901234567890' as Address,
-        )
-        .build();
+    it.each(['dopplerHookMigrator', 'dopplerHook'] as const)(
+      'encodes %s migration with rehype helper for dynamic auctions',
+      async (migrationType) => {
+        const marketCapParams = DynamicAuctionBuilder.forChain(1)
+          .tokenConfig({
+            name: 'Test Token',
+            symbol: 'TEST',
+            tokenURI: 'https://example.com/token',
+          })
+          .saleConfig({
+            initialSupply: parseEther('1000000'),
+            numTokensToSell: parseEther('500000'),
+            numeraire: mockAddresses.weth,
+          })
+          .withMarketCapRange({
+            marketCap: { start: 500_000, min: 50_000 },
+            numerairePrice: 3000,
+            minProceeds: parseEther('100'),
+            maxProceeds: parseEther('10000'),
+            fee: 3000,
+            tickSpacing: 10,
+            duration: 7 * DAY_SECONDS,
+            epochLength: 3600,
+          })
+          .withGovernance({ type: 'noOp' })
+          .withMigration({ type: 'uniswapV4', fee: 3000, tickSpacing: 10 })
+          .withUserAddress(
+            '0x1234567890123456789012345678901234567890' as Address,
+          )
+          .build();
 
-      const params: CreateDynamicAuctionParams = {
-        ...marketCapParams,
-        migration: {
-          type: 'dopplerHook',
+        const migration:
+          | DopplerHookMigratorConfig
+          | DopplerHookMigrationConfig = {
+          type: migrationType,
           fee: 3000,
           tickSpacing: 10,
           lockDuration: 30 * DAY_SECONDS,
@@ -1248,103 +1300,107 @@ describe('DopplerFactory', () => {
               numeraireFeesToLpWad: parseEther('0.25'),
             },
           },
-        },
-      };
+        };
+        const params: CreateDynamicAuctionParams = {
+          ...marketCapParams,
+          migration,
+        };
 
-      const { createParams } =
-        await factory.encodeCreateDynamicAuctionParams(params);
+        const { createParams } =
+          await factory.encodeCreateDynamicAuctionParams(params);
 
-      expect(createParams.liquidityMigrator).toBe(
-        mockAddresses.dopplerHookMigrator,
-      );
+        expect(createParams.liquidityMigrator).toBe(
+          mockAddresses.dopplerHookMigrator,
+        );
 
-      const decoded = decodeAbiParameters(
-        [
-          { type: 'uint24' },
-          { type: 'bool' },
-          { type: 'int24' },
-          { type: 'uint32' },
-          {
-            type: 'tuple[]',
-            components: [
-              { type: 'address', name: 'beneficiary' },
-              { type: 'uint96', name: 'shares' },
-            ],
-          },
-          { type: 'address' },
-          { type: 'bytes' },
-          { type: 'address' },
-          { type: 'uint256' },
-        ],
-        createParams.liquidityMigratorData,
-      ) as readonly [
-        number,
-        boolean,
-        number,
-        number,
-        readonly { beneficiary: Address; shares: bigint }[],
-        Address,
-        `0x${string}`,
-        Address,
-        bigint,
-      ];
+        const decoded = decodeAbiParameters(
+          [
+            { type: 'uint24' },
+            { type: 'bool' },
+            { type: 'int24' },
+            { type: 'uint32' },
+            {
+              type: 'tuple[]',
+              components: [
+                { type: 'address', name: 'beneficiary' },
+                { type: 'uint96', name: 'shares' },
+              ],
+            },
+            { type: 'address' },
+            { type: 'bytes' },
+            { type: 'address' },
+            { type: 'uint256' },
+          ],
+          createParams.liquidityMigratorData,
+        ) as readonly [
+          number,
+          boolean,
+          number,
+          number,
+          readonly { beneficiary: Address; shares: bigint }[],
+          Address,
+          `0x${string}`,
+          Address,
+          bigint,
+        ];
 
-      expect(decoded[0]).toBe(3000);
-      expect(decoded[1]).toBe(false);
-      expect(decoded[2]).toBe(10);
-      expect(decoded[3]).toBe(30 * DAY_SECONDS);
-      expect(decoded[4]).toHaveLength(1);
-      expect(decoded[5]).toBe(mockAddresses.rehypeDopplerHookMigrator);
-      expect(decoded[7]).toBe(ZERO_ADDRESS);
-      expect(decoded[8]).toBe(0n);
+        expect(decoded[0]).toBe(3000);
+        expect(decoded[1]).toBe(false);
+        expect(decoded[2]).toBe(10);
+        expect(decoded[3]).toBe(30 * DAY_SECONDS);
+        expect(decoded[4]).toHaveLength(1);
+        expect(decoded[5]).toBe(mockAddresses.rehypeDopplerHookMigrator);
+        expect(decoded[7]).toBe(ZERO_ADDRESS);
+        expect(decoded[8]).toBe(0n);
 
-      const [rehypeInit] = decodeAbiParameters(
-        [
-          {
-            type: 'tuple',
-            components: [
-              { name: 'numeraire', type: 'address' },
-              { name: 'buybackDst', type: 'address' },
-              { name: 'customFee', type: 'uint24' },
-              { name: 'feeRoutingMode', type: 'uint8' },
-              {
-                name: 'feeDistributionInfo',
-                type: 'tuple',
-                components: [
-                  { name: 'assetFeesToAssetBuybackWad', type: 'uint256' },
-                  { name: 'assetFeesToNumeraireBuybackWad', type: 'uint256' },
-                  { name: 'assetFeesToBeneficiaryWad', type: 'uint256' },
-                  { name: 'assetFeesToLpWad', type: 'uint256' },
-                  { name: 'numeraireFeesToAssetBuybackWad', type: 'uint256' },
-                  {
-                    name: 'numeraireFeesToNumeraireBuybackWad',
-                    type: 'uint256',
-                  },
-                  { name: 'numeraireFeesToBeneficiaryWad', type: 'uint256' },
-                  { name: 'numeraireFeesToLpWad', type: 'uint256' },
-                ],
-              },
-            ],
-          },
-        ],
-        decoded[6],
-      ) as any;
+        const [rehypeInit] = decodeAbiParameters(
+          [
+            {
+              type: 'tuple',
+              components: [
+                { name: 'numeraire', type: 'address' },
+                { name: 'buybackDst', type: 'address' },
+                { name: 'customFee', type: 'uint24' },
+                { name: 'feeRoutingMode', type: 'uint8' },
+                {
+                  name: 'feeDistributionInfo',
+                  type: 'tuple',
+                  components: [
+                    { name: 'assetFeesToAssetBuybackWad', type: 'uint256' },
+                    { name: 'assetFeesToNumeraireBuybackWad', type: 'uint256' },
+                    { name: 'assetFeesToBeneficiaryWad', type: 'uint256' },
+                    { name: 'assetFeesToLpWad', type: 'uint256' },
+                    { name: 'numeraireFeesToAssetBuybackWad', type: 'uint256' },
+                    {
+                      name: 'numeraireFeesToNumeraireBuybackWad',
+                      type: 'uint256',
+                    },
+                    { name: 'numeraireFeesToBeneficiaryWad', type: 'uint256' },
+                    { name: 'numeraireFeesToLpWad', type: 'uint256' },
+                  ],
+                },
+              ],
+            },
+          ],
+          decoded[6],
+        ) as any;
 
-      expect(rehypeInit.numeraire).toBe(marketCapParams.sale.numeraire);
-      expect(rehypeInit.buybackDst).toBe(
-        '0x1234567890123456789012345678901234567890',
-      );
-      expect(Number(rehypeInit.customFee)).toBe(3000);
-      expect(Number(rehypeInit.feeRoutingMode)).toBe(1);
-      expect(rehypeInit.feeDistributionInfo.assetFeesToBeneficiaryWad).toBe(
-        parseEther('0.35'),
-      );
-      expect(rehypeInit.feeDistributionInfo.numeraireFeesToLpWad).toBe(
-        parseEther('0.25'),
-      );
-    });
+        expect(rehypeInit.numeraire).toBe(marketCapParams.sale.numeraire);
+        expect(rehypeInit.buybackDst).toBe(
+          '0x1234567890123456789012345678901234567890',
+        );
+        expect(Number(rehypeInit.customFee)).toBe(3000);
+        expect(Number(rehypeInit.feeRoutingMode)).toBe(1);
+        expect(rehypeInit.feeDistributionInfo.assetFeesToBeneficiaryWad).toBe(
+          parseEther('0.35'),
+        );
+        expect(rehypeInit.feeDistributionInfo.numeraireFeesToLpWad).toBe(
+          parseEther('0.25'),
+        );
+      },
+    );
 
-    it('normalizes legacy dopplerHook rehype migration fields into the new migrator layout', async () => {
+    it('normalizes legacy RehypeDopplerHookMigrator fields into the new migrator layout', async () => {
       const marketCapParams = DynamicAuctionBuilder.forChain(1)
         .tokenConfig({
           name: 'Test Token',
@@ -1376,7 +1432,7 @@ describe('DopplerFactory', () => {
       const params: CreateDynamicAuctionParams = {
         ...marketCapParams,
         migration: {
-          type: 'dopplerHook',
+          type: 'dopplerHookMigrator',
           fee: 3000,
           tickSpacing: 10,
           lockDuration: 30 * DAY_SECONDS,
@@ -1476,7 +1532,7 @@ describe('DopplerFactory', () => {
       );
     });
 
-    it('rejects dopplerHook rehype migration configs where a distribution row does not sum to WAD', async () => {
+    it('rejects RehypeDopplerHookMigrator configs where a distribution row does not sum to WAD', async () => {
       const marketCapParams = DynamicAuctionBuilder.forChain(1)
         .tokenConfig({
           name: 'Test Token',
@@ -1508,7 +1564,7 @@ describe('DopplerFactory', () => {
       const params: CreateDynamicAuctionParams = {
         ...marketCapParams,
         migration: {
-          type: 'dopplerHook',
+          type: 'dopplerHookMigrator',
           fee: 3000,
           tickSpacing: 10,
           lockDuration: 30 * DAY_SECONDS,
@@ -1542,7 +1598,7 @@ describe('DopplerFactory', () => {
       ).rejects.toThrow('Rehype asset fee distribution must sum');
     });
 
-    it('encodes dopplerHook migration with generic hook + proceeds split', async () => {
+    it('encodes dopplerHookMigrator migration with generic hook + proceeds split', async () => {
       const genericHook =
         '0x9999999999999999999999999999999999999999' as Address;
       const proceedsRecipient =
@@ -1579,7 +1635,7 @@ describe('DopplerFactory', () => {
       const params: CreateDynamicAuctionParams = {
         ...marketCapParams,
         migration: {
-          type: 'dopplerHook',
+          type: 'dopplerHookMigrator',
           fee: 500,
           useDynamicFee: true,
           tickSpacing: 20,

--- a/test/evm/unit/entities/DopplerFactory.unsupportedContracts.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.unsupportedContracts.test.ts
@@ -122,15 +122,18 @@ describe('DopplerFactory unsupported contract guards', () => {
     ).rejects.toThrow('Lockable V3 initializer address not configured');
   });
 
-  it('rejects V2 migration when the V2 migrator is not configured', async () => {
+  it('rejects V2 migration when neither V2 migrator is configured', async () => {
     vi.mocked(getAddresses).mockReturnValue({
       ...mockAddresses,
       v2Migrator: ZERO_ADDRESS,
+      v2MigratorSplit: ZERO_ADDRESS,
     });
 
     await expect(
       factory.encodeCreateStaticAuctionParams(staticParams),
-    ).rejects.toThrow('UniswapV2Migrator not deployed');
+    ).rejects.toThrow(
+      'Neither UniswapV2Migrator nor UniswapV2MigratorSplit is deployed',
+    );
   });
 
   it('rejects dynamic auctions when V4 initializer is not configured', async () => {

--- a/test/evm/unit/entities/DopplerFactory.vestingV2.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.vestingV2.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { decodeAbiParameters, getAddress, parseEther, type Address } from 'viem';
+import {
+  decodeAbiParameters,
+  getAddress,
+  parseEther,
+  type Address,
+} from 'viem';
 import { DAY_SECONDS, WAD } from '../../../../src/evm/constants';
 import {
   DynamicAuctionBuilder,
@@ -73,6 +78,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('uses the V2 factory for static auctions with cliffs', async () => {
     const params = StaticAuctionBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Static Cliff',
         symbol: 'STCL',
         tokenURI: 'ipfs://static-cliff',
@@ -105,7 +111,10 @@ describe('DopplerFactory V2 cliff vesting', () => {
     expect(decoded[0]).toBe('Static Cliff');
     expect(decoded[1]).toBe('STCL');
     expect(decoded[3]).toEqual([
-      { cliff: 90n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+      {
+        cliff: 90n * BigInt(DAY_SECONDS),
+        duration: 180n * BigInt(DAY_SECONDS),
+      },
     ]);
     expect(decoded[4]).toEqual([
       getAddress(userAddress),
@@ -118,6 +127,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('uses the V2 factory for dynamic auctions with cliffs', async () => {
     const params = DynamicAuctionBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Dynamic Cliff',
         symbol: 'DYCL',
         tokenURI: 'ipfs://dynamic-cliff',
@@ -148,14 +158,16 @@ describe('DopplerFactory V2 cliff vesting', () => {
       .withUserAddress(userAddress)
       .build();
 
-    const { createParams } = await factory.encodeCreateDynamicAuctionParams(
-      params,
-    );
+    const { createParams } =
+      await factory.encodeCreateDynamicAuctionParams(params);
     const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
 
     expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
     expect(decoded[3]).toEqual([
-      { cliff: 90n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+      {
+        cliff: 90n * BigInt(DAY_SECONDS),
+        duration: 180n * BigInt(DAY_SECONDS),
+      },
     ]);
     expect(decoded[4]).toEqual([userAddress]);
     expect(decoded[5]).toEqual([0n]);
@@ -165,6 +177,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('assigns one custom schedule per allocation', async () => {
     const params = StaticAuctionBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Scheduled Cliff',
         symbol: 'SCFL',
         tokenURI: 'ipfs://scheduled-cliff',
@@ -209,8 +222,14 @@ describe('DopplerFactory V2 cliff vesting', () => {
 
     expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
     expect(decoded[3]).toEqual([
-      { cliff: 30n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
-      { cliff: 90n * BigInt(DAY_SECONDS), duration: 365n * BigInt(DAY_SECONDS) },
+      {
+        cliff: 30n * BigInt(DAY_SECONDS),
+        duration: 180n * BigInt(DAY_SECONDS),
+      },
+      {
+        cliff: 90n * BigInt(DAY_SECONDS),
+        duration: 365n * BigInt(DAY_SECONDS),
+      },
     ]);
     expect(decoded[4]).toEqual([
       getAddress(userAddress),
@@ -223,6 +242,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('dedupes identical allocation schedules across recipients', () => {
     const params = MulticurveBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Mapped Schedules',
         symbol: 'MAP',
         tokenURI: 'ipfs://mapped-schedules',
@@ -281,7 +301,10 @@ describe('DopplerFactory V2 cliff vesting', () => {
     const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
 
     expect(decoded[3]).toEqual([
-      { cliff: 30n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+      {
+        cliff: 30n * BigInt(DAY_SECONDS),
+        duration: 180n * BigInt(DAY_SECONDS),
+      },
       {
         cliff: 120n * BigInt(DAY_SECONDS),
         duration: 365n * BigInt(DAY_SECONDS),
@@ -304,6 +327,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
 
     const params = OpeningAuctionBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Opening Cliff',
         symbol: 'OPCL',
         tokenURI: 'ipfs://opening-cliff',
@@ -343,14 +367,16 @@ describe('DopplerFactory V2 cliff vesting', () => {
       .withOpeningAuctionInitializer(mockAddresses.v4Initializer)
       .build();
 
-    const { createParams } = await factory.encodeCreateOpeningAuctionParams(
-      params,
-    );
+    const { createParams } =
+      await factory.encodeCreateOpeningAuctionParams(params);
     const decoded = decodeV2TokenFactoryData(createParams.tokenFactoryData);
 
     expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
     expect(decoded[3]).toEqual([
-      { cliff: 90n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+      {
+        cliff: 90n * BigInt(DAY_SECONDS),
+        duration: 180n * BigInt(DAY_SECONDS),
+      },
     ]);
     expect(decoded[4]).toEqual([userAddress]);
     expect(decoded[5]).toEqual([0n]);
@@ -360,6 +386,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('uses the V2 factory for multicurve auctions with cliffs', () => {
     const params = MulticurveBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Multicurve Cliff',
         symbol: 'MUCL',
         tokenURI: 'ipfs://multicurve-cliff',
@@ -395,7 +422,10 @@ describe('DopplerFactory V2 cliff vesting', () => {
 
     expect(createParams.tokenFactory).toBe(mockAddresses.derc20V2Factory);
     expect(decoded[3]).toEqual([
-      { cliff: 90n * BigInt(DAY_SECONDS), duration: 180n * BigInt(DAY_SECONDS) },
+      {
+        cliff: 90n * BigInt(DAY_SECONDS),
+        duration: 180n * BigInt(DAY_SECONDS),
+      },
     ]);
     expect(decoded[4]).toEqual([userAddress]);
     expect(decoded[5]).toEqual([0n]);
@@ -405,6 +435,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('rejects cliff durations greater than the vesting duration', () => {
     const params = MulticurveBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Bad Cliff',
         symbol: 'BAD',
         tokenURI: 'ipfs://bad-cliff',
@@ -443,6 +474,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('rejects cliff vesting durations shorter than one day', () => {
     const params = MulticurveBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Short Cliff',
         symbol: 'SHRT',
         tokenURI: 'ipfs://short-cliff',
@@ -481,6 +513,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('rejects direct factory caller input that mixes allocations with shared vesting fields', () => {
     const params = MulticurveBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Mixed Schedules',
         symbol: 'MIX',
         tokenURI: 'ipfs://mixed-schedules',
@@ -531,6 +564,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('rejects empty allocation arrays', () => {
     const params = MulticurveBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Empty Allocations',
         symbol: 'EMPTY',
         tokenURI: 'ipfs://empty-allocations',
@@ -568,6 +602,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('rejects non-integer allocation schedule values for direct factory callers', () => {
     const params = MulticurveBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Fractional Schedule',
         symbol: 'FRACT',
         tokenURI: 'ipfs://fractional-schedule',
@@ -616,6 +651,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('rejects non-safe allocation schedule values for direct factory callers', () => {
     const params = MulticurveBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Unsafe Schedule',
         symbol: 'UNSAFE',
         tokenURI: 'ipfs://unsafe-schedule',
@@ -665,6 +701,7 @@ describe('DopplerFactory V2 cliff vesting', () => {
   it('rejects legacy tokenFactory overrides when cliffs are requested', async () => {
     const params = StaticAuctionBuilder.forChain(1)
       .tokenConfig({
+        type: 'standard',
         name: 'Legacy Override',
         symbol: 'LEGO',
         tokenURI: 'ipfs://legacy-override',
@@ -689,7 +726,9 @@ describe('DopplerFactory V2 cliff vesting', () => {
       .withTokenFactory(mockAddresses.tokenFactory)
       .build();
 
-    await expect(factory.encodeCreateStaticAuctionParams(params)).rejects.toThrow(
+    await expect(
+      factory.encodeCreateStaticAuctionParams(params),
+    ).rejects.toThrow(
       'Cliff vesting requires the DERC20 V2 factory. Remove the tokenFactory override or point it at the chain DERC20 V2 factory.',
     );
   });

--- a/test/evm/unit/review-findings-verification.test.ts
+++ b/test/evm/unit/review-findings-verification.test.ts
@@ -61,7 +61,9 @@ describe('C1: Runtime values must not be exported as type-only', () => {
 describe('C2: INK Airlock address should match generated deployment', () => {
   it('INK airlock address should match GENERATED_DOPPLER_DEPLOYMENTS', () => {
     const inkAddresses = ADDRESSES[CHAIN_IDS.INK];
-    const generatedInk = (GENERATED_DOPPLER_DEPLOYMENTS as Record<string, Record<string, string>>)[String(CHAIN_IDS.INK)];
+    const generatedInk = (
+      GENERATED_DOPPLER_DEPLOYMENTS as Record<string, Record<string, string>>
+    )[String(CHAIN_IDS.INK)];
 
     // The hardcoded INK airlock is 0x014E... but the generated one is 0x660e...
     // 0x014E... is actually INK's UniswapV4Initializer
@@ -72,7 +74,9 @@ describe('C2: INK Airlock address should match generated deployment', () => {
 
   it('INK airlock should NOT be the UniswapV4Initializer address', () => {
     const inkAddresses = ADDRESSES[CHAIN_IDS.INK];
-    const generatedInk = (GENERATED_DOPPLER_DEPLOYMENTS as Record<string, Record<string, string>>)[String(CHAIN_IDS.INK)];
+    const generatedInk = (
+      GENERATED_DOPPLER_DEPLOYMENTS as Record<string, Record<string, string>>
+    )[String(CHAIN_IDS.INK)];
 
     expect(inkAddresses.airlock.toLowerCase()).not.toBe(
       generatedInk.UniswapV4Initializer.toLowerCase(),
@@ -87,7 +91,8 @@ describe('H2: Fallback curve should not have tickLower >= tickUpper', () => {
   it('fallback curve generated when user curve tickUpper equals roundMaxTickDown', async () => {
     // Import DopplerFactory to test normalizeMulticurveCurves (it's private,
     // so we test the observable behavior through the public API)
-    const { DopplerFactory } = await import('../../../src/evm/entities/DopplerFactory');
+    const { DopplerFactory } =
+      await import('../../../src/evm/entities/DopplerFactory');
     const { MAX_TICK } = await import('../../../src/evm/utils');
     const { WAD } = await import('../../../src/evm/constants');
 
@@ -119,7 +124,11 @@ describe('H2: Fallback curve should not have tickLower >= tickUpper', () => {
       account: { address: '0x0000000000000000000000000000000000000001' },
       writeContract: vi.fn(),
     };
-    const factory = new DopplerFactory(mockPublicClient as any, mockWalletClient as any, 84532);
+    const factory = new DopplerFactory(
+      mockPublicClient as any,
+      mockWalletClient as any,
+      84532,
+    );
 
     expect(() =>
       (factory as any).normalizeMulticurveCurves(curves, tickSpacing, WAD),
@@ -130,7 +139,7 @@ describe('H2: Fallback curve should not have tickLower >= tickUpper', () => {
 // ============================================================================
 // H3: encodeMigrationData for opening auctions missing numeraire
 // ============================================================================
-describe('H3: Opening auction encodeMigrationData should pass numeraire for dopplerHook migration', () => {
+describe('H3: Opening auction encodeMigrationData should pass numeraire for dopplerHookMigrator migration', () => {
   it('opening auction path passes options to encodeMigrationData', async () => {
     // The static auction path at line 257 passes { numeraire, overrides }
     // The opening auction path at line 1405 passes NO options argument.
@@ -143,12 +152,19 @@ describe('H3: Opening auction encodeMigrationData should pass numeraire for dopp
     );
 
     // Find the encodeCreateOpeningAuctionParams method and check for encodeMigrationData call
-    const methodStart = factorySource.indexOf('async encodeCreateOpeningAuctionParams');
-    const methodEnd = factorySource.indexOf('async createOpeningAuction', methodStart);
+    const methodStart = factorySource.indexOf(
+      'async encodeCreateOpeningAuctionParams',
+    );
+    const methodEnd = factorySource.indexOf(
+      'async createOpeningAuction',
+      methodStart,
+    );
     const methodBody = factorySource.slice(methodStart, methodEnd);
 
     // Find the encodeMigrationData call in this method
-    const migrationCallMatch = methodBody.match(/this\.encodeMigrationData\(([^)]+)\)/);
+    const migrationCallMatch = methodBody.match(
+      /this\.encodeMigrationData\(([^)]+)\)/,
+    );
     expect(migrationCallMatch).toBeTruthy();
 
     // The call should include a second argument with numeraire, like the static auction path:
@@ -177,12 +193,22 @@ describe('H5: completeOpeningAuction should not return zeroAddress when dopplerS
     );
 
     // Find the pattern: dopplerHookAddress: zeroAddress in the dopplerSalt branch
-    const completeMethod = factorySource.indexOf('async completeOpeningAuction');
-    const afterComplete = factorySource.indexOf('async simulateCompleteOpeningAuction', completeMethod);
-    const methodBody = factorySource.slice(completeMethod, afterComplete > completeMethod ? afterComplete : undefined);
+    const completeMethod = factorySource.indexOf(
+      'async completeOpeningAuction',
+    );
+    const afterComplete = factorySource.indexOf(
+      'async simulateCompleteOpeningAuction',
+      completeMethod,
+    );
+    const methodBody = factorySource.slice(
+      completeMethod,
+      afterComplete > completeMethod ? afterComplete : undefined,
+    );
 
     // Check if there's a code path that sets dopplerHookAddress to zeroAddress
-    const hasZeroAddressFallback = methodBody.includes('dopplerHookAddress: zeroAddress');
+    const hasZeroAddressFallback = methodBody.includes(
+      'dopplerHookAddress: zeroAddress',
+    );
     // This should NOT happen — the bug means it does
     expect(hasZeroAddressFallback).toBe(false);
   });
@@ -200,7 +226,9 @@ describe('H6: Unichain Sepolia v2Migrator and v4Migrator should be different', (
   });
 
   it('v2Migrator should match generated deployment', () => {
-    const generated = (GENERATED_DOPPLER_DEPLOYMENTS as Record<string, Record<string, string>>)[String(CHAIN_IDS.UNICHAIN_SEPOLIA)];
+    const generated = (
+      GENERATED_DOPPLER_DEPLOYMENTS as Record<string, Record<string, string>>
+    )[String(CHAIN_IDS.UNICHAIN_SEPOLIA)];
     const addresses = ADDRESSES[CHAIN_IDS.UNICHAIN_SEPOLIA];
     expect(addresses.v2Migrator.toLowerCase()).toBe(
       generated.UniswapV2Migrator.toLowerCase(),
@@ -208,7 +236,9 @@ describe('H6: Unichain Sepolia v2Migrator and v4Migrator should be different', (
   });
 
   it('v4Migrator should match generated deployment', () => {
-    const generated = (GENERATED_DOPPLER_DEPLOYMENTS as Record<string, Record<string, string>>)[String(CHAIN_IDS.UNICHAIN_SEPOLIA)];
+    const generated = (
+      GENERATED_DOPPLER_DEPLOYMENTS as Record<string, Record<string, string>>
+    )[String(CHAIN_IDS.UNICHAIN_SEPOLIA)];
     const addresses = ADDRESSES[CHAIN_IDS.UNICHAIN_SEPOLIA];
     expect(addresses.v4Migrator.toLowerCase()).toBe(
       generated.UniswapV4Migrator.toLowerCase(),
@@ -233,7 +263,8 @@ describe('H7: Timestamp byte extraction should not lose entropy for bits > 32', 
     const methodBody = source.slice(methodStart, methodEnd);
 
     // Should use BigInt for timestamp extraction
-    const usesBigInt = methodBody.includes('BigInt(') || methodBody.includes('bigTimestamp');
+    const usesBigInt =
+      methodBody.includes('BigInt(') || methodBody.includes('bigTimestamp');
     expect(usesBigInt).toBe(true);
 
     // Should NOT use the broken >> operator for timestamp bytes
@@ -248,7 +279,7 @@ describe('H7: Timestamp byte extraction should not lose entropy for bits > 32', 
 
     const timestampBytes = new Uint8Array(8);
     for (let i = 0; i < 8; i++) {
-      timestampBytes[i] = Number((bigTimestamp >> BigInt(i * 8)) & 0xFFn);
+      timestampBytes[i] = Number((bigTimestamp >> BigInt(i * 8)) & 0xffn);
     }
 
     // With BigInt, bytes 4-7 should carry the upper bits of the timestamp
@@ -282,12 +313,17 @@ describe('H1: mineTokenOrder should handle isToken0=true for high numeraire addr
 
     // Find mineTokenOrder method
     const methodStart = factorySource.indexOf('private async mineTokenOrder');
-    const methodEnd = factorySource.indexOf('async encodeCreateDynamicAuctionParams', methodStart);
+    const methodEnd = factorySource.indexOf(
+      'async encodeCreateDynamicAuctionParams',
+      methodStart,
+    );
     const methodBody = factorySource.slice(methodStart, methodEnd);
 
     // Check if it handles both directions using isToken0Expected
     // The fix uses: isToken0Expected + wantToken0 logic instead of a single > check
-    const usesIsToken0Expected = methodBody.includes('isToken0Expected') || methodBody.includes('wantToken0');
+    const usesIsToken0Expected =
+      methodBody.includes('isToken0Expected') ||
+      methodBody.includes('wantToken0');
 
     // If the bug exists, neither isToken0Expected nor wantToken0 appears
     expect(usesIsToken0Expected).toBe(true);
@@ -309,9 +345,13 @@ describe('M5: Builder should validate tick values against int24 bounds', () => {
     const methodBody = builderSource.slice(buildStart);
 
     // Check if it validates ticks against int24 bounds
-    const checksInt24 = methodBody.includes('INT24_MIN') || methodBody.includes('INT24_MAX') ||
-                         methodBody.includes('-8388608') || methodBody.includes('8388607') ||
-                         methodBody.includes('-8_388_608') || methodBody.includes('8_388_607');
+    const checksInt24 =
+      methodBody.includes('INT24_MIN') ||
+      methodBody.includes('INT24_MAX') ||
+      methodBody.includes('-8388608') ||
+      methodBody.includes('8388607') ||
+      methodBody.includes('-8_388_608') ||
+      methodBody.includes('8_388_607');
 
     // If the bug exists, no int24 validation is performed
     expect(checksInt24).toBe(true);
@@ -323,14 +363,19 @@ describe('M5: Builder should validate tick values against int24 bounds', () => {
       'utf-8',
     );
 
-    const methodStart = factorySource.indexOf('private validateOpeningAuctionParams');
+    const methodStart = factorySource.indexOf(
+      'private validateOpeningAuctionParams',
+    );
     const nextMethod = factorySource.indexOf('\n  private ', methodStart + 1);
     const methodBody = factorySource.slice(methodStart, nextMethod);
 
     // Check if it validates ticks against int24 bounds
-    const checksInt24 = methodBody.includes('INT24') ||
-                         methodBody.includes('-8388608') || methodBody.includes('8388607') ||
-                         methodBody.includes('-8_388_608') || methodBody.includes('8_388_607');
+    const checksInt24 =
+      methodBody.includes('INT24') ||
+      methodBody.includes('-8388608') ||
+      methodBody.includes('8388607') ||
+      methodBody.includes('-8_388_608') ||
+      methodBody.includes('8_388_607');
 
     expect(checksInt24).toBe(true);
   });
@@ -346,7 +391,9 @@ describe('M9: incentiveShareBps + shareToAuctionBps should not exceed 10_000', (
       'utf-8',
     );
 
-    const methodStart = factorySource.indexOf('private validateOpeningAuctionParams');
+    const methodStart = factorySource.indexOf(
+      'private validateOpeningAuctionParams',
+    );
     const nextMethod = factorySource.indexOf('\n  private ', methodStart + 1);
     const methodBody = factorySource.slice(methodStart, nextMethod);
 
@@ -383,7 +430,8 @@ describe('H4: CreateOpeningAuctionParams types should be consistent', () => {
     // The builder version uses ResolvedOpeningAuctionDopplerConfig (gamma required)
     // The types.ts version uses OpeningAuctionDopplerConfig (gamma optional)
     // Verify by checking that the builder's gamma is required
-    const { OpeningAuctionBuilder } = await import('../../../src/evm/builders/OpeningAuctionBuilder');
+    const { OpeningAuctionBuilder } =
+      await import('../../../src/evm/builders/OpeningAuctionBuilder');
 
     const builder = new OpeningAuctionBuilder(84532);
     builder.tokenConfig({
@@ -416,7 +464,9 @@ describe('H4: CreateOpeningAuctionParams types should be consistent', () => {
     });
     builder.withMigration({ type: 'uniswapV2' });
     builder.withGovernance({ type: 'noOp' });
-    builder.withUserAddress('0x1234567890123456789012345678901234567890' as Address);
+    builder.withUserAddress(
+      '0x1234567890123456789012345678901234567890' as Address,
+    );
 
     const params = builder.build();
 
@@ -456,7 +506,10 @@ describe('T1: Phase constant values should match their semantic names', () => {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       // Look for mockResolvedValueOnce(2) with comment about "Active"
-      if (line.includes('mockResolvedValueOnce(2)') && line.includes('Active')) {
+      if (
+        line.includes('mockResolvedValueOnce(2)') &&
+        line.includes('Active')
+      ) {
         foundMislabeled = true;
         break;
       }
@@ -473,9 +526,8 @@ describe('T1: Phase constant values should match their semantic names', () => {
 // ============================================================================
 describe('T2: decodeDelta should correctly decode negative (signed) int128 values', () => {
   it('decodes negative amount0 from a BalanceDelta', async () => {
-    const { OpeningAuctionPositionManager } = await import(
-      '../../../src/evm/entities/auction/OpeningAuctionPositionManager'
-    );
+    const { OpeningAuctionPositionManager } =
+      await import('../../../src/evm/entities/auction/OpeningAuctionPositionManager');
 
     // Encode a negative amount0 (-5) and positive amount1 (7) into a BalanceDelta
     // BalanceDelta is packed as: (int128(amount0) << 128) | uint128(amount1)
@@ -491,9 +543,8 @@ describe('T2: decodeDelta should correctly decode negative (signed) int128 value
   });
 
   it('decodes negative amount1 from a BalanceDelta', async () => {
-    const { OpeningAuctionPositionManager } = await import(
-      '../../../src/evm/entities/auction/OpeningAuctionPositionManager'
-    );
+    const { OpeningAuctionPositionManager } =
+      await import('../../../src/evm/entities/auction/OpeningAuctionPositionManager');
 
     const posFive = 5n;
     const negSeven = -7n;
@@ -506,9 +557,8 @@ describe('T2: decodeDelta should correctly decode negative (signed) int128 value
   });
 
   it('decodes both negative amounts from a BalanceDelta', async () => {
-    const { OpeningAuctionPositionManager } = await import(
-      '../../../src/evm/entities/auction/OpeningAuctionPositionManager'
-    );
+    const { OpeningAuctionPositionManager } =
+      await import('../../../src/evm/entities/auction/OpeningAuctionPositionManager');
 
     const negThree = -3n;
     const negNine = -9n;
@@ -544,9 +594,13 @@ describe('L2: getLiquidityAtTick should use INT24_MIN/INT24_MAX constants', () =
     const methodBody = source.slice(methodStart, methodEnd);
 
     // Check if it uses hardcoded values instead of constants
-    const usesHardcoded = methodBody.includes('-8_388_608') || methodBody.includes('8_388_607') ||
-                          methodBody.includes('-8388608') || methodBody.includes('8388607');
-    const usesConstants = methodBody.includes('INT24_MIN') || methodBody.includes('INT24_MAX');
+    const usesHardcoded =
+      methodBody.includes('-8_388_608') ||
+      methodBody.includes('8_388_607') ||
+      methodBody.includes('-8388608') ||
+      methodBody.includes('8388607');
+    const usesConstants =
+      methodBody.includes('INT24_MIN') || methodBody.includes('INT24_MAX');
 
     // The method should use constants, not hardcoded values
     expect(usesConstants).toBe(true);
@@ -567,7 +621,9 @@ describe('L11: Dead private methods should not exist', () => {
     // Count occurrences of getAirlockAddress
     // The definition is `private getAirlockAddress()` — we exclude that
     const allOccurrences = source.split('getAirlockAddress').length - 1;
-    const definitionOccurrences = source.includes('private getAirlockAddress') ? 1 : 0;
+    const definitionOccurrences = source.includes('private getAirlockAddress')
+      ? 1
+      : 0;
     const callOccurrences = allOccurrences - definitionOccurrences;
 
     // If it's dead code, there should be 0 calls
@@ -581,7 +637,11 @@ describe('L11: Dead private methods should not exist', () => {
     );
 
     const allOccurrences = source.split('getInitializerAddress').length - 1;
-    const definitionOccurrences = source.includes('private getInitializerAddress') ? 1 : 0;
+    const definitionOccurrences = source.includes(
+      'private getInitializerAddress',
+    )
+      ? 1
+      : 0;
     const callOccurrences = allOccurrences - definitionOccurrences;
 
     expect(callOccurrences).toBe(0);
@@ -610,9 +670,8 @@ describe('L11: Dead private methods should not exist', () => {
 // ============================================================================
 describe('L12: Multicurve should use DEFAULT_V4_YEARLY_MINT_RATE', () => {
   it('both constants have the same value currently', async () => {
-    const { DEFAULT_V3_YEARLY_MINT_RATE, DEFAULT_V4_YEARLY_MINT_RATE } = await import(
-      '../../../src/evm/constants'
-    );
+    const { DEFAULT_V3_YEARLY_MINT_RATE, DEFAULT_V4_YEARLY_MINT_RATE } =
+      await import('../../../src/evm/constants');
     // This test documents that they are currently equal.
     // If they diverge, the multicurve path would silently use the wrong rate.
     expect(DEFAULT_V3_YEARLY_MINT_RATE).toBe(DEFAULT_V4_YEARLY_MINT_RATE);
@@ -645,12 +704,14 @@ describe('L13: Should use consistent zero address constant', () => {
     );
 
     // Check for both imports
-    const importsViemZeroAddress = source.includes("zeroAddress") &&
+    const importsViemZeroAddress =
+      source.includes('zeroAddress') &&
       (source.includes("from 'viem'") || source.includes('from "viem"'));
     const importsConstantsZeroAddress = source.includes('ZERO_ADDRESS');
 
     // Both should not be used in the same file — pick one
-    const usesBothInCode = importsViemZeroAddress && importsConstantsZeroAddress;
+    const usesBothInCode =
+      importsViemZeroAddress && importsConstantsZeroAddress;
 
     // If the bug exists, both are used
     expect(usesBothInCode).toBe(false);
@@ -679,8 +740,14 @@ describe('M10: Transaction receipt confirmation counts should be consistent', ()
     for (const methodSig of createMethods) {
       const methodStart = source.indexOf(methodSig);
       // Find the next method after this one
-      const nextMethodIdx = source.indexOf('\n  async ', methodStart + methodSig.length);
-      const methodBody = source.slice(methodStart, nextMethodIdx > methodStart ? nextMethodIdx : undefined);
+      const nextMethodIdx = source.indexOf(
+        '\n  async ',
+        methodStart + methodSig.length,
+      );
+      const methodBody = source.slice(
+        methodStart,
+        nextMethodIdx > methodStart ? nextMethodIdx : undefined,
+      );
 
       // Each should have waitForTransactionReceipt with confirmations
       if (methodBody.includes('waitForTransactionReceipt')) {
@@ -694,7 +761,7 @@ describe('M10: Transaction receipt confirmation counts should be consistent', ()
 // M8: validateOpeningAuctionParams doesn't validate migration type
 // ============================================================================
 describe('M8: Opening auction should validate migration type compatibility', () => {
-  it('dopplerHook migration type should be explicitly handled or rejected', async () => {
+  it('dopplerHookMigrator migration type should be explicitly handled or rejected', async () => {
     const source = fs.readFileSync(
       path.resolve(process.cwd(), 'src/evm/entities/DopplerFactory.ts'),
       'utf-8',
@@ -708,7 +775,8 @@ describe('M8: Opening auction should validate migration type compatibility', () 
     // Check if migration type is validated
     const checksMigrationType =
       methodBody.includes('migration.type') ||
-      methodBody.includes('migration') && methodBody.includes('dopplerHook');
+      (methodBody.includes('migration') &&
+        methodBody.includes('dopplerHookMigrator'));
 
     // If the bug exists, the method does NOT check migration type
     expect(checksMigrationType).toBe(true);
@@ -743,12 +811,14 @@ describe('D1: Examples README should list all example files', () => {
 // ============================================================================
 describe('L5: encodeOwnerHookData packed format should produce valid hex', () => {
   it('packed format should return a valid 42-char hex address', async () => {
-    const { OpeningAuctionPositionManager } = await import(
-      '../../../src/evm/entities/auction/OpeningAuctionPositionManager'
-    );
+    const { OpeningAuctionPositionManager } =
+      await import('../../../src/evm/entities/auction/OpeningAuctionPositionManager');
 
     const testAddress = '0x1234567890123456789012345678901234567890' as Address;
-    const result = OpeningAuctionPositionManager.encodeOwnerHookData(testAddress, 'packed');
+    const result = OpeningAuctionPositionManager.encodeOwnerHookData(
+      testAddress,
+      'packed',
+    );
 
     // Should be a valid hex string starting with 0x
     expect(result.startsWith('0x')).toBe(true);
@@ -757,12 +827,14 @@ describe('L5: encodeOwnerHookData packed format should produce valid hex', () =>
   });
 
   it('abi format should produce ABI-encoded address (66 chars)', async () => {
-    const { OpeningAuctionPositionManager } = await import(
-      '../../../src/evm/entities/auction/OpeningAuctionPositionManager'
-    );
+    const { OpeningAuctionPositionManager } =
+      await import('../../../src/evm/entities/auction/OpeningAuctionPositionManager');
 
     const testAddress = '0x1234567890123456789012345678901234567890' as Address;
-    const result = OpeningAuctionPositionManager.encodeOwnerHookData(testAddress, 'abi');
+    const result = OpeningAuctionPositionManager.encodeOwnerHookData(
+      testAddress,
+      'abi',
+    );
 
     // ABI-encoded address is 32 bytes = 64 hex chars + 0x prefix = 66 chars
     expect(result.startsWith('0x')).toBe(true);
@@ -798,8 +870,11 @@ describe('M1: isInRange should check both tick bounds', () => {
     const checksLowerBound = methodBody.includes('position.tickLower');
     const checksUpperBound = methodBody.includes('position.tickUpper');
     // Should contain a single return with both bounds
-    const hasCombinedCheck = methodBody.includes('tickLower') && methodBody.includes('tickUpper') &&
-                              methodBody.includes('refTick >=') && methodBody.includes('refTick <');
+    const hasCombinedCheck =
+      methodBody.includes('tickLower') &&
+      methodBody.includes('tickUpper') &&
+      methodBody.includes('refTick >=') &&
+      methodBody.includes('refTick <');
 
     expect(checksLowerBound).toBe(true);
     expect(checksUpperBound).toBe(true);
@@ -819,7 +894,8 @@ describe('M7: MulticurveBuilder fee validation should reject negative fees', () 
     );
 
     // Should check for negative fee anywhere in the file
-    const checksNegativeFee = source.includes('fee < 0') || source.includes('fee cannot be negative');
+    const checksNegativeFee =
+      source.includes('fee < 0') || source.includes('fee cannot be negative');
     expect(checksNegativeFee).toBe(true);
   });
 });
@@ -858,16 +934,23 @@ describe('M6: Factory should resolve startingTime from top-level params, not par
     );
 
     // Find the opening auction start time resolution
-    const encodeMethod = source.indexOf('async encodeCreateOpeningAuctionParams');
-    const nextMethod = source.indexOf('async createOpeningAuction', encodeMethod);
+    const encodeMethod = source.indexOf(
+      'async encodeCreateOpeningAuctionParams',
+    );
+    const nextMethod = source.indexOf(
+      'async createOpeningAuction',
+      encodeMethod,
+    );
     const methodBody = source.slice(encodeMethod, nextMethod);
 
     // The factory should read startTimeOffset from params (top-level),
     // not from params.doppler.startTimeOffset (which builder doesn't populate)
-    const readsFromDopplerSubfield = methodBody.includes('params.doppler.startTimeOffset') ||
-                                      methodBody.includes('params.doppler.startingTime');
-    const readsFromTopLevel = methodBody.includes('params.startTimeOffset') ||
-                               methodBody.includes('params.startingTime');
+    const readsFromDopplerSubfield =
+      methodBody.includes('params.doppler.startTimeOffset') ||
+      methodBody.includes('params.doppler.startingTime');
+    const readsFromTopLevel =
+      methodBody.includes('params.startTimeOffset') ||
+      methodBody.includes('params.startingTime');
 
     // Both patterns existing is OK (fallback chain), but if ONLY the doppler subfield
     // is checked, it will always be undefined for builder-created params

--- a/test/evm/unit/v4-compatibility.test.ts
+++ b/test/evm/unit/v4-compatibility.test.ts
@@ -34,6 +34,7 @@ describe('V4 SDK Compatibility', () => {
     // Create params matching the V4 SDK example
     const params: CreateDynamicAuctionParams = {
       token: {
+        type: 'standard',
         name: 'TestToken',
         symbol: 'TEST',
         tokenURI: 'https://example.com/token.json',


### PR DESCRIPTION
## Summary

- Make `DopplerERC20V1` the default token template when `tokenConfig.type` is omitted. Use `type: 'standard'` for the legacy DERC20 path.
- Make `DopplerHookInitializer` the default multicurve initializer while keeping explicit standard, scheduled, decay, and Rehype modes. Scheduled and decay configs select their matching initializer contracts.
- Rename the migration API to `DopplerHookMigratorConfig` with `type: 'dopplerHookMigrator'`. The deprecated `DopplerHookMigrationConfig` and `type: 'dopplerHook'` remain supported.
- Fall back from `UniswapV2Migrator` to `UniswapV2MigratorSplit` when only the split deployment is available, while preserving custom migration encoder output.
- Refresh deployed contract address mappings and reject conflicting multicurve initializer overrides consistently.

## Motivation

This updates SDK defaults to the primary supported contracts while keeping explicit legacy configurations available. Existing `dopplerHook` migration configs continue to work and can migrate to the clearer initializer and migrator naming over time.

## Files Changed

- `README.md`, `docs/api-builders.md`, and `examples/` - Document the new defaults, update canonical migrator usage, and make legacy examples select `type: 'standard'` explicitly.
- `src/evm/builders/` - Normalize omitted token types to `DopplerERC20V1`, select the correct multicurve initializer mode, and validate conflicting overrides.
- `src/evm/entities/DopplerFactory.ts` - Resolve the new defaults, support both DopplerHook migration discriminators, and add the V2 split fallback.
- `src/evm/types.ts` and `src/evm/index.ts` - Export the canonical migrator type while retaining deprecated compatibility types.
- `src/evm/addresses.ts` - Refresh generated deployment mappings used by the SDK.
- `test/evm/` - Cover token and initializer defaults, legacy compatibility, scheduled and decay routing, split migrators, custom encoder precedence, and updated addresses.