### PR TITLE
chore: pin foundry version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.7.1
 
       - name: Verify Anvil installation
         run: anvil --version


### PR DESCRIPTION
Foundry 1.8.0 nightly is currently breaking on RPC calls. Pinning 1.7.1.