### PR TITLE
ci: remove Monad RPC override

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,6 @@ jobs:
         env:
           LIVE_TEST_ENABLED: 'true'
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
-          MONAD_MAINNET_RPC_URL: ${{ secrets.MONAD_MAINNET_RPC_URL }}
           TEST_CHAINS: ${{ matrix.chain }}
         timeout-minutes: 10
 

--- a/README.md
+++ b/README.md
@@ -1878,7 +1878,7 @@ The whitelisting suite is scoped to the release-audit chains: Ethereum Mainnet, 
 
 Whitelisting test RPC priority is:
 
-1. Chain-specific RPC URL env var (`ETH_MAINNET_RPC_URL`, `BASE_RPC_URL`, `BASE_SEPOLIA_RPC_URL`, `MONAD_MAINNET_RPC_URL`)
+1. Chain-specific RPC URL env var (`ETH_MAINNET_RPC_URL`, `BASE_RPC_URL`, `BASE_SEPOLIA_RPC_URL`)
 2. `ALCHEMY_API_KEY` fallback for supported Alchemy networks, including Monad Mainnet
 3. Public/default RPC URL
 

--- a/test/evm/fork/multicurve-scheduled.monad-mainnet.test.ts
+++ b/test/evm/fork/multicurve-scheduled.monad-mainnet.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeAll } from 'vitest'
 import { decodeAbiParameters } from 'viem'
 
 import { DopplerSDK, getAddresses, CHAIN_IDS, airlockAbi, WAD } from '../../../src/evm'
-import { getTestClient, hasRpcUrl, getRpcEnvVar } from '../utils'
+import { getTestClient, hasRpcUrl } from '../utils'
 
 describe('Scheduled Multicurve (Monad Mainnet) smoke test', () => {
   if (!hasRpcUrl(CHAIN_IDS.MONAD_MAINNET)) {
-    it.skip(`requires ${getRpcEnvVar(CHAIN_IDS.MONAD_MAINNET)} env var`)
+    it.skip('requires ALCHEMY_API_KEY')
     return
   }
 

--- a/test/evm/utils/anvil.ts
+++ b/test/evm/utils/anvil.ts
@@ -86,7 +86,9 @@ function getForkUrl(chainId: number): string | undefined {
         (alchemyKey ? `https://base-sepolia.g.alchemy.com/v2/${alchemyKey}` : undefined)
       )
     case CHAIN_IDS.MONAD_MAINNET:
-      return process.env.MONAD_MAINNET_RPC_URL
+      return alchemyKey
+        ? `https://monad-mainnet.g.alchemy.com/v2/${alchemyKey}`
+        : undefined
     default:
       return undefined
   }

--- a/test/evm/utils/clients.ts
+++ b/test/evm/utils/clients.ts
@@ -87,7 +87,7 @@ export const robinhoodChain = defineChain({
 /** Chain configuration for tests */
 interface ChainTestConfig {
   chain: Chain
-  envVar: string
+  envVar?: string
   /** Optional Alchemy network name for fallback */
   alchemyNetwork?: string
 }
@@ -119,7 +119,6 @@ const CHAIN_CONFIG: Record<number, ChainTestConfig> = {
   },
   [CHAIN_IDS.MONAD_MAINNET]: {
     chain: monadMainnet,
-    envVar: 'MONAD_MAINNET_RPC_URL',
     alchemyNetwork: 'monad-mainnet',
   },
 }
@@ -130,7 +129,7 @@ const CHAIN_CONFIG: Record<number, ChainTestConfig> = {
  */
 function getRpcUrl(config: ChainTestConfig): string | undefined {
   // 1. Check environment variable
-  const envUrl = process.env[config.envVar]
+  const envUrl = config.envVar ? process.env[config.envVar] : undefined
   if (envUrl) return envUrl
 
   // 2. Try Alchemy fallback
@@ -168,10 +167,15 @@ export function getTestClient(
 
   const rpcUrl = getRpcUrl(config)
   if (!rpcUrl) {
+    const requirements = [
+      config.envVar ? `Set ${config.envVar} environment variable` : undefined,
+      config.alchemyNetwork
+        ? `ALCHEMY_API_KEY for ${config.alchemyNetwork}`
+        : undefined,
+    ].filter(Boolean)
     throw new Error(
       `No RPC URL available for chain ${chainId}. ` +
-      `Set ${config.envVar} environment variable` +
-      (config.alchemyNetwork ? ` or ALCHEMY_API_KEY for ${config.alchemyNetwork}` : '')
+        requirements.join(' or '),
     )
   }
 
@@ -334,12 +338,15 @@ export function getTestClients(
   // Live or unit mode - use rate-limited client
   const rpcUrl = options.rpcUrl ?? getRpcUrl(config)
   if (!rpcUrl) {
+    const requirements = [
+      config.envVar ? `Set ${config.envVar} environment variable` : undefined,
+      config.alchemyNetwork
+        ? `ALCHEMY_API_KEY for ${config.alchemyNetwork}`
+        : undefined,
+    ].filter(Boolean)
     throw new Error(
       `No RPC URL available for chain ${chainId}. ` +
-        `Set ${config.envVar} environment variable` +
-        (config.alchemyNetwork
-          ? ` or ALCHEMY_API_KEY for ${config.alchemyNetwork}`
-          : '')
+        requirements.join(' or '),
     )
   }
 


### PR DESCRIPTION
## Summary
- Remove the obsolete `MONAD_MAINNET_RPC_URL` override from code, docs, and release workflow configuration.
- Use the shared `ALCHEMY_API_KEY` for Monad live and Anvil fork clients.
- Improve missing-RPC error/skip messaging now that Monad has no chain-specific variable.

## Verification
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- All workflow YAML parsed successfully
- `pnpm test:unit` — 71 files, 877 tests passed