### PR TITLE
feat: add prepareCreateMulticurve utility

### DIFF
--- a/examples/.env.example
+++ b/examples/.env.example
@@ -25,6 +25,9 @@ RPC_URL=https://mainnet.base.org
 # Alternative RPC endpoints:
 # Base Sepolia Testnet
 # RPC_URL=https://sepolia.base.org
+# Required opt-in for examples/multicurve-custom-executor.ts to broadcast.
+# Without this exact value, the example prepares but does not submit.
+# EXECUTE_TRANSACTION=true
 
 # Ethereum Sepolia (used by examples/multicurve-scheduled-eth-sepolia.ts)
 # ETH_SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY

--- a/examples/README.md
+++ b/examples/README.md
@@ -104,6 +104,10 @@ Create and simulate a Base multicurve launch using the default DopplerERC20V1 an
 
 Build a Base multicurve configuration using the `dopplerERC20V1` token template, standard governance, and per-allocation vesting schedules. Includes multiple unique vesting schedules and one recipient with two vesting allocations on different schedules.
 
+### 12e. [Wallet-Independent Multicurve External Executor](./multicurve-custom-executor.ts)
+
+Prepare an exact unsigned Base Sepolia DopplerERC20V1/Rehype/no-op multicurve create with a public-client-only SDK, then submit it through a separately owned wallet client and verify the mined Airlock receipt. Set a Base Sepolia `RPC_URL` and funded `PRIVATE_KEY`; add `EXECUTE_TRANSACTION=true` to broadcast. Without that explicit opt-in, the example prepares and prints predictions but does not submit. The application remains responsible for signer authorization, nonce allocation, signed-transaction persistence, retries, replacements, and confirmation policy.
+
 ### 13. [Multicurve Vanity Launch (Market Cap)](./multicurve-vanity-by-marketcap.ts)
 
 Create a multicurve pool and mine a salt so the deployed token address ends with a chosen hex suffix (identifier). Launches on-chain (requires RPC + PRIVATE_KEY).

--- a/examples/README.md
+++ b/examples/README.md
@@ -106,7 +106,7 @@ Build a Base multicurve configuration using the `dopplerERC20V1` token template,
 
 ### 12e. [Wallet-Independent Multicurve External Executor](./multicurve-custom-executor.ts)
 
-Prepare an exact unsigned Base Sepolia DopplerERC20V1/Rehype/no-op multicurve create with a public-client-only SDK, then submit it through a separately owned wallet client and verify the mined Airlock receipt. Set a Base Sepolia `RPC_URL` and funded `PRIVATE_KEY`; add `EXECUTE_TRANSACTION=true` to broadcast. Without that explicit opt-in, the example prepares and prints predictions but does not submit. The application remains responsible for signer authorization, nonce allocation, signed-transaction persistence, retries, replacements, and confirmation policy.
+Prepare an exact unsigned Base Sepolia DopplerERC20V1/Rehype/no-op multicurve create with a public-client-only SDK, then submit it through a separately owned wallet client. The example uses `verifyPreparedCreateExecution()` to perform the receipt checks and retrieve the mined transaction to verify its exact input and value; integrators that only have a receipt can instead use synchronous `verifyPreparedCreateReceipt()`. Set a Base Sepolia `RPC_URL` and funded `PRIVATE_KEY`; add `EXECUTE_TRANSACTION=true` to broadcast. Without that explicit opt-in, the example prepares and prints predictions but does not submit. The application remains responsible for signer authorization, nonce allocation, signed-transaction persistence, retries, replacements, and confirmation policy.
 
 ### 13. [Multicurve Vanity Launch (Market Cap)](./multicurve-vanity-by-marketcap.ts)
 

--- a/examples/multicurve-custom-executor.ts
+++ b/examples/multicurve-custom-executor.ts
@@ -1,0 +1,156 @@
+import './env';
+
+import { randomBytes } from 'node:crypto';
+import {
+  CHAIN_IDS,
+  DopplerSDK,
+  WAD,
+  getAddresses,
+  verifyPreparedCreateReceipt,
+} from '../src/evm';
+import { createPublicClient, createWalletClient, http, toHex } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { baseSepolia } from 'viem/chains';
+
+const rpcUrl = process.env.RPC_URL;
+const privateKey = process.env.PRIVATE_KEY as `0x${string}` | undefined;
+const shouldExecute = process.env.EXECUTE_TRANSACTION === 'true';
+
+if (!rpcUrl) throw new Error('RPC_URL must be set to a Base Sepolia endpoint');
+if (!privateKey) throw new Error('PRIVATE_KEY must be set');
+
+async function main(): Promise<void> {
+  const account = privateKeyToAccount(privateKey);
+  const publicClient = createPublicClient({
+    chain: baseSepolia,
+    transport: http(rpcUrl),
+  });
+  const rpcChainId = await publicClient.getChainId();
+  if (rpcChainId !== CHAIN_IDS.BASE_SEPOLIA) {
+    throw new Error(
+      `Expected Base Sepolia chain ${CHAIN_IDS.BASE_SEPOLIA}, received ${rpcChainId}`,
+    );
+  }
+
+  const addresses = getAddresses(CHAIN_IDS.BASE_SEPOLIA);
+  const rehypeHook = addresses.rehypeDopplerHookInitializer;
+  if (!rehypeHook) {
+    throw new Error('Base Sepolia Rehype hook address is required');
+  }
+
+  const sdk = new DopplerSDK({
+    publicClient,
+    chainId: CHAIN_IDS.BASE_SEPOLIA,
+  });
+  const protocolBeneficiary = await sdk.getAirlockBeneficiary(WAD / 10n);
+  const salt = toHex(randomBytes(32));
+  const params = sdk
+    .buildMulticurveAuction()
+    .tokenConfig({
+      name: 'External Executor Rehype Token',
+      symbol: 'EERT',
+      tokenURI: 'ipfs://external-executor-rehype-token',
+    })
+    .saleConfig({
+      initialSupply: 1_000_000_000n * WAD,
+      numTokensToSell: 1_000_000_000n * WAD,
+      numeraire: addresses.weth,
+    })
+    .poolConfig({
+      fee: 0,
+      tickSpacing: 8,
+      curves: Array.from({ length: 10 }, (_, index) => ({
+        tickLower: index * 16_000,
+        tickUpper: 240_000,
+        numPositions: 10,
+        shares: WAD / 10n,
+      })),
+      beneficiaries: [
+        protocolBeneficiary,
+        { beneficiary: account.address, shares: (WAD * 9n) / 10n },
+      ],
+    })
+    .withRehypeDopplerHookInitializer({
+      hookAddress: rehypeHook,
+      buybackDestination: account.address,
+      startFee: 3000,
+      endFee: 3000,
+      durationSeconds: 0,
+      feeRoutingMode: 0,
+      feeDistributionInfo: {
+        assetFeesToAssetBuybackWad: WAD / 4n,
+        assetFeesToNumeraireBuybackWad: WAD / 4n,
+        assetFeesToBeneficiaryWad: WAD / 4n,
+        assetFeesToLpWad: WAD / 4n,
+        numeraireFeesToAssetBuybackWad: WAD / 4n,
+        numeraireFeesToNumeraireBuybackWad: WAD / 4n,
+        numeraireFeesToBeneficiaryWad: WAD / 4n,
+        numeraireFeesToLpWad: WAD / 4n,
+      },
+      farTick: 200_000,
+    })
+    .withMigration({ type: 'noOp' })
+    .withUserAddress(account.address)
+    .withSalt(salt)
+    .build();
+
+  const prepared = await sdk.factory.prepareCreateMulticurve(params, {
+    account: account.address,
+  });
+  console.log('Prepared Airlock:', prepared.airlock);
+  console.log('Prepared sender:', prepared.account);
+  console.log('Predicted token:', prepared.prediction.tokenAddress);
+  console.log('Predicted pool or hook:', prepared.prediction.poolOrHookAddress);
+  console.log('Predicted pool ID:', prepared.prediction.poolId);
+  console.log('Gas status:', prepared.gasEstimate.status);
+
+  if (!shouldExecute) {
+    console.log(
+      'Transaction not broadcast. Set EXECUTE_TRANSACTION=true to submit it.',
+    );
+    return;
+  }
+
+  const walletClient = createWalletClient({
+    chain: baseSepolia,
+    transport: http(rpcUrl),
+    account,
+  });
+  const hash = await walletClient.sendTransaction({
+    account,
+    chain: baseSepolia,
+    ...prepared.transaction,
+    ...(prepared.gasEstimate.status === 'estimated'
+      ? { gas: prepared.gasEstimate.gas }
+      : {}),
+  });
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+  const verified = verifyPreparedCreateReceipt({ prepared, receipt });
+
+  console.log('Transaction hash:', receipt.transactionHash);
+  console.log('Block number:', receipt.blockNumber.toString());
+  console.log('Receipt token:', verified.receiptIdentity.tokenAddress);
+  console.log(
+    'Receipt pool or hook:',
+    verified.receiptIdentity.poolOrHookAddress,
+  );
+  console.log(
+    'Prepared governance:',
+    verified.preparedIdentity.governanceAddress,
+  );
+  console.log('Prepared timelock:', verified.preparedIdentity.timelockAddress);
+  console.log(
+    'Prepared migration pool:',
+    verified.preparedIdentity.migrationPoolAddress,
+  );
+  console.log('Prepared pool ID:', verified.preparedIdentity.poolId);
+  console.log(
+    'Prepared token is currency0:',
+    verified.preparedIdentity.tokenIsCurrency0,
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : 'Unknown error');
+  process.exit(1);
+});

--- a/examples/multicurve-custom-executor.ts
+++ b/examples/multicurve-custom-executor.ts
@@ -6,7 +6,7 @@ import {
   DopplerSDK,
   WAD,
   getAddresses,
-  verifyPreparedCreateReceipt,
+  verifyPreparedCreateExecution,
 } from '../src/evm';
 import { createPublicClient, createWalletClient, http, toHex } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -18,9 +18,9 @@ const shouldExecute = process.env.EXECUTE_TRANSACTION === 'true';
 
 if (!rpcUrl) throw new Error('RPC_URL must be set to a Base Sepolia endpoint');
 if (!privateKey) throw new Error('PRIVATE_KEY must be set');
+const account = privateKeyToAccount(privateKey);
 
 async function main(): Promise<void> {
-  const account = privateKeyToAccount(privateKey);
   const publicClient = createPublicClient({
     chain: baseSepolia,
     transport: http(rpcUrl),
@@ -125,7 +125,13 @@ async function main(): Promise<void> {
       : {}),
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash });
-  const verified = verifyPreparedCreateReceipt({ prepared, receipt });
+  // The execution verifier includes receipt checks and also retrieves the
+  // mined transaction to confirm its exact input and value.
+  const verified = await verifyPreparedCreateExecution({
+    prepared,
+    receipt,
+    publicClient,
+  });
 
   console.log('Transaction hash:', receipt.transactionHash);
   console.log('Block number:', receipt.blockNumber.toString());

--- a/src/evm/entities/DopplerFactory.ts
+++ b/src/evm/entities/DopplerFactory.ts
@@ -1,4 +1,7 @@
 import {
+  BaseError,
+  ContractFunctionRevertedError,
+  ExecutionRevertedError,
   type Address,
   type Hex,
   type Hash,
@@ -6,6 +9,7 @@ import {
   type WalletClient,
   type Account,
   encodeAbiParameters,
+  encodeFunctionData,
   encodePacked,
   keccak256,
   getAddress,
@@ -41,6 +45,12 @@ import type {
   GovernanceOption,
   ProceedsSplitConfig,
   StreamableFeesConfig,
+} from '../types';
+import type {
+  MulticurveCreateGasEstimate,
+  MulticurveCreatePrediction,
+  PrepareCreateMulticurveOptions,
+  PreparedMulticurveCreate,
 } from '../types';
 import type { ModuleAddressOverrides } from '../types';
 import { assertTokenConfigSupportsYearlyMintRate } from '../builders/shared';
@@ -80,6 +90,7 @@ import {
   MIN_TICK,
   MAX_TICK,
   isToken0Expected,
+  parseAirlockCreateReceipt,
   sortBeneficiaries,
   encodeRehypeDopplerHookInitializerData,
   normalizeRehypeDopplerHookInitializerConfig,
@@ -147,6 +158,11 @@ type ResolvedMulticurveInitializerMode =
     };
 
 type StandardTokenFactoryMode = 'legacy' | 'v2';
+
+type InternalCreateGasEstimate =
+  | { status: 'estimated'; gas: bigint }
+  | { status: 'unavailable' }
+  | { status: 'reverted'; error: unknown };
 type TokenFactoryVariant =
   | 'standard'
   | 'standard-v2'
@@ -3701,38 +3717,71 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     throw new Error('Unable to mine opening auction salt');
   }
 
+  private isCreateGasRevert(error: unknown): boolean {
+    if (
+      error instanceof ContractFunctionRevertedError ||
+      error instanceof ExecutionRevertedError
+    ) {
+      return true;
+    }
+    if (!(error instanceof BaseError)) return false;
+
+    return Boolean(
+      error.walk(
+        (cause) =>
+          cause instanceof ContractFunctionRevertedError ||
+          cause instanceof ExecutionRevertedError,
+      ),
+    );
+  }
+
+  private async resolveInternalCreateGasEstimate(args: {
+    request?: unknown;
+    address: Address;
+    createParams: CreateParams;
+    account?: Address | Account;
+  }): Promise<InternalCreateGasEstimate> {
+    const { request, address, createParams, account } = args;
+    let gasFromRequest: bigint | undefined;
+    if (
+      request &&
+      typeof request === 'object' &&
+      'gas' in request &&
+      typeof request.gas === 'bigint'
+    ) {
+      gasFromRequest = request.gas;
+    }
+
+    if (gasFromRequest !== undefined) {
+      return { status: 'estimated', gas: gasFromRequest };
+    }
+
+    try {
+      const gas = await (this.publicClient as PublicClient).estimateContractGas(
+        {
+          address,
+          abi: airlockAbi,
+          functionName: 'create',
+          args: [{ ...createParams }],
+          account,
+        },
+      );
+      return { status: 'estimated', gas };
+    } catch (error) {
+      return this.isCreateGasRevert(error)
+        ? { status: 'reverted', error }
+        : { status: 'unavailable' };
+    }
+  }
+
   private async resolveCreateGasEstimate(args: {
     request?: unknown;
     address: Address;
     createParams: CreateParams;
     account?: Address | Account;
   }): Promise<bigint | undefined> {
-    const { request, address, createParams, account } = args;
-    const gasFromRequest =
-      request &&
-      typeof request === 'object' &&
-      'gas' in (request as Record<string, unknown>)
-        ? (request as { gas?: bigint }).gas
-        : undefined;
-
-    if (gasFromRequest) {
-      return gasFromRequest;
-    }
-
-    try {
-      const estimated = await (
-        this.publicClient as PublicClient
-      ).estimateContractGas({
-        address,
-        abi: airlockAbi,
-        functionName: 'create',
-        args: [{ ...createParams }],
-        account,
-      });
-      return estimated;
-    } catch {
-      return undefined;
-    }
+    const estimate = await this.resolveInternalCreateGasEstimate(args);
+    return estimate.status === 'estimated' ? estimate.gas : undefined;
   }
 
   private isDoppler404Token(
@@ -4690,6 +4739,133 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     return createParams;
   }
 
+  private async resolveFinalMulticurveCreate(args: {
+    params: CreateMulticurveParams<C>;
+    simulationAccount?: Address | Account;
+    createParams?: CreateParams;
+  }) {
+    const { params, simulationAccount } = args;
+    const addresses = getAddresses(this.chainId);
+    const airlock = params.modules?.airlock ?? addresses.airlock;
+    const initialCreateParams =
+      args.createParams ?? this.encodeCreateMulticurveParams(params);
+    const initialSimulation = await (
+      this.publicClient as PublicClient
+    ).simulateContract({
+      address: airlock,
+      abi: airlockAbi,
+      functionName: 'create',
+      args: [{ ...initialCreateParams }],
+      account: simulationAccount,
+    });
+    const initialResult = initialSimulation.result as
+      | readonly unknown[]
+      | undefined;
+    if (
+      !initialResult ||
+      !Array.isArray(initialResult) ||
+      initialResult.length < 5
+    ) {
+      throw new Error('Failed to simulate multicurve create');
+    }
+
+    let createParams = initialCreateParams;
+    let request = initialSimulation.request;
+    let result = initialResult;
+    if (!args.createParams) {
+      const enrichedCreateParams =
+        this.withSimulationGovernanceTimelockExclusion({
+          createParams,
+          simResult: initialResult,
+          token: params.token,
+          governance: params.governance,
+          modules: params.modules,
+          addresses,
+        });
+
+      if (
+        enrichedCreateParams.tokenFactoryData !== createParams.tokenFactoryData
+      ) {
+        createParams = enrichedCreateParams;
+        const finalSimulation = await (
+          this.publicClient as PublicClient
+        ).simulateContract({
+          address: airlock,
+          abi: airlockAbi,
+          functionName: 'create',
+          args: [{ ...createParams }],
+          account: simulationAccount,
+        });
+        const finalResult = finalSimulation.result as
+          | readonly unknown[]
+          | undefined;
+        if (
+          !finalResult ||
+          !Array.isArray(finalResult) ||
+          finalResult.length < 5
+        ) {
+          throw new Error('Failed to simulate enriched multicurve create');
+        }
+        request = finalSimulation.request;
+        result = finalResult;
+      }
+    }
+
+    const tokenAddress = result[0] as Address;
+    const poolIdentity = await this.computeMulticurvePoolIdentity(
+      params,
+      tokenAddress,
+    );
+    const prediction: MulticurveCreatePrediction = {
+      tokenAddress,
+      poolOrHookAddress: result[1] as Address,
+      governanceAddress: result[2] as Address,
+      timelockAddress: result[3] as Address,
+      migrationPoolAddress: result[4] as Address,
+      ...poolIdentity,
+    };
+
+    return { airlock, createParams, prediction, request };
+  }
+
+  async prepareCreateMulticurve(
+    params: CreateMulticurveParams<C>,
+    options: PrepareCreateMulticurveOptions,
+  ): Promise<PreparedMulticurveCreate<C>> {
+    const resolved = await this.resolveFinalMulticurveCreate({
+      params,
+      simulationAccount: options.account,
+    });
+    const internalGasEstimate = await this.resolveInternalCreateGasEstimate({
+      request: resolved.request,
+      address: resolved.airlock,
+      createParams: resolved.createParams,
+      account: options.account,
+    });
+    if (internalGasEstimate.status === 'reverted') {
+      throw internalGasEstimate.error;
+    }
+    const gasEstimate: MulticurveCreateGasEstimate = internalGasEstimate;
+
+    return {
+      chainId: this.chainId,
+      account: options.account,
+      airlock: resolved.airlock,
+      createParams: resolved.createParams,
+      prediction: resolved.prediction,
+      transaction: {
+        to: resolved.airlock,
+        data: encodeFunctionData({
+          abi: airlockAbi,
+          functionName: 'create',
+          args: [{ ...resolved.createParams }],
+        }),
+        value: 0n,
+      },
+      gasEstimate,
+    };
+  }
+
   async simulateCreateMulticurve(params: CreateMulticurveParams<C>): Promise<{
     createParams: CreateParams;
     tokenAddress: Address;
@@ -4702,51 +4878,25 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       transactionHash: string;
     }>;
   }> {
-    const addresses = getAddresses(this.chainId);
-    const createParams = this.encodeCreateMulticurveParams(params);
-    const airlockAddress = params.modules?.airlock ?? addresses.airlock;
-    const { request, result } = await (
-      this.publicClient as PublicClient
-    ).simulateContract({
-      address: airlockAddress,
-      abi: airlockAbi,
-      functionName: 'create',
-      args: [{ ...createParams }],
-      account: this.walletClient?.account,
+    const resolved = await this.resolveFinalMulticurveCreate({
+      params,
+      simulationAccount: this.walletClient?.account,
     });
-    const simResult = result as readonly unknown[] | undefined;
     const gasEstimate = await this.resolveCreateGasEstimate({
-      request,
-      address: airlockAddress,
-      createParams,
+      request: resolved.request,
+      address: resolved.airlock,
+      createParams: resolved.createParams,
       account: this.walletClient?.account ?? params.userAddress,
     });
-    if (!simResult || !Array.isArray(simResult) || simResult.length < 2) {
-      throw new Error('Failed to simulate multicurve create');
-    }
-
-    // simResult[0] is "asset" in contract terminology, we call it tokenAddress for SDK consistency
-    const tokenAddress = simResult[0] as Address;
-    const poolId = await this.computeMulticurvePoolId(params, tokenAddress);
-
-    const createParamsWithTimelock =
-      this.withSimulationGovernanceTimelockExclusion({
-        createParams,
-        simResult,
-        token: params.token,
-        governance: params.governance,
-        modules: params.modules,
-        addresses,
-      });
 
     return {
-      createParams: createParamsWithTimelock,
-      tokenAddress,
-      poolId,
+      createParams: resolved.createParams,
+      tokenAddress: resolved.prediction.tokenAddress,
+      poolId: resolved.prediction.poolId,
       gasEstimate,
       execute: () =>
         this.createMulticurve(params, {
-          _createParams: createParamsWithTimelock,
+          _createParams: resolved.createParams,
         }),
     };
   }
@@ -4755,65 +4905,54 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
     params: CreateMulticurveParams<C>,
     options?: { _createParams?: CreateParams },
   ): Promise<{ tokenAddress: Address; poolId: Hex; transactionHash: string }> {
-    const addresses = getAddresses(this.chainId);
-    if (!this.walletClient)
+    if (!this.walletClient) {
       throw new Error('Wallet client required for write operations');
+    }
 
-    // Use provided createParams (from simulate) or auto-simulate to get consistent params
-    const createParams =
-      options?._createParams ??
-      (await this.simulateCreateMulticurve(params)).createParams;
-    const airlockAddress = params.modules?.airlock ?? addresses.airlock;
-    const { request, result } = await (
-      this.publicClient as PublicClient
-    ).simulateContract({
-      address: airlockAddress,
-      abi: airlockAbi,
-      functionName: 'create',
-      args: [{ ...createParams }],
-      account: this.walletClient.account,
+    const resolved = await this.resolveFinalMulticurveCreate({
+      params,
+      simulationAccount: this.walletClient.account,
+      createParams: options?._createParams,
     });
-    const simResult = result as readonly unknown[] | undefined;
     const gasEstimate = await this.resolveCreateGasEstimate({
-      request,
-      address: airlockAddress,
-      createParams,
+      request: resolved.request,
+      address: resolved.airlock,
+      createParams: resolved.createParams,
       account: this.walletClient.account,
     });
     const gas = params.gas ?? gasEstimate ?? DEFAULT_CREATE_GAS_LIMIT;
-    const hash = await this.walletClient.writeContract({ ...request, gas });
+    const hash = await this.walletClient.writeContract({
+      ...resolved.request,
+      gas,
+    });
     const receipt = await (
       this.publicClient as PublicClient
     ).waitForTransactionReceipt({ hash, confirmations: 2 });
-
-    // Always extract actual addresses from event logs (source of truth)
-    const actualAddresses = this.extractAddressesFromCreateEvent(receipt);
-
-    if (!actualAddresses) {
+    const createResult = parseAirlockCreateReceipt({
+      receipt,
+      expectedAirlock: resolved.airlock,
+    });
+    if (!createResult) {
       throw new Error(
         'Failed to extract token address from Create event in transaction logs',
       );
     }
 
-    const actualTokenAddress = actualAddresses.tokenAddress;
-
-    // Warn if simulation predicted different address (helps debugging state divergence)
-    if (simResult && Array.isArray(simResult) && simResult.length >= 1) {
-      const simulatedToken = simResult[0] as Address;
-      if (simulatedToken.toLowerCase() !== actualTokenAddress.toLowerCase()) {
-        console.warn(
-          `[DopplerSDK] Simulation predicted token ${simulatedToken} but actual is ${actualTokenAddress}. ` +
-            `This may indicate state divergence between simulation and execution.`,
-        );
-      }
+    const actualTokenAddress = createResult.tokenAddress;
+    if (
+      resolved.prediction.tokenAddress.toLowerCase() !==
+      actualTokenAddress.toLowerCase()
+    ) {
+      console.warn(
+        `[DopplerSDK] Simulation predicted token ${resolved.prediction.tokenAddress} but actual is ${actualTokenAddress}. ` +
+          `This may indicate state divergence between simulation and execution.`,
+      );
     }
 
-    // Compute poolId from the PoolKey using actual token address
-    const poolId = await this.computeMulticurvePoolId(
+    const { poolId } = await this.computeMulticurvePoolIdentity(
       params,
       actualTokenAddress,
     );
-
     return { tokenAddress: actualTokenAddress, poolId, transactionHash: hash };
   }
 
@@ -6395,20 +6534,24 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
   }
 
   /**
-   * Compute the V4 poolId for a multicurve pool from the same pool-key fields
-   * the initializer will register on-chain.
+   * Compute the complete V4 multicurve pool identity from the same pool-key
+   * fields the initializer will register on-chain.
    */
-  private async computeMulticurvePoolId(
+  private async computeMulticurvePoolIdentity(
     params: CreateMulticurveParams<C>,
     tokenAddress: Address,
-  ): Promise<Hex> {
+  ): Promise<{
+    poolKey: V4PoolKey;
+    poolId: Hex;
+    tokenIsCurrency0: boolean;
+  }> {
     const addresses = getAddresses(this.chainId);
-
     const initializerMode = this.resolveMulticurveInitializerMode(params);
     let hookAddress: Address;
+
     if (initializerMode.type === 'rehype') {
       // DopplerHookInitializer pools are registered on Uniswap with the
-      // initializer itself as poolKey.hooks. The rehype hook lives separately
+      // initializer itself as poolKey.hooks. The Rehype hook lives separately
       // in the encoded init payload and is not part of the Uniswap pool key.
       hookAddress =
         params.modules?.dopplerHookInitializer ??
@@ -6441,7 +6584,6 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
         throw new Error('Multicurve initializer address not configured');
       }
 
-      // Standard/scheduled/decay initializers expose HOOK() directly.
       hookAddress = (await (this.publicClient as PublicClient).readContract({
         address: initializerAddress,
         abi: v4MulticurveInitializerAbi,
@@ -6449,24 +6591,25 @@ export class DopplerFactory<C extends SupportedChainId = SupportedChainId> {
       })) as Address;
     }
 
-    // Construct the pool key and compute poolId
     const numeraire = params.sale.numeraire;
     const tokenIsCurrency0 = BigInt(tokenAddress) < BigInt(numeraire);
-    const currency0 = tokenIsCurrency0 ? tokenAddress : numeraire;
-    const currency1 = tokenIsCurrency0 ? numeraire : tokenAddress;
-    const fee =
-      initializerMode.type === 'decay' ||
-      (initializerMode.type === 'rehype' && initializerMode.hookConfig)
-        ? DYNAMIC_FEE_FLAG
-        : params.pool.fee;
-
-    return this.computePoolId({
-      currency0,
-      currency1,
-      fee,
+    const poolKey: V4PoolKey = {
+      currency0: tokenIsCurrency0 ? tokenAddress : numeraire,
+      currency1: tokenIsCurrency0 ? numeraire : tokenAddress,
+      fee:
+        initializerMode.type === 'decay' ||
+        (initializerMode.type === 'rehype' && initializerMode.hookConfig)
+          ? DYNAMIC_FEE_FLAG
+          : params.pool.fee,
       tickSpacing: params.pool.tickSpacing,
       hooks: hookAddress,
-    }) as Hex;
+    };
+
+    return {
+      poolKey,
+      poolId: this.computePoolId(poolKey) as Hex,
+      tokenIsCurrency0,
+    };
   }
 
   private async ensureMulticurveBundlerSupport(

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -154,7 +154,10 @@ export type {
   OpeningAuctionState,
   OpeningAuctionCreateResult,
   OpeningAuctionCompleteResult,
-
+  PrepareCreateMulticurveOptions,
+  MulticurveCreateGasEstimate,
+  MulticurveCreatePrediction,
+  PreparedMulticurveCreate,
   // Configuration types
   DopplerSDKConfig,
 

--- a/src/evm/types.ts
+++ b/src/evm/types.ts
@@ -1149,6 +1149,41 @@ export interface CreateParams {
   salt: `0x${string}`;
 }
 
+export interface PrepareCreateMulticurveOptions {
+  account: Address;
+}
+
+export type MulticurveCreateGasEstimate =
+  | { status: 'estimated'; gas: bigint }
+  | { status: 'unavailable' };
+
+export interface MulticurveCreatePrediction {
+  tokenAddress: Address;
+  poolOrHookAddress: Address;
+  governanceAddress: Address;
+  timelockAddress: Address;
+  migrationPoolAddress: Address;
+  poolKey: V4PoolKey;
+  poolId: Hex;
+  tokenIsCurrency0: boolean;
+}
+
+export interface PreparedMulticurveCreate<
+  C extends SupportedChainId = SupportedChainId,
+> {
+  chainId: C;
+  account: Address;
+  airlock: Address;
+  createParams: CreateParams;
+  prediction: MulticurveCreatePrediction;
+  transaction: {
+    to: Address;
+    data: Hex;
+    value: 0n;
+  };
+  gasEstimate: MulticurveCreateGasEstimate;
+}
+
 // Optional per-call module address overrides. When provided, these take precedence
 // over chain defaults resolved via getAddresses(chainId).
 export interface ModuleAddressOverrides {

--- a/src/evm/utils/airlockCreateReceipt.ts
+++ b/src/evm/utils/airlockCreateReceipt.ts
@@ -1,7 +1,9 @@
 import {
   decodeEventLog,
+  keccak256,
   type Address,
   type Hash,
+  type Hex,
   type TransactionReceipt,
 } from 'viem';
 import { airlockAbi } from '../abis';
@@ -36,7 +38,10 @@ export type AirlockCreateReceiptErrorCode =
   | 'TOKEN_MISMATCH'
   | 'NUMERAIRE_MISMATCH'
   | 'INITIALIZER_MISMATCH'
-  | 'POOL_OR_HOOK_MISMATCH';
+  | 'POOL_OR_HOOK_MISMATCH'
+  | 'TRANSACTION_HASH_MISMATCH'
+  | 'TRANSACTION_INPUT_MISMATCH'
+  | 'TRANSACTION_VALUE_MISMATCH';
 
 export class AirlockCreateReceiptError extends Error {
   readonly code: AirlockCreateReceiptErrorCode;
@@ -151,6 +156,16 @@ export interface VerifiedMulticurveCreate<
   preparedIdentity: PreparedMulticurveIdentity<C>;
 }
 
+export type PreparedCreateTransactionClient = {
+  getTransaction(parameters: { hash: Hash }): Promise<{
+    hash: Hash;
+    from: Address;
+    to: Address | null;
+    input: Hex;
+    value: bigint;
+  }>;
+};
+
 function assertAddressMatch(
   code: AirlockCreateReceiptErrorCode,
   expected: Address,
@@ -161,6 +176,13 @@ function assertAddressMatch(
   }
 }
 
+/**
+ * Verifies only facts available in a mined receipt: success, sender, target,
+ * one matching Airlock Create event, and its emitted deployment identity.
+ *
+ * This synchronous check does not retrieve or verify the transaction input or
+ * value. Prepared-only predictions remain separate from receipt-derived facts.
+ */
 export function verifyPreparedCreateReceipt<C extends SupportedChainId>({
   prepared,
   receipt,
@@ -231,4 +253,65 @@ export function verifyPreparedCreateReceipt<C extends SupportedChainId>({
       tokenIsCurrency0: prepared.prediction.tokenIsCurrency0,
     },
   };
+}
+
+/**
+ * Performs the receipt checks in {@link verifyPreparedCreateReceipt}, then
+ * retrieves the mined transaction. Its hash must match the receipt, while its
+ * sender, target, input, and value must match the prepared unsigned transaction.
+ *
+ * This stronger check requires one additional RPC request. It proves that the
+ * prepared protocol call was mined, but does not turn simulation-only
+ * predictions into receipt-derived facts.
+ */
+export async function verifyPreparedCreateExecution<
+  C extends SupportedChainId,
+>({
+  prepared,
+  receipt,
+  publicClient,
+}: {
+  prepared: PreparedMulticurveCreate<C>;
+  receipt: TransactionReceipt;
+  publicClient: PreparedCreateTransactionClient;
+}): Promise<VerifiedMulticurveCreate<C>> {
+  const verified = verifyPreparedCreateReceipt({ prepared, receipt });
+  const transaction = await publicClient.getTransaction({
+    hash: receipt.transactionHash,
+  });
+
+  if (
+    transaction.hash.toLowerCase() !== receipt.transactionHash.toLowerCase()
+  ) {
+    throw new AirlockCreateReceiptError('TRANSACTION_HASH_MISMATCH', {
+      expected: receipt.transactionHash,
+      actual: transaction.hash,
+    });
+  }
+  assertAddressMatch(
+    'WRONG_TRANSACTION_TARGET',
+    prepared.transaction.to,
+    transaction.to,
+  );
+  assertAddressMatch(
+    'WRONG_TRANSACTION_SENDER',
+    prepared.account,
+    transaction.from,
+  );
+  if (
+    transaction.input.toLowerCase() !== prepared.transaction.data.toLowerCase()
+  ) {
+    throw new AirlockCreateReceiptError('TRANSACTION_INPUT_MISMATCH', {
+      expected: keccak256(prepared.transaction.data),
+      actual: keccak256(transaction.input),
+    });
+  }
+  if (transaction.value !== prepared.transaction.value) {
+    throw new AirlockCreateReceiptError('TRANSACTION_VALUE_MISMATCH', {
+      expected: prepared.transaction.value.toString(),
+      actual: transaction.value.toString(),
+    });
+  }
+
+  return verified;
 }

--- a/src/evm/utils/airlockCreateReceipt.ts
+++ b/src/evm/utils/airlockCreateReceipt.ts
@@ -1,0 +1,234 @@
+import {
+  decodeEventLog,
+  type Address,
+  type Hash,
+  type TransactionReceipt,
+} from 'viem';
+import { airlockAbi } from '../abis';
+import type {
+  PreparedMulticurveCreate,
+  SupportedChainId,
+  V4PoolKey,
+} from '../types';
+
+export interface ParseAirlockCreateReceiptParams {
+  receipt: TransactionReceipt;
+  expectedAirlock: Address;
+}
+
+export interface AirlockCreateResult {
+  airlock: Address;
+  tokenAddress: Address;
+  numeraire: Address;
+  initializer: Address;
+  poolOrHookAddress: Address;
+  transactionHash: Hash;
+  blockNumber: bigint;
+  logIndex: number;
+}
+
+export type AirlockCreateReceiptErrorCode =
+  | 'RECEIPT_FAILED'
+  | 'WRONG_TRANSACTION_TARGET'
+  | 'WRONG_TRANSACTION_SENDER'
+  | 'MISSING_CREATE_EVENT'
+  | 'MULTIPLE_CREATE_EVENTS'
+  | 'TOKEN_MISMATCH'
+  | 'NUMERAIRE_MISMATCH'
+  | 'INITIALIZER_MISMATCH'
+  | 'POOL_OR_HOOK_MISMATCH';
+
+export class AirlockCreateReceiptError extends Error {
+  readonly code: AirlockCreateReceiptErrorCode;
+  readonly expected?: string | number;
+  readonly actual?: string | number | null;
+
+  constructor(
+    code: AirlockCreateReceiptErrorCode,
+    options: {
+      expected?: string | number;
+      actual?: string | number | null;
+    } = {},
+  ) {
+    super(`Airlock Create receipt verification failed: ${code}`);
+    this.name = 'AirlockCreateReceiptError';
+    this.code = code;
+    this.expected = options.expected;
+    this.actual = options.actual;
+  }
+}
+
+type DecodedAirlockCreate = {
+  airlock: Address;
+  tokenAddress: Address;
+  numeraire: Address;
+  initializer: Address;
+  poolOrHookAddress: Address;
+  logIndex: number;
+};
+
+function addressesEqual(left: Address | null, right: Address): boolean {
+  return left?.toLowerCase() === right.toLowerCase();
+}
+
+function decodeAirlockCreateLogs(
+  receipt: TransactionReceipt,
+  expectedAirlock: Address,
+): DecodedAirlockCreate[] {
+  const matches: DecodedAirlockCreate[] = [];
+
+  for (const log of receipt.logs) {
+    if (!addressesEqual(log.address, expectedAirlock)) continue;
+
+    try {
+      const decoded = decodeEventLog({
+        abi: airlockAbi,
+        data: log.data,
+        topics: log.topics,
+        eventName: 'Create',
+      });
+      const args = decoded.args as {
+        asset: Address;
+        numeraire: Address;
+        initializer: Address;
+        poolOrHook: Address;
+      };
+      matches.push({
+        airlock: log.address,
+        tokenAddress: args.asset,
+        numeraire: args.numeraire,
+        initializer: args.initializer,
+        poolOrHookAddress: args.poolOrHook,
+        logIndex: log.logIndex,
+      });
+    } catch {
+      // Logs emitted by the expected contract but belonging to other events are
+      // intentionally ignored.
+    }
+  }
+
+  return matches;
+}
+
+export function parseAirlockCreateReceipt({
+  receipt,
+  expectedAirlock,
+}: ParseAirlockCreateReceiptParams): AirlockCreateResult | null {
+  const matches = decodeAirlockCreateLogs(receipt, expectedAirlock);
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    throw new AirlockCreateReceiptError('MULTIPLE_CREATE_EVENTS', {
+      expected: 1,
+      actual: matches.length,
+    });
+  }
+
+  return {
+    ...matches[0],
+    transactionHash: receipt.transactionHash,
+    blockNumber: receipt.blockNumber,
+  };
+}
+
+export interface PreparedMulticurveIdentity<
+  C extends SupportedChainId = SupportedChainId,
+> {
+  chainId: C;
+  tokenAddress: Address;
+  poolOrHookAddress: Address;
+  governanceAddress: Address;
+  timelockAddress: Address;
+  migrationPoolAddress: Address;
+  poolKey: V4PoolKey;
+  poolId: Hash;
+  tokenIsCurrency0: boolean;
+}
+
+export interface VerifiedMulticurveCreate<
+  C extends SupportedChainId = SupportedChainId,
+> {
+  receiptIdentity: AirlockCreateResult;
+  preparedIdentity: PreparedMulticurveIdentity<C>;
+}
+
+function assertAddressMatch(
+  code: AirlockCreateReceiptErrorCode,
+  expected: Address,
+  actual: Address | null,
+): void {
+  if (!addressesEqual(actual, expected)) {
+    throw new AirlockCreateReceiptError(code, { expected, actual });
+  }
+}
+
+export function verifyPreparedCreateReceipt<C extends SupportedChainId>({
+  prepared,
+  receipt,
+}: {
+  prepared: PreparedMulticurveCreate<C>;
+  receipt: TransactionReceipt;
+}): VerifiedMulticurveCreate<C> {
+  if (receipt.status !== 'success') {
+    throw new AirlockCreateReceiptError('RECEIPT_FAILED', {
+      expected: 'success',
+      actual: receipt.status,
+    });
+  }
+  assertAddressMatch(
+    'WRONG_TRANSACTION_TARGET',
+    prepared.transaction.to,
+    receipt.to,
+  );
+  assertAddressMatch(
+    'WRONG_TRANSACTION_SENDER',
+    prepared.account,
+    receipt.from,
+  );
+
+  const receiptIdentity = parseAirlockCreateReceipt({
+    receipt,
+    expectedAirlock: prepared.airlock,
+  });
+  if (!receiptIdentity) {
+    throw new AirlockCreateReceiptError('MISSING_CREATE_EVENT', {
+      expected: prepared.airlock,
+      actual: null,
+    });
+  }
+
+  assertAddressMatch(
+    'TOKEN_MISMATCH',
+    prepared.prediction.tokenAddress,
+    receiptIdentity.tokenAddress,
+  );
+  assertAddressMatch(
+    'NUMERAIRE_MISMATCH',
+    prepared.createParams.numeraire,
+    receiptIdentity.numeraire,
+  );
+  assertAddressMatch(
+    'INITIALIZER_MISMATCH',
+    prepared.createParams.poolInitializer,
+    receiptIdentity.initializer,
+  );
+  assertAddressMatch(
+    'POOL_OR_HOOK_MISMATCH',
+    prepared.prediction.poolOrHookAddress,
+    receiptIdentity.poolOrHookAddress,
+  );
+
+  return {
+    receiptIdentity,
+    preparedIdentity: {
+      chainId: prepared.chainId,
+      tokenAddress: prepared.prediction.tokenAddress,
+      poolOrHookAddress: prepared.prediction.poolOrHookAddress,
+      governanceAddress: prepared.prediction.governanceAddress,
+      timelockAddress: prepared.prediction.timelockAddress,
+      migrationPoolAddress: prepared.prediction.migrationPoolAddress,
+      poolKey: prepared.prediction.poolKey,
+      poolId: prepared.prediction.poolId,
+      tokenIsCurrency0: prepared.prediction.tokenIsCurrency0,
+    },
+  };
+}

--- a/src/evm/utils/index.ts
+++ b/src/evm/utils/index.ts
@@ -79,11 +79,13 @@ export {
   AirlockCreateReceiptError,
   parseAirlockCreateReceipt,
   verifyPreparedCreateReceipt,
+  verifyPreparedCreateExecution,
 } from './airlockCreateReceipt';
 export type {
   AirlockCreateReceiptErrorCode,
   AirlockCreateResult,
   ParseAirlockCreateReceiptParams,
+  PreparedCreateTransactionClient,
   PreparedMulticurveIdentity,
   VerifiedMulticurveCreate,
 } from './airlockCreateReceipt';

--- a/src/evm/utils/index.ts
+++ b/src/evm/utils/index.ts
@@ -75,6 +75,19 @@ export { encodeRehypeDopplerHookInitializerData } from './rehypeDopplerHookIniti
 
 export { encodeRehypeDopplerHookMigratorCalldata } from './dopplerHookMigrator';
 
+export {
+  AirlockCreateReceiptError,
+  parseAirlockCreateReceipt,
+  verifyPreparedCreateReceipt,
+} from './airlockCreateReceipt';
+export type {
+  AirlockCreateReceiptErrorCode,
+  AirlockCreateResult,
+  ParseAirlockCreateReceiptParams,
+  PreparedMulticurveIdentity,
+  VerifiedMulticurveCreate,
+} from './airlockCreateReceipt';
+
 // Re-export market cap conversion utilities
 export {
   // Core conversion functions (pure math)

--- a/test/evm/fork/base-sepolia/multicurve-prepare-rehype.base-sepolia.test.ts
+++ b/test/evm/fork/base-sepolia/multicurve-prepare-rehype.base-sepolia.test.ts
@@ -5,7 +5,7 @@ import {
   DopplerSDK,
   WAD,
   getAddresses,
-  verifyPreparedCreateReceipt,
+  verifyPreparedCreateExecution,
 } from '../../../../src/evm';
 import {
   getAnvilManager,
@@ -123,7 +123,11 @@ describe('prepared Rehype multicurve create (Base Sepolia fork)', () => {
       const receipt = await clients.publicClient.waitForTransactionReceipt({
         hash,
       });
-      const verified = verifyPreparedCreateReceipt({ prepared, receipt });
+      const verified = await verifyPreparedCreateExecution({
+        prepared,
+        receipt,
+        publicClient: clients.publicClient,
+      });
       console.log('Prepared Rehype fork transaction:', receipt.transactionHash);
 
       expect(verified.receiptIdentity.tokenAddress).toBe(

--- a/test/evm/fork/base-sepolia/multicurve-prepare-rehype.base-sepolia.test.ts
+++ b/test/evm/fork/base-sepolia/multicurve-prepare-rehype.base-sepolia.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { parseEther } from 'viem';
+import {
+  CHAIN_IDS,
+  DopplerSDK,
+  WAD,
+  getAddresses,
+  verifyPreparedCreateReceipt,
+} from '../../../../src/evm';
+import {
+  getAnvilManager,
+  getForkClients,
+  getRpcEnvVar,
+  hasRpcUrl,
+  isAnvilForkEnabled,
+  type ForkClients,
+} from '../../utils';
+
+const fixedSalt = `0x${'35'.repeat(32)}` as const;
+
+describe('prepared Rehype multicurve create (Base Sepolia fork)', () => {
+  if (!isAnvilForkEnabled()) {
+    it.skip('requires ANVIL_FORK_ENABLED=true');
+    return;
+  }
+  if (!hasRpcUrl(CHAIN_IDS.BASE_SEPOLIA)) {
+    it.skip(`requires ${getRpcEnvVar(CHAIN_IDS.BASE_SEPOLIA)} env var`);
+    return;
+  }
+
+  const chainId = CHAIN_IDS.BASE_SEPOLIA;
+  const addresses = getAddresses(chainId);
+  const anvilManager = getAnvilManager();
+  let clients: ForkClients;
+
+  beforeAll(async () => {
+    await anvilManager.start(chainId);
+    clients = getForkClients(chainId, 0, { timeout: 90_000 });
+  }, 90_000);
+
+  afterAll(async () => {
+    await anvilManager.stop(chainId);
+  });
+
+  it(
+    'broadcasts and verifies an externally submitted DopplerERC20V1 Rehype create',
+    { timeout: 120_000 },
+    async () => {
+      const dopplerHookInitializer = addresses.dopplerHookInitializer;
+      const rehypeHook = addresses.rehypeDopplerHookInitializer;
+      if (!dopplerHookInitializer || !rehypeHook) {
+        throw new Error(
+          'Base Sepolia Rehype and DopplerHook initializer addresses are required',
+        );
+      }
+
+      const sdk = new DopplerSDK({
+        publicClient: clients.publicClient,
+        chainId,
+      });
+      const protocolBeneficiary = await sdk.getAirlockBeneficiary(WAD / 10n);
+      const params = sdk
+        .buildMulticurveAuction()
+        .tokenConfig({
+          name: 'Prepared Rehype Fork Token',
+          symbol: 'PRFT',
+          tokenURI: 'ipfs://prepared-rehype-fork-token',
+        })
+        .saleConfig({
+          initialSupply: parseEther('1000000000'),
+          numTokensToSell: parseEther('1000000000'),
+          numeraire: addresses.weth,
+        })
+        .poolConfig({
+          fee: 0,
+          tickSpacing: 8,
+          curves: Array.from({ length: 10 }, (_, index) => ({
+            tickLower: index * 16_000,
+            tickUpper: 240_000,
+            numPositions: 10,
+            shares: WAD / 10n,
+          })),
+          beneficiaries: [
+            protocolBeneficiary,
+            { beneficiary: clients.account.address, shares: (WAD * 9n) / 10n },
+          ],
+        })
+        .withRehypeDopplerHookInitializer({
+          hookAddress: rehypeHook,
+          buybackDestination: clients.account.address,
+          startFee: 3000,
+          endFee: 3000,
+          durationSeconds: 0,
+          feeRoutingMode: 0,
+          feeDistributionInfo: {
+            assetFeesToAssetBuybackWad: WAD / 4n,
+            assetFeesToNumeraireBuybackWad: WAD / 4n,
+            assetFeesToBeneficiaryWad: WAD / 4n,
+            assetFeesToLpWad: WAD / 4n,
+            numeraireFeesToAssetBuybackWad: WAD / 4n,
+            numeraireFeesToNumeraireBuybackWad: WAD / 4n,
+            numeraireFeesToBeneficiaryWad: WAD / 4n,
+            numeraireFeesToLpWad: WAD / 4n,
+          },
+          farTick: 200_000,
+        })
+        .withMigration({ type: 'noOp' })
+        .withUserAddress(clients.account.address)
+        .withSalt(fixedSalt)
+        .build();
+
+      const prepared = await sdk.factory.prepareCreateMulticurve(params, {
+        account: clients.account.address,
+      });
+      const hash = await clients.walletClient.sendTransaction({
+        account: clients.account,
+        chain: clients.chain,
+        ...prepared.transaction,
+        ...(prepared.gasEstimate.status === 'estimated'
+          ? { gas: prepared.gasEstimate.gas }
+          : {}),
+      });
+      const receipt = await clients.publicClient.waitForTransactionReceipt({
+        hash,
+      });
+      const verified = verifyPreparedCreateReceipt({ prepared, receipt });
+      console.log('Prepared Rehype fork transaction:', receipt.transactionHash);
+
+      expect(verified.receiptIdentity.tokenAddress).toBe(
+        prepared.prediction.tokenAddress,
+      );
+      expect(verified.receiptIdentity.poolOrHookAddress).toBe(
+        prepared.prediction.poolOrHookAddress,
+      );
+      expect(verified.preparedIdentity.poolKey.hooks).toBe(
+        dopplerHookInitializer,
+      );
+      expect(verified.preparedIdentity.poolKey.hooks).not.toBe(rehypeHook);
+      expect(verified.preparedIdentity.poolId).toBe(prepared.prediction.poolId);
+      expect(verified.preparedIdentity.tokenIsCurrency0).toBe(
+        prepared.prediction.tokenIsCurrency0,
+      );
+      expect(verified).toHaveProperty('receiptIdentity');
+      expect(verified).toHaveProperty('preparedIdentity');
+    },
+  );
+});

--- a/test/evm/setup/fixtures/clients.ts
+++ b/test/evm/setup/fixtures/clients.ts
@@ -1,8 +1,7 @@
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { mainnet } from 'viem/chains';
 import { vi } from 'vitest';
-import type { Address, WalletClient } from 'viem';
-import type { SupportedPublicClient } from '../../../../src/evm/types';
+import type { Address, PublicClient, WalletClient } from 'viem';
 import {
   mockAddresses,
   mockGovernanceAddress,
@@ -13,8 +12,8 @@ import {
   mockV2PoolAddress,
 } from './addresses';
 
-type MockedPublicClient = Omit<
-  ReturnType<typeof createPublicClient>,
+export type MockedPublicClient = Omit<
+  PublicClient,
   | 'call'
   | 'estimateContractGas'
   | 'getBalance'
@@ -54,7 +53,7 @@ type MockSimulationCall = {
 };
 
 // Mock viem clients for testing
-export const createMockPublicClient = (): SupportedPublicClient => {
+export const createMockPublicClient = (): MockedPublicClient => {
   const defaultCreateResult: readonly Address[] = [
     mockTokenAddress,
     mockPoolAddress,

--- a/test/evm/unit/entities/DopplerFactory.prepareMulticurve.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.prepareMulticurve.test.ts
@@ -1,0 +1,415 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  decodeFunctionData,
+  encodeAbiParameters,
+  ExecutionRevertedError,
+  keccak256,
+  parseEther,
+  type Address,
+} from 'viem';
+import { airlockAbi } from '../../../../src/evm/abis';
+import { DEFAULT_CREATE_GAS_LIMIT, DYNAMIC_FEE_FLAG } from '../../../../src/evm/constants';
+import { DopplerFactory } from '../../../../src/evm/entities/DopplerFactory';
+import type { CreateMulticurveParams } from '../../../../src/evm/types';
+import type * as AddressesModule from '../../../../src/evm/addresses';
+import {
+  createMockPublicClient,
+  createMockTransactionReceiptWithCreateEvent,
+  createMockWalletClient,
+  type MockedPublicClient,
+} from '../../setup/fixtures/clients';
+import {
+  mockAddresses,
+  mockGovernanceAddress,
+  mockPoolAddress,
+  mockTimelockAddress,
+  mockTokenAddress,
+  mockV2PoolAddress,
+} from '../../setup/fixtures/addresses';
+
+vi.mock('../../../../src/evm/addresses', async (importOriginal) => {
+  const actual = await importOriginal<typeof AddressesModule>();
+  return {
+    ...actual,
+    getAddresses: vi.fn(() => mockAddresses),
+  };
+});
+
+const account = '0x1234567890123456789012345678901234567890' as Address;
+const explicitSalt = `0x${'11'.repeat(32)}` as const;
+
+function multicurveParams(): CreateMulticurveParams {
+  return {
+    token: {
+      type: 'standard',
+      name: 'Prepared Token',
+      symbol: 'PREP',
+      tokenURI: 'https://example.com/prepared-token',
+    },
+    sale: {
+      initialSupply: parseEther('1000000'),
+      numTokensToSell: parseEther('400000'),
+      numeraire: mockAddresses.weth,
+    },
+    pool: {
+      fee: 3000,
+      tickSpacing: 60,
+      curves: [
+        {
+          tickLower: -120000,
+          tickUpper: -60000,
+          numPositions: 8,
+          shares: parseEther('1'),
+        },
+      ],
+    },
+    initializer: { type: 'standard' },
+    governance: { type: 'default' },
+    migration: { type: 'uniswapV2' },
+    userAddress: account,
+    salt: explicitSalt,
+  };
+}
+
+function recordedAccount(call: unknown): unknown {
+  if (!call || typeof call !== 'object' || !('account' in call)) return undefined;
+  return call.account;
+}
+
+describe('DopplerFactory.prepareCreateMulticurve', () => {
+  let publicClient: MockedPublicClient;
+  let client: MockedPublicClient;
+
+  beforeEach(() => {
+    publicClient = createMockPublicClient();
+    client = publicClient;
+    vi.mocked(client.readContract).mockResolvedValue(mockPoolAddress);
+    vi.mocked(client.estimateContractGas).mockResolvedValue(500_000n);
+  });
+
+  it('prepares with only a public client and never reads a wallet account', async () => {
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+
+    const prepared = await factory.prepareCreateMulticurve(multicurveParams(), {
+      account,
+    });
+
+    expect(prepared.account).toBe(account);
+    expect(recordedAccount(vi.mocked(client.simulateContract).mock.calls[0][0])).toBe(
+      account,
+    );
+  });
+
+  it('returns calldata for the exact final params and complete transaction metadata', async () => {
+    const override = '0x9999999999999999999999999999999999999999' as Address;
+    const params = multicurveParams();
+    params.modules = { airlock: override };
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+
+    const prepared = await factory.prepareCreateMulticurve(params, { account });
+    const decoded = decodeFunctionData({
+      abi: airlockAbi,
+      data: prepared.transaction.data,
+    });
+
+    expect(decoded.functionName).toBe('create');
+    expect(decoded.args?.[0]).toEqual(prepared.createParams);
+    expect(prepared).toMatchObject({
+      chainId: 1,
+      account,
+      airlock: override,
+      transaction: { to: override, value: 0n },
+    });
+  });
+
+  it('selects a generated salt once and reuses it through enrichment', async () => {
+    const params = multicurveParams();
+    params.salt = undefined;
+    params.token = {
+      name: 'Limited Token',
+      symbol: 'LIMIT',
+      tokenURI: 'https://example.com/limited-token',
+      maxBalanceLimit: parseEther('10000'),
+      balanceLimitEnd: 2_000_000_000,
+    };
+    const firstPassResult = [
+      '0x1000000000000000000000000000000000000001',
+      '0x1000000000000000000000000000000000000002',
+      '0x1000000000000000000000000000000000000003',
+      '0x1000000000000000000000000000000000000004',
+      '0x1000000000000000000000000000000000000005',
+    ] as const satisfies readonly Address[];
+    vi.mocked(client.simulateContract).mockImplementationOnce(async (call) => ({
+      request: call,
+      result: firstPassResult,
+    }));
+    const entropy = vi
+      .spyOn(globalThis.crypto, 'getRandomValues')
+      .mockImplementation((array) => {
+        (array as Uint8Array).fill(7);
+        return array;
+      });
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+
+    try {
+      const prepared = await factory.prepareCreateMulticurve(params, { account });
+      const calls = vi.mocked(client.simulateContract).mock.calls;
+      const firstParams = calls[0][0].args?.[0];
+      const finalParams = calls[1][0].args?.[0];
+
+      expect(entropy).toHaveBeenCalledOnce();
+      expect(calls).toHaveLength(2);
+      expect(firstParams?.salt).toBe(prepared.createParams.salt);
+      expect(finalParams?.salt).toBe(prepared.createParams.salt);
+      expect(finalParams?.tokenFactoryData).toBe(
+        prepared.createParams.tokenFactoryData,
+      );
+      expect(firstParams?.tokenFactoryData).not.toBe(
+        prepared.createParams.tokenFactoryData,
+      );
+      expect(prepared.prediction).toMatchObject({
+        tokenAddress: mockTokenAddress,
+        poolOrHookAddress: mockPoolAddress,
+        governanceAddress: mockGovernanceAddress,
+        timelockAddress: mockTimelockAddress,
+        migrationPoolAddress: mockV2PoolAddress,
+      });
+      expect(prepared.prediction.tokenAddress).not.toBe(firstPassResult[0]);
+    } finally {
+      entropy.mockRestore();
+    }
+  });
+
+  it('maps every final Airlock output and derives the complete pool identity', async () => {
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+    const prepared = await factory.prepareCreateMulticurve(multicurveParams(), {
+      account,
+    });
+    const expectedPoolKey = {
+      currency0:
+        BigInt(mockTokenAddress) < BigInt(mockAddresses.weth)
+          ? mockTokenAddress
+          : mockAddresses.weth,
+      currency1:
+        BigInt(mockTokenAddress) < BigInt(mockAddresses.weth)
+          ? mockAddresses.weth
+          : mockTokenAddress,
+      fee: 3000,
+      tickSpacing: 60,
+      hooks: mockPoolAddress,
+    };
+
+    expect(prepared.prediction).toEqual({
+      tokenAddress: mockTokenAddress,
+      poolOrHookAddress: mockPoolAddress,
+      governanceAddress: mockGovernanceAddress,
+      timelockAddress: mockTimelockAddress,
+      migrationPoolAddress: mockV2PoolAddress,
+      poolKey: expectedPoolKey,
+      poolId: keccak256(
+        encodeAbiParameters(
+          [
+            { type: 'address' },
+            { type: 'address' },
+            { type: 'uint24' },
+            { type: 'int24' },
+            { type: 'address' },
+          ],
+          [
+            expectedPoolKey.currency0,
+            expectedPoolKey.currency1,
+            expectedPoolKey.fee,
+            expectedPoolKey.tickSpacing,
+            expectedPoolKey.hooks,
+          ],
+        ),
+      ),
+      tokenIsCurrency0:
+        BigInt(mockTokenAddress) < BigInt(mockAddresses.weth),
+    });
+  });
+
+  it.each([
+    ['standard', { type: 'standard' } as const, 3000],
+    ['scheduled', { type: 'scheduled', startTime: 2_000_000_000 } as const, 3000],
+    [
+      'decay',
+      {
+        type: 'decay',
+        startTime: 2_000_000_000,
+        startFee: 10_000,
+        durationSeconds: 3600,
+      } as const,
+      DYNAMIC_FEE_FLAG,
+    ],
+  ])('derives %s pool key hook and fee mode', async (_name, initializer, fee) => {
+    const params = multicurveParams();
+    params.initializer = initializer;
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+
+    const prepared = await factory.prepareCreateMulticurve(params, { account });
+
+    expect(prepared.prediction.poolKey).toMatchObject({
+      fee,
+      hooks: mockPoolAddress,
+    });
+  });
+
+  it('uses the DopplerHookInitializer and dynamic fee for Rehype identity', async () => {
+    const params = multicurveParams();
+    params.initializer = {
+      type: 'rehype',
+      config: {
+        hookAddress: mockPoolAddress,
+        buybackDestination: account,
+        startFee: 3000,
+        endFee: 3000,
+        durationSeconds: 0,
+        feeRoutingMode: 0,
+        feeDistributionInfo: {
+          assetFeesToAssetBuybackWad: parseEther('0.25'),
+          assetFeesToNumeraireBuybackWad: parseEther('0.25'),
+          assetFeesToBeneficiaryWad: parseEther('0.25'),
+          assetFeesToLpWad: parseEther('0.25'),
+          numeraireFeesToAssetBuybackWad: parseEther('0.25'),
+          numeraireFeesToNumeraireBuybackWad: parseEther('0.25'),
+          numeraireFeesToBeneficiaryWad: parseEther('0.25'),
+          numeraireFeesToLpWad: parseEther('0.25'),
+        },
+      },
+    };
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+
+    const prepared = await factory.prepareCreateMulticurve(params, { account });
+
+    expect(prepared.prediction.poolKey).toMatchObject({
+      fee: DYNAMIC_FEE_FLAG,
+      hooks: mockAddresses.dopplerHookInitializer,
+    });
+    expect(prepared.prediction.poolKey.hooks).not.toBe(mockPoolAddress);
+  });
+
+  it('uses simulation request gas without fallback estimation', async () => {
+    vi.mocked(client.simulateContract).mockImplementationOnce(async (call) => ({
+      request: { ...call, gas: 700_000n },
+      result: [
+        mockTokenAddress,
+        mockPoolAddress,
+        mockGovernanceAddress,
+        mockTimelockAddress,
+        mockV2PoolAddress,
+      ],
+    }));
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+
+    const prepared = await factory.prepareCreateMulticurve(multicurveParams(), {
+      account,
+    });
+
+    expect(prepared.gasEstimate).toEqual({ status: 'estimated', gas: 700_000n });
+    expect(client.estimateContractGas).not.toHaveBeenCalled();
+  });
+
+  it('reports successful fallback estimation and unavailable transport failures', async () => {
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+    const estimated = await factory.prepareCreateMulticurve(multicurveParams(), {
+      account,
+    });
+    expect(estimated.gasEstimate).toEqual({ status: 'estimated', gas: 500_000n });
+
+    vi.mocked(client.estimateContractGas).mockRejectedValueOnce(
+      new Error('provider unavailable'),
+    );
+    const unavailable = await factory.prepareCreateMulticurve(
+      multicurveParams(),
+      { account },
+    );
+    expect(unavailable.gasEstimate).toEqual({ status: 'unavailable' });
+    expect(
+      vi
+        .mocked(client.estimateContractGas)
+        .mock.calls.map(([call]) => recordedAccount(call)),
+    ).toEqual([account, account]);
+  });
+
+  it('throws the original revert-shaped estimation failure', async () => {
+    const revert = new ExecutionRevertedError({ message: 'execution reverted' });
+    vi.mocked(client.estimateContractGas).mockRejectedValueOnce(revert);
+    const factory = new DopplerFactory(publicClient, undefined, 1);
+
+    await expect(
+      factory.prepareCreateMulticurve(multicurveParams(), { account }),
+    ).rejects.toBe(revert);
+  });
+
+  it.each([
+    [
+      'revert-shaped',
+      new ExecutionRevertedError({ message: 'execution reverted' }),
+    ],
+    ['transport/provider', new Error('provider unavailable')],
+  ])(
+    'preserves legacy %s estimation failures as an absent estimate',
+    async (_label, error) => {
+      vi.mocked(client.estimateContractGas).mockRejectedValue(error);
+      const factory = new DopplerFactory(publicClient, undefined, 1);
+
+      const simulated = await factory.simulateCreateMulticurve(multicurveParams());
+
+      expect(simulated.gasEstimate).toBeUndefined();
+    },
+  );
+
+  it('preserves simulation and estimation sender selection', async () => {
+    const wallet = createMockWalletClient();
+    const walletFactory = new DopplerFactory(publicClient, wallet, 1);
+    await walletFactory.simulateCreateMulticurve(multicurveParams());
+    expect(recordedAccount(vi.mocked(client.simulateContract).mock.calls[0][0])).toBe(
+      wallet.account,
+    );
+    expect(recordedAccount(vi.mocked(client.estimateContractGas).mock.calls[0][0])).toBe(
+      wallet.account,
+    );
+
+    vi.clearAllMocks();
+    vi.mocked(client.readContract).mockResolvedValue(mockPoolAddress);
+    vi.mocked(client.estimateContractGas).mockResolvedValue(500_000n);
+    const publicFactory = new DopplerFactory(publicClient, undefined, 1);
+    await publicFactory.simulateCreateMulticurve(multicurveParams());
+    expect(recordedAccount(vi.mocked(client.simulateContract).mock.calls[0][0])).toBeUndefined();
+    expect(recordedAccount(vi.mocked(client.estimateContractGas).mock.calls[0][0])).toBe(
+      account,
+    );
+  });
+
+  it('preserves explicit gas and the 13.5M legacy fallback', async () => {
+    const wallet = createMockWalletClient();
+    const receipt = createMockTransactionReceiptWithCreateEvent(
+      mockTokenAddress,
+      mockPoolAddress,
+      mockAddresses.weth,
+    );
+    vi.mocked(client.waitForTransactionReceipt).mockResolvedValue(receipt);
+    vi.mocked(wallet.writeContract).mockResolvedValue(receipt.transactionHash);
+    vi.mocked(client.estimateContractGas).mockRejectedValue(
+      new Error('provider unavailable'),
+    );
+    const factory = new DopplerFactory(publicClient, wallet, 1);
+
+    const explicitParams = multicurveParams();
+    explicitParams.gas = 900_000n;
+    await factory.createMulticurve(explicitParams);
+    expect(vi.mocked(wallet.writeContract).mock.calls[0][0].gas).toBe(900_000n);
+    expect(
+      recordedAccount(vi.mocked(client.simulateContract).mock.calls[0][0]),
+    ).toBe(wallet.account);
+    expect(
+      recordedAccount(vi.mocked(client.estimateContractGas).mock.calls[0][0]),
+    ).toBe(wallet.account);
+
+    await factory.createMulticurve(multicurveParams());
+    expect(vi.mocked(wallet.writeContract).mock.calls[1][0].gas).toBe(
+      DEFAULT_CREATE_GAS_LIMIT,
+    );
+  });
+});

--- a/test/evm/unit/entities/DopplerFactory.test.ts
+++ b/test/evm/unit/entities/DopplerFactory.test.ts
@@ -269,12 +269,14 @@ describe('DopplerFactory', () => {
       const createCalls = vi
         .mocked(client.simulateContract)
         .mock.calls.filter(([call]) => call.functionName === 'create');
-      const executeCreateParams = getRecordedCreateParams(createCalls[1]?.[0]);
+      const enrichedCreateParams = getRecordedCreateParams(createCalls[1]?.[0]);
+      const executeCreateParams = getRecordedCreateParams(createCalls[2]?.[0]);
       const submittedCreateParams = getRecordedCreateParams(
         vi.mocked(walletClient.writeContract).mock.calls[0]?.[0],
       );
 
-      expect(createCalls).toHaveLength(2);
+      expect(createCalls).toHaveLength(3);
+      expect(enrichedCreateParams).toEqual(simulation.createParams);
       expect(executeCreateParams.salt).toBe(explicitSalt);
       expect(submittedCreateParams.salt).toBe(explicitSalt);
       expect(executeCreateParams).toEqual(simulation.createParams);
@@ -641,7 +643,7 @@ describe('DopplerFactory', () => {
       params.modules = { dopplerHookInitializer };
 
       // When
-      const poolId = await factory['computeMulticurvePoolId'](
+      const { poolId } = await factory['computeMulticurvePoolIdentity'](
         params,
         tokenAddress,
       );

--- a/test/evm/unit/utils/airlockCreateReceipt.test.ts
+++ b/test/evm/unit/utils/airlockCreateReceipt.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { getAddress, type Address, type TransactionReceipt } from 'viem';
 import {
   AirlockCreateReceiptError,
   parseAirlockCreateReceipt,
   verifyPreparedCreateReceipt,
+  verifyPreparedCreateExecution,
   type AirlockCreateReceiptErrorCode,
+  type PreparedCreateTransactionClient,
 } from '../../../../src/evm/utils/airlockCreateReceipt';
 import type { PreparedMulticurveCreate } from '../../../../src/evm/types';
 import {
@@ -26,14 +28,16 @@ const poolInitializer = getAddress(
   '0x7100000000000000000000000000000000000007',
 );
 
-function createLog(options: {
-  emitter?: Address;
-  token?: Address;
-  numeraire?: Address;
-  initializer?: Address;
-  poolOrHook?: Address;
-  logIndex?: number;
-} = {}) {
+function createLog(
+  options: {
+    emitter?: Address;
+    token?: Address;
+    numeraire?: Address;
+    initializer?: Address;
+    poolOrHook?: Address;
+    logIndex?: number;
+  } = {},
+) {
   return {
     ...createMockCreateEventLog(
       options.token ?? mockTokenAddress,
@@ -108,6 +112,20 @@ function expectReceiptError(
 ): void {
   try {
     run();
+    throw new Error(`Expected ${code}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(AirlockCreateReceiptError);
+    if (!(error instanceof AirlockCreateReceiptError)) throw error;
+    expect(error.code).toBe(code);
+  }
+}
+
+async function expectAsyncReceiptError(
+  run: () => Promise<unknown>,
+  code: AirlockCreateReceiptErrorCode,
+): Promise<void> {
+  try {
+    await run();
     throw new Error(`Expected ${code}`);
   } catch (error) {
     expect(error).toBeInstanceOf(AirlockCreateReceiptError);
@@ -271,8 +289,7 @@ describe('verifyPreparedCreateReceipt', () => {
       },
       prediction: {
         ...prepared.prediction,
-        tokenAddress:
-          prepared.prediction.tokenAddress.toLowerCase() as Address,
+        tokenAddress: prepared.prediction.tokenAddress.toLowerCase() as Address,
         poolOrHookAddress:
           prepared.prediction.poolOrHookAddress.toLowerCase() as Address,
       },
@@ -289,4 +306,98 @@ describe('verifyPreparedCreateReceipt', () => {
       }).receiptIdentity.tokenAddress,
     ).toBe(mockTokenAddress);
   });
+});
+
+describe('verifyPreparedCreateExecution', () => {
+  function createClient(
+    receipt: TransactionReceipt,
+    overrides: Partial<{
+      hash: `0x${string}`;
+      from: Address;
+      to: Address | null;
+      input: `0x${string}`;
+      value: bigint;
+    }> = {},
+  ) {
+    const getTransaction = vi.fn().mockResolvedValue({
+      hash: receipt.transactionHash,
+      from: prepared.account,
+      to: prepared.transaction.to,
+      input: prepared.transaction.data,
+      value: prepared.transaction.value,
+      ...overrides,
+    });
+    return {
+      getTransaction,
+      publicClient: {
+        getTransaction,
+      } satisfies PreparedCreateTransactionClient,
+    };
+  }
+
+  it('fetches and verifies the mined transaction after receipt verification', async () => {
+    const receipt = createReceipt();
+    const { publicClient, getTransaction } = createClient(receipt);
+
+    const verified = await verifyPreparedCreateExecution({
+      prepared,
+      receipt,
+      publicClient,
+    });
+
+    expect(getTransaction).toHaveBeenCalledWith({
+      hash: receipt.transactionHash,
+    });
+    expect(verified.receiptIdentity.transactionHash).toBe(
+      receipt.transactionHash,
+    );
+    expect(verified.preparedIdentity).toEqual({
+      chainId: 1,
+      ...prepared.prediction,
+    });
+  });
+
+  it('rejects an invalid receipt before retrieving the transaction', async () => {
+    const receipt = createReceipt(undefined, { status: 'reverted' });
+    const { publicClient, getTransaction } = createClient(receipt);
+
+    await expectAsyncReceiptError(
+      () =>
+        verifyPreparedCreateExecution({
+          prepared,
+          receipt,
+          publicClient,
+        }),
+      'RECEIPT_FAILED',
+    );
+    expect(getTransaction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'hash',
+      { hash: `0x${'33'.repeat(32)}` as const },
+      'TRANSACTION_HASH_MISMATCH',
+    ],
+    ['target', { to: wrongAddress }, 'WRONG_TRANSACTION_TARGET'],
+    ['sender', { from: wrongAddress }, 'WRONG_TRANSACTION_SENDER'],
+    ['input', { input: '0xabcd' as const }, 'TRANSACTION_INPUT_MISMATCH'],
+    ['value', { value: 1n }, 'TRANSACTION_VALUE_MISMATCH'],
+  ] as const)(
+    'rejects a mismatched transaction %s',
+    async (_field, overrides, code) => {
+      const receipt = createReceipt();
+      const { publicClient } = createClient(receipt, overrides);
+
+      await expectAsyncReceiptError(
+        () =>
+          verifyPreparedCreateExecution({
+            prepared,
+            receipt,
+            publicClient,
+          }),
+        code,
+      );
+    },
+  );
 });

--- a/test/evm/unit/utils/airlockCreateReceipt.test.ts
+++ b/test/evm/unit/utils/airlockCreateReceipt.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest';
+import { getAddress, type Address, type TransactionReceipt } from 'viem';
+import {
+  AirlockCreateReceiptError,
+  parseAirlockCreateReceipt,
+  verifyPreparedCreateReceipt,
+  type AirlockCreateReceiptErrorCode,
+} from '../../../../src/evm/utils/airlockCreateReceipt';
+import type { PreparedMulticurveCreate } from '../../../../src/evm/types';
+import {
+  createMockCreateEventLog,
+  createMockTransactionReceipt,
+} from '../../setup/fixtures/clients';
+import {
+  mockAddresses,
+  mockGovernanceAddress,
+  mockPoolAddress,
+  mockTimelockAddress,
+  mockTokenAddress,
+  mockV2PoolAddress,
+} from '../../setup/fixtures/addresses';
+
+const account = getAddress('0xa000000000000000000000000000000000000001');
+const wrongAddress = getAddress('0xb000000000000000000000000000000000000002');
+const poolInitializer = getAddress(
+  '0x7100000000000000000000000000000000000007',
+);
+
+function createLog(options: {
+  emitter?: Address;
+  token?: Address;
+  numeraire?: Address;
+  initializer?: Address;
+  poolOrHook?: Address;
+  logIndex?: number;
+} = {}) {
+  return {
+    ...createMockCreateEventLog(
+      options.token ?? mockTokenAddress,
+      options.poolOrHook ?? mockPoolAddress,
+      options.numeraire ?? mockAddresses.weth,
+      options.initializer ?? poolInitializer,
+    ),
+    address: options.emitter ?? mockAddresses.airlock,
+    logIndex: options.logIndex ?? 7,
+  };
+}
+
+function createReceipt(
+  logs = [createLog()],
+  overrides: Partial<TransactionReceipt> = {},
+): TransactionReceipt {
+  const receipt = {
+    ...createMockTransactionReceipt(logs),
+    from: account,
+    to: mockAddresses.airlock,
+    ...overrides,
+  };
+  return receipt;
+}
+
+const prepared = {
+  chainId: 1,
+  account,
+  airlock: mockAddresses.airlock,
+  createParams: {
+    initialSupply: 1_000n,
+    numTokensToSell: 400n,
+    numeraire: mockAddresses.weth,
+    tokenFactory: mockAddresses.tokenFactory,
+    tokenFactoryData: '0x',
+    governanceFactory: mockAddresses.governanceFactory,
+    governanceFactoryData: '0x',
+    poolInitializer,
+    poolInitializerData: '0x',
+    liquidityMigrator: mockAddresses.v2Migrator,
+    liquidityMigratorData: '0x',
+    integrator: mockAddresses.airlock,
+    salt: `0x${'11'.repeat(32)}`,
+  },
+  prediction: {
+    tokenAddress: mockTokenAddress,
+    poolOrHookAddress: mockPoolAddress,
+    governanceAddress: mockGovernanceAddress,
+    timelockAddress: mockTimelockAddress,
+    migrationPoolAddress: mockV2PoolAddress,
+    poolKey: {
+      currency0: mockTokenAddress,
+      currency1: mockAddresses.weth,
+      fee: 3000,
+      tickSpacing: 60,
+      hooks: poolInitializer,
+    },
+    poolId: `0x${'22'.repeat(32)}`,
+    tokenIsCurrency0: true,
+  },
+  transaction: {
+    to: mockAddresses.airlock,
+    data: '0x1234',
+    value: 0n,
+  },
+  gasEstimate: { status: 'unavailable' },
+} satisfies PreparedMulticurveCreate<1>;
+
+function expectReceiptError(
+  run: () => unknown,
+  code: AirlockCreateReceiptErrorCode,
+): void {
+  try {
+    run();
+    throw new Error(`Expected ${code}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(AirlockCreateReceiptError);
+    if (!(error instanceof AirlockCreateReceiptError)) throw error;
+    expect(error.code).toBe(code);
+  }
+}
+
+describe('parseAirlockCreateReceipt', () => {
+  it('ignores a valid same-signature event emitted by another address', () => {
+    const result = parseAirlockCreateReceipt({
+      receipt: createReceipt([createLog({ emitter: wrongAddress })]),
+      expectedAirlock: mockAddresses.airlock,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns every emitted Create field and receipt metadata', () => {
+    const receipt = createReceipt();
+    const result = parseAirlockCreateReceipt({
+      receipt,
+      expectedAirlock: mockAddresses.airlock,
+    });
+
+    expect(result).toEqual({
+      airlock: mockAddresses.airlock,
+      tokenAddress: mockTokenAddress,
+      numeraire: mockAddresses.weth,
+      initializer: poolInitializer,
+      poolOrHookAddress: mockPoolAddress,
+      transactionHash: receipt.transactionHash,
+      blockNumber: receipt.blockNumber,
+      logIndex: 7,
+    });
+  });
+
+  it('returns null for no match and rejects multiple expected-Airlock events', () => {
+    expect(
+      parseAirlockCreateReceipt({
+        receipt: createReceipt([]),
+        expectedAirlock: mockAddresses.airlock,
+      }),
+    ).toBeNull();
+
+    expectReceiptError(
+      () =>
+        parseAirlockCreateReceipt({
+          receipt: createReceipt([createLog(), createLog({ logIndex: 8 })]),
+          expectedAirlock: mockAddresses.airlock,
+        }),
+      'MULTIPLE_CREATE_EVENTS',
+    );
+  });
+});
+
+describe('verifyPreparedCreateReceipt', () => {
+  it('returns separate receipt-derived and prepared-derived identities', () => {
+    const verified = verifyPreparedCreateReceipt({
+      prepared,
+      receipt: createReceipt(),
+    });
+
+    expect(verified.receiptIdentity).toMatchObject({
+      airlock: mockAddresses.airlock,
+      tokenAddress: mockTokenAddress,
+      numeraire: mockAddresses.weth,
+      initializer: poolInitializer,
+      poolOrHookAddress: mockPoolAddress,
+    });
+    expect(verified.preparedIdentity).toEqual({
+      chainId: 1,
+      ...prepared.prediction,
+    });
+    expect(verified.receiptIdentity).not.toHaveProperty('chainId');
+    expect(verified.receiptIdentity).not.toHaveProperty('governanceAddress');
+  });
+
+  it('rejects every stable receipt mismatch code', () => {
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({
+          prepared,
+          receipt: createReceipt(undefined, { status: 'reverted' }),
+        }),
+      'RECEIPT_FAILED',
+    );
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({
+          prepared,
+          receipt: createReceipt(undefined, { to: wrongAddress }),
+        }),
+      'WRONG_TRANSACTION_TARGET',
+    );
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({
+          prepared,
+          receipt: createReceipt(undefined, { from: wrongAddress }),
+        }),
+      'WRONG_TRANSACTION_SENDER',
+    );
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({ prepared, receipt: createReceipt([]) }),
+      'MISSING_CREATE_EVENT',
+    );
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({
+          prepared,
+          receipt: createReceipt([createLog(), createLog({ logIndex: 8 })]),
+        }),
+      'MULTIPLE_CREATE_EVENTS',
+    );
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({
+          prepared,
+          receipt: createReceipt([createLog({ token: wrongAddress })]),
+        }),
+      'TOKEN_MISMATCH',
+    );
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({
+          prepared,
+          receipt: createReceipt([createLog({ numeraire: wrongAddress })]),
+        }),
+      'NUMERAIRE_MISMATCH',
+    );
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({
+          prepared,
+          receipt: createReceipt([createLog({ initializer: wrongAddress })]),
+        }),
+      'INITIALIZER_MISMATCH',
+    );
+    expectReceiptError(
+      () =>
+        verifyPreparedCreateReceipt({
+          prepared,
+          receipt: createReceipt([createLog({ poolOrHook: wrongAddress })]),
+        }),
+      'POOL_OR_HOOK_MISMATCH',
+    );
+  });
+
+  it('compares emitter and identity addresses case-insensitively', () => {
+    const lowercasePrepared = {
+      ...prepared,
+      account: prepared.account.toLowerCase() as Address,
+      airlock: prepared.airlock.toLowerCase() as Address,
+      createParams: {
+        ...prepared.createParams,
+        numeraire: prepared.createParams.numeraire.toLowerCase() as Address,
+        poolInitializer:
+          prepared.createParams.poolInitializer.toLowerCase() as Address,
+      },
+      prediction: {
+        ...prepared.prediction,
+        tokenAddress:
+          prepared.prediction.tokenAddress.toLowerCase() as Address,
+        poolOrHookAddress:
+          prepared.prediction.poolOrHookAddress.toLowerCase() as Address,
+      },
+      transaction: {
+        ...prepared.transaction,
+        to: prepared.transaction.to.toLowerCase() as Address,
+      },
+    } satisfies PreparedMulticurveCreate<1>;
+
+    expect(
+      verifyPreparedCreateReceipt({
+        prepared: lowercasePrepared,
+        receipt: createReceipt(),
+      }).receiptIdentity.tokenAddress,
+    ).toBe(mockTokenAddress);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a wallet-independent multicurve creation lifecycle for EVM consumers:

- Prepares the exact unsigned Airlock create transaction using a `PublicClient` and explicit sender.
- Returns final simulation predictions, complete Uniswap V4 pool identity, and a truthful gas-estimation status.
- Preserves existing `simulateCreateMulticurve()` and `createMulticurve()` behavior.
- Adds strict Airlock `Create` receipt parsing and prepared-transaction verification.
- Includes unit coverage, an externally submitted Base Sepolia fork test, and a Base Sepolia external-executor example.

## Files Changed

- `src/evm/entities/DopplerFactory.ts`: Adds `prepareCreateMulticurve()`, shares final multicurve resolution and simulation across workflows, derives complete pool identity, and preserves legacy sender and gas behavior.
- `src/evm/types.ts`: Defines the public preparation options, gas status, prediction, and prepared transaction contracts.
- `src/evm/utils/airlockCreateReceipt.ts`: Adds strict Airlock `Create` receipt parsing, coded verification errors, and prepared receipt verification.
- `src/evm/utils/index.ts`: Exports the new receipt parser, verifier, errors, and result types.
- `src/evm/index.ts`: Exposes the new preparation and receipt APIs from the public EVM entry point.
- `examples/multicurve-custom-executor.ts`: Demonstrates preparing with a public-only SDK and submitting through a separately owned Base Sepolia wallet.
- `examples/README.md`: Documents the wallet-independent external-executor example and application-owned responsibilities.
- `test/evm/unit/entities/DopplerFactory.prepareMulticurve.test.ts`: Covers preparation metadata, final calldata, salt reuse, predictions, gas semantics, and legacy compatibility.
- `test/evm/unit/utils/airlockCreateReceipt.test.ts`: Covers emitter filtering, event cardinality, identity verification, error codes, and case-insensitive comparisons.
- `test/evm/unit/entities/DopplerFactory.test.ts`: Updates existing multicurve assertions for final enriched re-simulation and complete pool identity.
- `test/evm/fork/base-sepolia/multicurve-prepare-rehype.base-sepolia.test.ts`: Broadcasts and verifies an externally submitted Rehype multicurve create on an Anvil Base Sepolia fork.
- `test/evm/setup/fixtures/clients.ts`: Extends mocked Airlock simulation outputs and client typing for preparation coverage.