### PR TITLE
feat: add salt controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,31 @@ console.log('Pool address:', result.poolAddress);
 console.log('Token address:', result.tokenAddress);
 ```
 
+**Deterministic preview/create identities:**
+
+By default, each independent multicurve assembly generates a new salt and may
+predict a different token and pool identity. Supply an explicit 32-byte salt
+when separate preview and create operations must assemble the same
+`CreateParams`:
+
+```typescript
+import type { Hex } from 'viem';
+
+const salt =
+  '0x1111111111111111111111111111111111111111111111111111111111111111' satisfies Hex;
+
+const deterministicParams = { ...params, salt };
+const preview =
+  await sdk.factory.simulateCreateMulticurve(deterministicParams);
+```
+
+Persist and reuse the salt with otherwise identical inputs for a later
+independent create operation. Builder users can call `.withSalt(salt)` before
+`.build()`. Omitting the salt, or clearing it with `.withSalt(undefined)`,
+preserves the generated-salt behavior. Explicit salts must be `0x` followed by
+exactly 64 hexadecimal characters.
+
+
 **Market Cap Presets (Low / Medium / High):**
 
 ```typescript

--- a/docs/api-builders.md
+++ b/docs/api-builders.md
@@ -312,6 +312,10 @@ Methods (chainable):
   - Supports `uniswapV2`, `uniswapV2Split`, `uniswapV4`, `uniswapV4Split`, and `noOp`
 - withUserAddress(address)
 - withIntegrator(address?)
+- withSalt(salt?: Hex)
+  - Uses the exact 32-byte salt for deterministic multicurve `CreateParams`, token prediction, and pool identity
+  - Reuse the same salt and otherwise identical inputs across independent preview and create operations
+  - Pass `undefined` to clear it and restore generated-salt behavior
 - Address overrides (optional):
   - withAirlock(address)
   - withTokenFactory(address)
@@ -328,6 +332,7 @@ Validation highlights:
 - `initialSupply > 0`, `numTokensToSell > 0`, and `numTokensToSell <= initialSupply`
 - Governance selection is required
 - SDK sorts beneficiaries by address as required on-chain when encoding
+- Explicit salts must be `0x` followed by exactly 64 hexadecimal characters; invalid values fail before RPC or wallet work
 
 Examples:
 ```ts
@@ -567,7 +572,7 @@ console.log('withdraw tx:', transactionHash)
 
 - Static: `CreateStaticAuctionParams` with fields: `token`, `sale`, `pool`, optional `vesting`, `governance`, `migration`, `integrator`, `userAddress`
 - Dynamic: `CreateDynamicAuctionParams` with fields: `token`, `sale`, `auction`, `pool`, optional `vesting`, `governance`, `migration`, `integrator`, `userAddress`, optional `startTimeOffset`, optional `blockTimestamp`
-- Multicurve: `CreateMulticurveParams` with fields: `token`, `sale`, `pool` (with `curves`), optional `vesting`, `governance`, `migration`, `integrator`, `userAddress`
+- Multicurve: `CreateMulticurveParams` with fields: `token`, `sale`, `pool` (with `curves`), optional `vesting`, `governance`, `migration`, `integrator`, `userAddress`, optional `salt`
 - Opening auction: `CreateOpeningAuctionParams` with fields: `token`, `sale`, `openingAuction`, `doppler`, optional `vesting`, `governance`, `migration`, `integrator`, `userAddress`, optional `startTimeOffset`, optional `startingTime`, optional `blockTimestamp`, optional module overrides
 
 Pass the built object directly to the factory:

--- a/src/evm/builders/MulticurveBuilder.ts
+++ b/src/evm/builders/MulticurveBuilder.ts
@@ -1,4 +1,4 @@
-import type { Address } from 'viem';
+import type { Address, Hex } from 'viem';
 import {
   DEFAULT_V3_YEARLY_MINT_RATE,
   DECAY_MAX_START_FEE,
@@ -55,6 +55,7 @@ export class MulticurveBuilder<
   private migration?: MigrationConfig;
   private integrator?: Address;
   private userAddress?: Address;
+  private salt?: Hex;
   private moduleAddresses?: ModuleAddressOverrides;
   private gasLimit?: bigint;
   // Stored from withCurves() for graduationMarketCap conversion in build()
@@ -605,6 +606,11 @@ export class MulticurveBuilder<
     return this;
   }
 
+  withSalt(salt?: Hex): this {
+    this.salt = salt;
+    return this;
+  }
+
   withGasLimit(gas?: bigint): this {
     this.gasLimit = gas;
     return this;
@@ -914,6 +920,7 @@ export class MulticurveBuilder<
       migration: this.migration,
       integrator: this.integrator ?? ZERO_ADDRESS,
       userAddress: this.userAddress,
+      salt: this.salt,
       modules: this.moduleAddresses,
       gas: this.gasLimit,
     };

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -4528,7 +4528,7 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     })();
 
     // Resolve module addresses
-    const salt = this.generateRandomSalt(params.userAddress);
+    const salt = params.salt ?? this.generateRandomSalt(params.userAddress);
 
     const resolvedInitializer: Address | undefined = (() => {
       if (useDopplerHookInitializer) {
@@ -5469,6 +5469,14 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
    * Validate multicurve auction parameters
    */
   private validateMulticurveParams(params: CreateMulticurveParams<C>): void {
+    if (
+      params.salt !== undefined &&
+      (typeof params.salt !== 'string' ||
+        !/^0x[0-9a-fA-F]{64}$/.test(params.salt))
+    ) {
+      throw new Error('Multicurve salt must be exactly 32 bytes');
+    }
+
     // Validate token parameters
     if (!params.token.name || params.token.name.trim().length === 0) {
       throw new Error('Token name is required');

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -9,7 +9,7 @@ import {
 import { CHAIN_IDS, type SupportedChainId } from './addresses';
 // Re-export SupportedChainId so consumers can import from this module
 export { type SupportedChainId } from './addresses';
-import type { Address, WalletClient } from 'viem';
+import type { Address, Hex, WalletClient } from 'viem';
 
 export type SupportedChain =
   | typeof mainnet
@@ -1121,6 +1121,9 @@ export interface CreateMulticurveParams<
   // Integrator details
   integrator?: Address;
   userAddress: Address;
+
+  // Optional deterministic salt for CREATE2 token address selection
+  salt?: Hex;
 
   // Optional address overrides for on-chain modules used during encoding/creation
   modules?: ModuleAddressOverrides;

--- a/test/evm/fork/base-sepolia/multicurve.base-sepolia.test.ts
+++ b/test/evm/fork/base-sepolia/multicurve.base-sepolia.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest'
 import { DopplerSDK, getAddresses, CHAIN_IDS, airlockAbi, WAD } from '../../../../src/evm'
 import { getTestClient, hasRpcUrl, getRpcEnvVar, delay } from '../../utils'
+import type { Hex } from 'viem'
 
 describe('Multicurve (Base Sepolia fork) smoke test', () => {
   if (!hasRpcUrl(CHAIN_IDS.BASE_SEPOLIA)) {
@@ -109,6 +110,62 @@ describe('Multicurve (Base Sepolia fork) smoke test', () => {
     expect(tokenAddress).toMatch(/^0x[a-fA-F0-9]{40}$/)
     expect(poolId).toMatch(/^0x[a-fA-F0-9]{64}$/)
   })
+
+  it('preserves deterministic identities across independent explicit-salt simulations', async () => {
+    expect(states.tokenFactory).toBe(1)
+    expect(states.governanceFactory).toBe(2)
+    expect(states.initializer).toBe(3)
+    expect(states.migrator).toBe(4)
+
+    const buildParams = (salt: Hex) =>
+      sdk
+        .buildMulticurveAuction()
+        .tokenConfig({
+          type: 'standard',
+          name: 'MultiCurveSaltTest',
+          symbol: 'MCST',
+          tokenURI: 'ipfs://salt-test',
+        })
+        .saleConfig({
+          initialSupply: 1_000_000n * WAD,
+          numTokensToSell: 1_000_000n * WAD,
+          numeraire: addresses.weth,
+        })
+        .poolConfig({
+          fee: 0,
+          tickSpacing: 8,
+          curves: Array.from({ length: 10 }, (_, i) => ({
+            tickLower: i * 16_000,
+            tickUpper: 240_000,
+            numPositions: 10,
+            shares: WAD / 10n,
+          })),
+        })
+        .withGovernance({ type: 'default' })
+        .withMigration({ type: 'uniswapV2' })
+        .withUserAddress(addresses.airlock)
+        .withSalt(salt)
+        .withV4MulticurveInitializer(addresses.v4MulticurveInitializer!)
+        .withV2Migrator(addresses.v2Migrator)
+        .build()
+
+    const saltA =
+      '0x0000000000000000000000000000000000000000000000000000000000000001' as const
+    const saltB =
+      '0x0000000000000000000000000000000000000000000000000000000000000002' as const
+
+    const firstA = await sdk.factory.simulateCreateMulticurve(buildParams(saltA))
+    await delay(500)
+    const secondA = await sdk.factory.simulateCreateMulticurve(buildParams(saltA))
+    await delay(500)
+    const resultB = await sdk.factory.simulateCreateMulticurve(buildParams(saltB))
+
+    expect(firstA.createParams).toEqual(secondA.createParams)
+    expect(firstA.tokenAddress).toBe(secondA.tokenAddress)
+    expect(firstA.poolId).toBe(secondA.poolId)
+    expect(resultB.tokenAddress).not.toBe(firstA.tokenAddress)
+    expect(resultB.poolId).not.toBe(firstA.poolId)
+  }, 120_000)
 
   it('can simulate create() for multicurve with a non-zero fee', async () => {
     expect(states.tokenFactory).toBe(1)

--- a/test/evm/unit/builders/MulticurveBuilder.test.ts
+++ b/test/evm/unit/builders/MulticurveBuilder.test.ts
@@ -62,6 +62,15 @@ describe('MulticurveBuilder', () => {
     expect(params.initializer).toEqual({ type: 'dopplerHookInitializer' });
   });
 
+  it('stores and clears an explicit salt', () => {
+    const salt =
+      '0x1111111111111111111111111111111111111111111111111111111111111111' as const;
+    const builder = createDefaultBuilder().withSalt(salt);
+
+    expect(builder.build().salt).toBe(salt);
+    expect(builder.withSalt(undefined).build().salt).toBeUndefined();
+  });
+
   it('requires an explicit standard token type', () => {
     const params = createDefaultBuilder()
       .tokenConfig({

--- a/test/evm/unit/entities/DopplerFactory.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.test.ts
@@ -30,6 +30,7 @@ import {
   getAddress,
   keccak256,
   type Address,
+  type PublicClient,
 } from 'viem';
 import {
   MAX_TICK,
@@ -134,6 +135,150 @@ describe('DopplerFactory', () => {
       governance: { type: 'default' },
       migration: { type: 'uniswapV2' },
       userAddress: '0x1234567890123456789012345678901234567890' as Address,
+    });
+
+    const explicitSalt =
+      '0x1111111111111111111111111111111111111111111111111111111111111111' as const;
+
+    const getRecordedCreateParams = (call: unknown) => {
+      if (
+        typeof call !== 'object' ||
+        call === null ||
+        !('args' in call) ||
+        !Array.isArray(call.args) ||
+        typeof call.args[0] !== 'object' ||
+        call.args[0] === null ||
+        !('salt' in call.args[0]) ||
+        !('tokenFactoryData' in call.args[0])
+      ) {
+        throw new Error('Expected a recorded Airlock create call');
+      }
+      return call.args[0];
+    };
+
+    it('encodes the same complete params for the same explicit salt', () => {
+      const params = { ...multicurveParams(), salt: explicitSalt };
+
+      const first = factory.encodeCreateMulticurveParams(params);
+      const second = factory.encodeCreateMulticurveParams(params);
+
+      expect(first).toEqual(second);
+      expect(first.salt).toBe(explicitSalt);
+
+      const zeroSalt =
+        '0x0000000000000000000000000000000000000000000000000000000000000000' as const;
+      expect(
+        factory.encodeCreateMulticurveParams({
+          ...multicurveParams(),
+          salt: zeroSalt,
+        }).salt,
+      ).toBe(zeroSalt);
+    });
+
+    it.each([
+      ['a missing 0x prefix', '11'.repeat(32)],
+      ['fewer than 32 bytes', `0x${'11'.repeat(31)}`],
+      ['more than 32 bytes', `0x${'11'.repeat(33)}`],
+      ['non-hex characters', `0x${'gg'.repeat(32)}`],
+      ['a non-string value', 123],
+    ])('rejects %s before RPC or wallet work', async (_label, salt) => {
+      const params = {
+        ...multicurveParams(),
+        salt,
+      } as unknown as CreateMulticurveParams;
+      const client = publicClient as PublicClient;
+
+      await expect(factory.simulateCreateMulticurve(params)).rejects.toThrow(
+        'Multicurve salt must be exactly 32 bytes',
+      );
+      expect(client.simulateContract).not.toHaveBeenCalled();
+      expect(walletClient.writeContract).not.toHaveBeenCalled();
+    });
+
+    it('uses the generated-salt path only when salt is omitted', () => {
+      const entropy = 0x11;
+      const getRandomValues = vi
+        .spyOn(globalThis.crypto, 'getRandomValues')
+        .mockImplementation((array) => {
+          (array as Uint8Array).fill(entropy);
+          return array;
+        });
+
+      try {
+        const params = multicurveParams();
+        const generated = factory.encodeCreateMulticurveParams(params);
+        const expectedBytes = new Uint8Array(32).fill(entropy);
+        const addressBytes = params.userAddress.slice(2);
+        for (let i = 0; i < 20; i++) {
+          expectedBytes[i] ^=
+            Number.parseInt(addressBytes.slice(i * 2, (i + 1) * 2), 16);
+        }
+        const expectedSalt = `0x${Array.from(expectedBytes)
+          .map((byte) => byte.toString(16).padStart(2, '0'))
+          .join('')}`;
+
+        expect(generated.salt).toBe(expectedSalt);
+        expect(getRandomValues).toHaveBeenCalledOnce();
+
+        const explicit = factory.encodeCreateMulticurveParams({
+          ...params,
+          salt: explicitSalt,
+        });
+        expect(explicit.salt).toBe(explicitSalt);
+        expect(getRandomValues).toHaveBeenCalledOnce();
+      } finally {
+        getRandomValues.mockRestore();
+      }
+    });
+
+    it('preserves explicit salt through enrichment and execute', async () => {
+      const params = multicurveParams();
+      params.token = {
+        name: 'Limited MC Token',
+        symbol: 'LMCT',
+        tokenURI: 'https://example.com/limited-mc-token',
+        maxBalanceLimit: parseEther('10000'),
+        balanceLimitEnd: Math.floor(Date.now() / 1000) + 86_400,
+      };
+      params.salt = explicitSalt;
+      const client = publicClient as PublicClient;
+
+      vi.mocked(client.readContract).mockResolvedValue(mockPoolAddress);
+      const receipt = createMockTransactionReceiptWithCreateEvent();
+      vi.mocked(walletClient.writeContract).mockResolvedValue(
+        receipt.transactionHash,
+      );
+      vi.mocked(client.waitForTransactionReceipt).mockResolvedValue(
+        receipt,
+      );
+
+      const simulation = await factory.simulateCreateMulticurve(params);
+      const initialCreateCall = vi
+        .mocked(client.simulateContract)
+        .mock.calls.find(([call]) => call.functionName === 'create')?.[0];
+      const initialCreateParams = getRecordedCreateParams(initialCreateCall);
+
+      expect(initialCreateParams.salt).toBe(explicitSalt);
+      expect(simulation.createParams.salt).toBe(explicitSalt);
+      expect(simulation.createParams.tokenFactoryData).not.toBe(
+        initialCreateParams.tokenFactoryData,
+      );
+
+      await simulation.execute();
+
+      const createCalls = vi
+        .mocked(client.simulateContract)
+        .mock.calls.filter(([call]) => call.functionName === 'create');
+      const executeCreateParams = getRecordedCreateParams(createCalls[1]?.[0]);
+      const submittedCreateParams = getRecordedCreateParams(
+        vi.mocked(walletClient.writeContract).mock.calls[0]?.[0],
+      );
+
+      expect(createCalls).toHaveLength(2);
+      expect(executeCreateParams.salt).toBe(explicitSalt);
+      expect(submittedCreateParams.salt).toBe(explicitSalt);
+      expect(executeCreateParams).toEqual(simulation.createParams);
+      expect(submittedCreateParams).toEqual(simulation.createParams);
     });
 
     it('uses LTS token and multicurve initializer defaults', () => {


### PR DESCRIPTION
This PR introduces the capability to manually specify salts, rather than the SDK nondeterministically generating new ones with each request. This is important for integrators who run simulations prior to execution, and need more determinism.