### PR TITLE
[SOL-89] fix(solana): support permissionless Rehype settlement

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -215,7 +215,8 @@ Fee rehypothecation launches initialize their routing state and launch in two
 transactions. The launch helper configures the router as the Initializer fee
 beneficiary; the router's beneficiary list and routing strategy control the
 eventual payouts. Settlement conversions use a 50 bps slippage tolerance by
-default and require the immutable settlement authority configured at creation.
+default. Settlement is permissionless: any signer can submit and pay for the
+transaction, and no keeper authority is configured at launch creation.
 
 The high-level launch helper uses the deployment's Doppler launch hook v1 automatically. Set `dynamicFee`, a gate returned by `dopplerLaunchHookV1.resolveManagedCosignerGate`, or both in the helper params to enable those features; omit both for static fees without cosigning. The resolver fetches the hook's singleton on-chain config and selects its first active Doppler-managed signer, while `createLaunch` remains an offline instruction builder that pins the resolved signer. Launch creators cannot register or select a cosigner through this flow. Integrators that require their own cosigner must use a separate hook program approved by the protocol; passing a key to the low-level hook helpers does not authorize or register it with the Doppler-managed hook. The gated swap examples require `COSIGNER_KEYPAIR_PATH` or `COSIGNER_KEYPAIR` to match that selected signer because they execute the managed cosigned swap themselves.
 

--- a/examples/solana-fee-rehypothecation-launch.ts
+++ b/examples/solana-fee-rehypothecation-launch.ts
@@ -102,7 +102,6 @@ async function main(): Promise<void> {
     },
     metadata: DEFAULT_TEST_METADATA,
     buybackDestination: payer.address,
-    settlementAuthority: payer,
     beneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
     strategy: strategies[strategyName](),
   });
@@ -166,7 +165,7 @@ async function main(): Promise<void> {
     rpc,
     deployment,
     launch: prepared.launchAddresses.launch,
-    settlementAuthority: payer,
+    payer,
   });
   const settlementSignature = await sendInstructions({
     rpc,

--- a/examples/solana-fee-rehypothecation-settle-and-claim.ts
+++ b/examples/solana-fee-rehypothecation-settle-and-claim.ts
@@ -24,21 +24,12 @@ async function main(): Promise<void> {
   const beneficiary = process.env.SOLANA_FEE_BENEFICIARY
     ? address(process.env.SOLANA_FEE_BENEFICIARY)
     : payer.address;
-  const settlementAuthority =
-    process.env.SOLANA_SETTLEMENT_AUTHORITY_KEYPAIR_PATH ||
-    process.env.SOLANA_SETTLEMENT_AUTHORITY_KEYPAIR
-      ? await loadKeypairSignerFromEnv({
-          pathEnv: 'SOLANA_SETTLEMENT_AUTHORITY_KEYPAIR_PATH',
-          jsonEnv: 'SOLANA_SETTLEMENT_AUTHORITY_KEYPAIR',
-          label: 'SOLANA_SETTLEMENT_AUTHORITY_KEYPAIR',
-        })
-      : payer;
 
   const settlement = await feeRehypothecation.prepareSettlement({
     rpc,
     deployment,
     launch,
-    settlementAuthority,
+    payer,
   });
   console.log('Settlement quote:', settlement.quote);
   const settlementSignature = await sendInstructions({

--- a/scripts/idl/doppler_rehype_router_v1.json
+++ b/scripts/idl/doppler_rehype_router_v1.json
@@ -364,10 +364,6 @@
           "signer": true
         },
         {
-          "name": "settlement_authority",
-          "signer": true
-        },
-        {
           "name": "base_mint",
           "docs": [
             "Future launch mint. Its signature prevents another caller from claiming this state PDA."
@@ -568,7 +564,7 @@
       ],
       "accounts": [
         {
-          "name": "settlement_authority",
+          "name": "payer",
           "writable": true,
           "signer": true
         },
@@ -880,7 +876,7 @@
       ],
       "accounts": [
         {
-          "name": "settlement_authority",
+          "name": "payer",
           "writable": true,
           "signer": true
         },
@@ -2502,8 +2498,16 @@
             "type": "u8"
           },
           {
-            "name": "settlement_authority",
-            "type": "pubkey"
+            "name": "_reserved_settlement_authority",
+            "docs": [
+              "Reserved bytes formerly used by the privileged settlement authority."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "cumulative_routed_base_fees",

--- a/src/solana/feeRehypothecation/launch.ts
+++ b/src/solana/feeRehypothecation/launch.ts
@@ -77,7 +77,6 @@ export type PrepareFeeRehypothecationLaunchInput = PrepareLaunchBaseInput & {
   payer: TransactionSigner;
   authority: TransactionSigner;
   buybackDestination: Address;
-  settlementAuthority: TransactionSigner;
   beneficiaries: ReadonlyArray<RehypeBeneficiaryInputArgs>;
   strategy: FeeRehypothecationStrategy;
   dynamicFee?: DynamicFeeScheduleArgs | null;
@@ -224,7 +223,6 @@ export async function prepareLaunch(
         namespace,
         launchId,
         buybackDestination: input.buybackDestination,
-        settlementAuthority: input.settlementAuthority,
         routingMode: input.strategy.routingMode,
         feeRouting: input.strategy.feeRouting,
         beneficiaries,

--- a/src/solana/feeRehypothecation/settlement.ts
+++ b/src/solana/feeRehypothecation/settlement.ts
@@ -52,7 +52,7 @@ export type FeeRehypothecationRpc = Rpc<
 export type PrepareFeeRehypothecationSettlementInput = {
   rpc: FeeRehypothecationRpc;
   launch: Address;
-  settlementAuthority: TransactionSigner;
+  payer: TransactionSigner;
   deployment?: SolanaFeeRehypothecationDeployment;
   slippageBps?: number;
   minBaseToQuoteOut?: bigint;
@@ -179,7 +179,6 @@ export async function prepareSettlement(
     routingState.baseMint !== launch.baseMint ||
     routingState.quoteMint !== launch.quoteMint ||
     routingState.hookProgram !== launch.hookProgram ||
-    routingState.settlementAuthority !== input.settlementAuthority.address ||
     baseMintAccount.address !== launch.baseMint ||
     quoteMintAccount.address !== launch.quoteMint ||
     baseVaultAccount.address !== launch.baseVault ||
@@ -321,7 +320,7 @@ export async function prepareSettlement(
   });
   const instruction = await getSettleFeesInstructionAsync(
     {
-      settlementAuthority: input.settlementAuthority,
+      payer: input.payer,
       initializerProgram: deployment.initializerProgram,
       initializerConfig: deployment.initializerConfig,
       launch: input.launch,

--- a/src/solana/generated/dopplerRehypeRouterV1/accounts/rehypeState.ts
+++ b/src/solana/generated/dopplerRehypeRouterV1/accounts/rehypeState.ts
@@ -88,7 +88,8 @@ export type RehypeState = {
   beneficiaryCount: number;
   inflightKind: number;
   inflightDirection: number;
-  settlementAuthority: Address;
+  /** Reserved bytes formerly used by the privileged settlement authority. */
+  reservedSettlementAuthority: ReadonlyUint8Array;
   cumulativeRoutedBaseFees: bigint;
   cumulativeRoutedQuoteFees: bigint;
   settledInitializerBaseFees: bigint;
@@ -122,7 +123,8 @@ export type RehypeStateArgs = {
   beneficiaryCount: number;
   inflightKind: number;
   inflightDirection: number;
-  settlementAuthority: Address;
+  /** Reserved bytes formerly used by the privileged settlement authority. */
+  reservedSettlementAuthority: ReadonlyUint8Array;
   cumulativeRoutedBaseFees: number | bigint;
   cumulativeRoutedQuoteFees: number | bigint;
   settledInitializerBaseFees: number | bigint;
@@ -169,7 +171,7 @@ export function getRehypeStateEncoder(): FixedSizeEncoder<RehypeStateArgs> {
       ['beneficiaryCount', getU8Encoder()],
       ['inflightKind', getU8Encoder()],
       ['inflightDirection', getU8Encoder()],
-      ['settlementAuthority', getAddressEncoder()],
+      ['reservedSettlementAuthority', fixEncoderSize(getBytesEncoder(), 32)],
       ['cumulativeRoutedBaseFees', getU64Encoder()],
       ['cumulativeRoutedQuoteFees', getU64Encoder()],
       ['settledInitializerBaseFees', getU64Encoder()],
@@ -218,7 +220,7 @@ export function getRehypeStateDecoder(): FixedSizeDecoder<RehypeState> {
     ['beneficiaryCount', getU8Decoder()],
     ['inflightKind', getU8Decoder()],
     ['inflightDirection', getU8Decoder()],
-    ['settlementAuthority', getAddressDecoder()],
+    ['reservedSettlementAuthority', fixDecoderSize(getBytesDecoder(), 32)],
     ['cumulativeRoutedBaseFees', getU64Decoder()],
     ['cumulativeRoutedQuoteFees', getU64Decoder()],
     ['settledInitializerBaseFees', getU64Decoder()],

--- a/src/solana/generated/dopplerRehypeRouterV1/instructions/initializeRehype.ts
+++ b/src/solana/generated/dopplerRehypeRouterV1/instructions/initializeRehype.ts
@@ -70,7 +70,6 @@ export function getInitializeRehypeDiscriminatorBytes() {
 export type InitializeRehypeInstruction<
   TProgram extends string = typeof DOPPLER_REHYPE_ROUTER_V1_PROGRAM_ADDRESS,
   TAccountPayer extends string | AccountMeta<string> = string,
-  TAccountSettlementAuthority extends string | AccountMeta<string> = string,
   TAccountBaseMint extends string | AccountMeta<string> = string,
   TAccountQuoteMint extends string | AccountMeta<string> = string,
   TAccountHookProgram extends string | AccountMeta<string> = string,
@@ -90,10 +89,6 @@ export type InitializeRehypeInstruction<
         ? WritableSignerAccount<TAccountPayer> &
             AccountSignerMeta<TAccountPayer>
         : TAccountPayer,
-      TAccountSettlementAuthority extends string
-        ? ReadonlySignerAccount<TAccountSettlementAuthority> &
-            AccountSignerMeta<TAccountSettlementAuthority>
-        : TAccountSettlementAuthority,
       TAccountBaseMint extends string
         ? ReadonlySignerAccount<TAccountBaseMint> &
             AccountSignerMeta<TAccountBaseMint>
@@ -181,7 +176,6 @@ export function getInitializeRehypeInstructionDataCodec(): Codec<
 
 export type InitializeRehypeAsyncInput<
   TAccountPayer extends string = string,
-  TAccountSettlementAuthority extends string = string,
   TAccountBaseMint extends string = string,
   TAccountQuoteMint extends string = string,
   TAccountHookProgram extends string = string,
@@ -192,7 +186,6 @@ export type InitializeRehypeAsyncInput<
   TAccountSystemProgram extends string = string,
 > = {
   payer: TransactionSigner<TAccountPayer>;
-  settlementAuthority: TransactionSigner<TAccountSettlementAuthority>;
   /** Future launch mint. Its signature prevents another caller from claiming this state PDA. */
   baseMint: TransactionSigner<TAccountBaseMint>;
   quoteMint: Address<TAccountQuoteMint>;
@@ -212,7 +205,6 @@ export type InitializeRehypeAsyncInput<
 
 export async function getInitializeRehypeInstructionAsync<
   TAccountPayer extends string,
-  TAccountSettlementAuthority extends string,
   TAccountBaseMint extends string,
   TAccountQuoteMint extends string,
   TAccountHookProgram extends string,
@@ -226,7 +218,6 @@ export async function getInitializeRehypeInstructionAsync<
 >(
   input: InitializeRehypeAsyncInput<
     TAccountPayer,
-    TAccountSettlementAuthority,
     TAccountBaseMint,
     TAccountQuoteMint,
     TAccountHookProgram,
@@ -241,7 +232,6 @@ export async function getInitializeRehypeInstructionAsync<
   InitializeRehypeInstruction<
     TProgramAddress,
     TAccountPayer,
-    TAccountSettlementAuthority,
     TAccountBaseMint,
     TAccountQuoteMint,
     TAccountHookProgram,
@@ -259,10 +249,6 @@ export async function getInitializeRehypeInstructionAsync<
   // Original accounts.
   const originalAccounts = {
     payer: { value: input.payer ?? null, isWritable: true },
-    settlementAuthority: {
-      value: input.settlementAuthority ?? null,
-      isWritable: false,
-    },
     baseMint: { value: input.baseMint ?? null, isWritable: false },
     quoteMint: { value: input.quoteMint ?? null, isWritable: false },
     hookProgram: { value: input.hookProgram ?? null, isWritable: false },
@@ -359,7 +345,6 @@ export async function getInitializeRehypeInstructionAsync<
   return Object.freeze({
     accounts: [
       getAccountMeta('payer', accounts.payer),
-      getAccountMeta('settlementAuthority', accounts.settlementAuthority),
       getAccountMeta('baseMint', accounts.baseMint),
       getAccountMeta('quoteMint', accounts.quoteMint),
       getAccountMeta('hookProgram', accounts.hookProgram),
@@ -376,7 +361,6 @@ export async function getInitializeRehypeInstructionAsync<
   } as InitializeRehypeInstruction<
     TProgramAddress,
     TAccountPayer,
-    TAccountSettlementAuthority,
     TAccountBaseMint,
     TAccountQuoteMint,
     TAccountHookProgram,
@@ -390,7 +374,6 @@ export async function getInitializeRehypeInstructionAsync<
 
 export type InitializeRehypeInput<
   TAccountPayer extends string = string,
-  TAccountSettlementAuthority extends string = string,
   TAccountBaseMint extends string = string,
   TAccountQuoteMint extends string = string,
   TAccountHookProgram extends string = string,
@@ -401,7 +384,6 @@ export type InitializeRehypeInput<
   TAccountSystemProgram extends string = string,
 > = {
   payer: TransactionSigner<TAccountPayer>;
-  settlementAuthority: TransactionSigner<TAccountSettlementAuthority>;
   /** Future launch mint. Its signature prevents another caller from claiming this state PDA. */
   baseMint: TransactionSigner<TAccountBaseMint>;
   quoteMint: Address<TAccountQuoteMint>;
@@ -421,7 +403,6 @@ export type InitializeRehypeInput<
 
 export function getInitializeRehypeInstruction<
   TAccountPayer extends string,
-  TAccountSettlementAuthority extends string,
   TAccountBaseMint extends string,
   TAccountQuoteMint extends string,
   TAccountHookProgram extends string,
@@ -435,7 +416,6 @@ export function getInitializeRehypeInstruction<
 >(
   input: InitializeRehypeInput<
     TAccountPayer,
-    TAccountSettlementAuthority,
     TAccountBaseMint,
     TAccountQuoteMint,
     TAccountHookProgram,
@@ -449,7 +429,6 @@ export function getInitializeRehypeInstruction<
 ): InitializeRehypeInstruction<
   TProgramAddress,
   TAccountPayer,
-  TAccountSettlementAuthority,
   TAccountBaseMint,
   TAccountQuoteMint,
   TAccountHookProgram,
@@ -466,10 +445,6 @@ export function getInitializeRehypeInstruction<
   // Original accounts.
   const originalAccounts = {
     payer: { value: input.payer ?? null, isWritable: true },
-    settlementAuthority: {
-      value: input.settlementAuthority ?? null,
-      isWritable: false,
-    },
     baseMint: { value: input.baseMint ?? null, isWritable: false },
     quoteMint: { value: input.quoteMint ?? null, isWritable: false },
     hookProgram: { value: input.hookProgram ?? null, isWritable: false },
@@ -510,7 +485,6 @@ export function getInitializeRehypeInstruction<
   return Object.freeze({
     accounts: [
       getAccountMeta('payer', accounts.payer),
-      getAccountMeta('settlementAuthority', accounts.settlementAuthority),
       getAccountMeta('baseMint', accounts.baseMint),
       getAccountMeta('quoteMint', accounts.quoteMint),
       getAccountMeta('hookProgram', accounts.hookProgram),
@@ -527,7 +501,6 @@ export function getInitializeRehypeInstruction<
   } as InitializeRehypeInstruction<
     TProgramAddress,
     TAccountPayer,
-    TAccountSettlementAuthority,
     TAccountBaseMint,
     TAccountQuoteMint,
     TAccountHookProgram,
@@ -546,16 +519,15 @@ export type ParsedInitializeRehypeInstruction<
   programAddress: Address<TProgram>;
   accounts: {
     payer: TAccountMetas[0];
-    settlementAuthority: TAccountMetas[1];
     /** Future launch mint. Its signature prevents another caller from claiming this state PDA. */
-    baseMint: TAccountMetas[2];
-    quoteMint: TAccountMetas[3];
-    hookProgram: TAccountMetas[4];
-    initializerProgram: TAccountMetas[5];
-    rehypeState: TAccountMetas[6];
-    rehypeAuthority: TAccountMetas[7];
-    settlementSigner: TAccountMetas[8];
-    systemProgram: TAccountMetas[9];
+    baseMint: TAccountMetas[1];
+    quoteMint: TAccountMetas[2];
+    hookProgram: TAccountMetas[3];
+    initializerProgram: TAccountMetas[4];
+    rehypeState: TAccountMetas[5];
+    rehypeAuthority: TAccountMetas[6];
+    settlementSigner: TAccountMetas[7];
+    systemProgram: TAccountMetas[8];
   };
   data: InitializeRehypeInstructionData;
 };
@@ -568,12 +540,12 @@ export function parseInitializeRehypeInstruction<
     InstructionWithAccounts<TAccountMetas> &
     InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeRehypeInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 10) {
+  if (instruction.accounts.length < 9) {
     throw new SolanaError(
       SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
       {
         actualAccountMetas: instruction.accounts.length,
-        expectedAccountMetas: 10,
+        expectedAccountMetas: 9,
       },
     );
   }
@@ -587,7 +559,6 @@ export function parseInitializeRehypeInstruction<
     programAddress: instruction.programAddress,
     accounts: {
       payer: getNextAccount(),
-      settlementAuthority: getNextAccount(),
       baseMint: getNextAccount(),
       quoteMint: getNextAccount(),
       hookProgram: getNextAccount(),

--- a/src/solana/generated/dopplerRehypeRouterV1/instructions/settleFees.ts
+++ b/src/solana/generated/dopplerRehypeRouterV1/instructions/settleFees.ts
@@ -53,7 +53,7 @@ export function getSettleFeesDiscriminatorBytes() {
 
 export type SettleFeesInstruction<
   TProgram extends string = typeof DOPPLER_REHYPE_ROUTER_V1_PROGRAM_ADDRESS,
-  TAccountSettlementAuthority extends string | AccountMeta<string> = string,
+  TAccountPayer extends string | AccountMeta<string> = string,
   TAccountInitializerProgram extends string | AccountMeta<string> =
     '4h3Dqyo5qmteJoMxXt3tdtfXELDB6pdRTPU9mWruiKp1',
   TAccountInitializerConfig extends string | AccountMeta<string> = string,
@@ -88,10 +88,10 @@ export type SettleFeesInstruction<
   InstructionWithData<ReadonlyUint8Array> &
   InstructionWithAccounts<
     [
-      TAccountSettlementAuthority extends string
-        ? WritableSignerAccount<TAccountSettlementAuthority> &
-            AccountSignerMeta<TAccountSettlementAuthority>
-        : TAccountSettlementAuthority,
+      TAccountPayer extends string
+        ? WritableSignerAccount<TAccountPayer> &
+            AccountSignerMeta<TAccountPayer>
+        : TAccountPayer,
       TAccountInitializerProgram extends string
         ? ReadonlyAccount<TAccountInitializerProgram>
         : TAccountInitializerProgram,
@@ -215,7 +215,7 @@ export function getSettleFeesInstructionDataCodec(): FixedSizeCodec<
 }
 
 export type SettleFeesAsyncInput<
-  TAccountSettlementAuthority extends string = string,
+  TAccountPayer extends string = string,
   TAccountInitializerProgram extends string = string,
   TAccountInitializerConfig extends string = string,
   TAccountLaunch extends string = string,
@@ -243,7 +243,7 @@ export type SettleFeesAsyncInput<
   TAccountGateCosigner extends string = string,
   TAccountCosignGateControl extends string = string,
 > = {
-  settlementAuthority: TransactionSigner<TAccountSettlementAuthority>;
+  payer: TransactionSigner<TAccountPayer>;
   initializerProgram?: Address<TAccountInitializerProgram>;
   initializerConfig: Address<TAccountInitializerConfig>;
   launch: Address<TAccountLaunch>;
@@ -275,7 +275,7 @@ export type SettleFeesAsyncInput<
 };
 
 export async function getSettleFeesInstructionAsync<
-  TAccountSettlementAuthority extends string,
+  TAccountPayer extends string,
   TAccountInitializerProgram extends string,
   TAccountInitializerConfig extends string,
   TAccountLaunch extends string,
@@ -306,7 +306,7 @@ export async function getSettleFeesInstructionAsync<
     typeof DOPPLER_REHYPE_ROUTER_V1_PROGRAM_ADDRESS,
 >(
   input: SettleFeesAsyncInput<
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -338,7 +338,7 @@ export async function getSettleFeesInstructionAsync<
 ): Promise<
   SettleFeesInstruction<
     TProgramAddress,
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -373,10 +373,7 @@ export async function getSettleFeesInstructionAsync<
 
   // Original accounts.
   const originalAccounts = {
-    settlementAuthority: {
-      value: input.settlementAuthority ?? null,
-      isWritable: true,
-    },
+    payer: { value: input.payer ?? null, isWritable: true },
     initializerProgram: {
       value: input.initializerProgram ?? null,
       isWritable: false,
@@ -567,7 +564,7 @@ export async function getSettleFeesInstructionAsync<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   return Object.freeze({
     accounts: [
-      getAccountMeta('settlementAuthority', accounts.settlementAuthority),
+      getAccountMeta('payer', accounts.payer),
       getAccountMeta('initializerProgram', accounts.initializerProgram),
       getAccountMeta('initializerConfig', accounts.initializerConfig),
       getAccountMeta('launch', accounts.launch),
@@ -601,7 +598,7 @@ export async function getSettleFeesInstructionAsync<
     programAddress,
   } as SettleFeesInstruction<
     TProgramAddress,
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -632,7 +629,7 @@ export async function getSettleFeesInstructionAsync<
 }
 
 export type SettleFeesInput<
-  TAccountSettlementAuthority extends string = string,
+  TAccountPayer extends string = string,
   TAccountInitializerProgram extends string = string,
   TAccountInitializerConfig extends string = string,
   TAccountLaunch extends string = string,
@@ -660,7 +657,7 @@ export type SettleFeesInput<
   TAccountGateCosigner extends string = string,
   TAccountCosignGateControl extends string = string,
 > = {
-  settlementAuthority: TransactionSigner<TAccountSettlementAuthority>;
+  payer: TransactionSigner<TAccountPayer>;
   initializerProgram?: Address<TAccountInitializerProgram>;
   initializerConfig: Address<TAccountInitializerConfig>;
   launch: Address<TAccountLaunch>;
@@ -692,7 +689,7 @@ export type SettleFeesInput<
 };
 
 export function getSettleFeesInstruction<
-  TAccountSettlementAuthority extends string,
+  TAccountPayer extends string,
   TAccountInitializerProgram extends string,
   TAccountInitializerConfig extends string,
   TAccountLaunch extends string,
@@ -723,7 +720,7 @@ export function getSettleFeesInstruction<
     typeof DOPPLER_REHYPE_ROUTER_V1_PROGRAM_ADDRESS,
 >(
   input: SettleFeesInput<
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -754,7 +751,7 @@ export function getSettleFeesInstruction<
   config?: { programAddress?: TProgramAddress },
 ): SettleFeesInstruction<
   TProgramAddress,
-  TAccountSettlementAuthority,
+  TAccountPayer,
   TAccountInitializerProgram,
   TAccountInitializerConfig,
   TAccountLaunch,
@@ -788,10 +785,7 @@ export function getSettleFeesInstruction<
 
   // Original accounts.
   const originalAccounts = {
-    settlementAuthority: {
-      value: input.settlementAuthority ?? null,
-      isWritable: true,
-    },
+    payer: { value: input.payer ?? null, isWritable: true },
     initializerProgram: {
       value: input.initializerProgram ?? null,
       isWritable: false,
@@ -874,7 +868,7 @@ export function getSettleFeesInstruction<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   return Object.freeze({
     accounts: [
-      getAccountMeta('settlementAuthority', accounts.settlementAuthority),
+      getAccountMeta('payer', accounts.payer),
       getAccountMeta('initializerProgram', accounts.initializerProgram),
       getAccountMeta('initializerConfig', accounts.initializerConfig),
       getAccountMeta('launch', accounts.launch),
@@ -908,7 +902,7 @@ export function getSettleFeesInstruction<
     programAddress,
   } as SettleFeesInstruction<
     TProgramAddress,
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -944,7 +938,7 @@ export type ParsedSettleFeesInstruction<
 > = {
   programAddress: Address<TProgram>;
   accounts: {
-    settlementAuthority: TAccountMetas[0];
+    payer: TAccountMetas[0];
     initializerProgram: TAccountMetas[1];
     initializerConfig: TAccountMetas[2];
     launch: TAccountMetas[3];
@@ -1007,7 +1001,7 @@ export function parseSettleFeesInstruction<
   return {
     programAddress: instruction.programAddress,
     accounts: {
-      settlementAuthority: getNextAccount(),
+      payer: getNextAccount(),
       initializerProgram: getNextAccount(),
       initializerConfig: getNextAccount(),
       launch: getNextAccount(),

--- a/src/solana/generated/dopplerRehypeRouterV1/instructions/settleMigratedFees.ts
+++ b/src/solana/generated/dopplerRehypeRouterV1/instructions/settleMigratedFees.ts
@@ -67,7 +67,7 @@ export function getSettleMigratedFeesDiscriminatorBytes() {
 
 export type SettleMigratedFeesInstruction<
   TProgram extends string = typeof DOPPLER_REHYPE_ROUTER_V1_PROGRAM_ADDRESS,
-  TAccountSettlementAuthority extends string | AccountMeta<string> = string,
+  TAccountPayer extends string | AccountMeta<string> = string,
   TAccountInitializerProgram extends string | AccountMeta<string> =
     '4h3Dqyo5qmteJoMxXt3tdtfXELDB6pdRTPU9mWruiKp1',
   TAccountInitializerConfig extends string | AccountMeta<string> = string,
@@ -106,10 +106,10 @@ export type SettleMigratedFeesInstruction<
   InstructionWithData<ReadonlyUint8Array> &
   InstructionWithAccounts<
     [
-      TAccountSettlementAuthority extends string
-        ? WritableSignerAccount<TAccountSettlementAuthority> &
-            AccountSignerMeta<TAccountSettlementAuthority>
-        : TAccountSettlementAuthority,
+      TAccountPayer extends string
+        ? WritableSignerAccount<TAccountPayer> &
+            AccountSignerMeta<TAccountPayer>
+        : TAccountPayer,
       TAccountInitializerProgram extends string
         ? ReadonlyAccount<TAccountInitializerProgram>
         : TAccountInitializerProgram,
@@ -253,7 +253,7 @@ export function getSettleMigratedFeesInstructionDataCodec(): Codec<
 }
 
 export type SettleMigratedFeesAsyncInput<
-  TAccountSettlementAuthority extends string = string,
+  TAccountPayer extends string = string,
   TAccountInitializerProgram extends string = string,
   TAccountInitializerConfig extends string = string,
   TAccountLaunch extends string = string,
@@ -284,7 +284,7 @@ export type SettleMigratedFeesAsyncInput<
   TAccountSystemProgram extends string = string,
   TAccountOracle extends string = string,
 > = {
-  settlementAuthority: TransactionSigner<TAccountSettlementAuthority>;
+  payer: TransactionSigner<TAccountPayer>;
   initializerProgram?: Address<TAccountInitializerProgram>;
   initializerConfig: Address<TAccountInitializerConfig>;
   launch: Address<TAccountLaunch>;
@@ -321,7 +321,7 @@ export type SettleMigratedFeesAsyncInput<
 };
 
 export async function getSettleMigratedFeesInstructionAsync<
-  TAccountSettlementAuthority extends string,
+  TAccountPayer extends string,
   TAccountInitializerProgram extends string,
   TAccountInitializerConfig extends string,
   TAccountLaunch extends string,
@@ -355,7 +355,7 @@ export async function getSettleMigratedFeesInstructionAsync<
     typeof DOPPLER_REHYPE_ROUTER_V1_PROGRAM_ADDRESS,
 >(
   input: SettleMigratedFeesAsyncInput<
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -390,7 +390,7 @@ export async function getSettleMigratedFeesInstructionAsync<
 ): Promise<
   SettleMigratedFeesInstruction<
     TProgramAddress,
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -428,10 +428,7 @@ export async function getSettleMigratedFeesInstructionAsync<
 
   // Original accounts.
   const originalAccounts = {
-    settlementAuthority: {
-      value: input.settlementAuthority ?? null,
-      isWritable: true,
-    },
+    payer: { value: input.payer ?? null, isWritable: true },
     initializerProgram: {
       value: input.initializerProgram ?? null,
       isWritable: false,
@@ -613,7 +610,7 @@ export async function getSettleMigratedFeesInstructionAsync<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   return Object.freeze({
     accounts: [
-      getAccountMeta('settlementAuthority', accounts.settlementAuthority),
+      getAccountMeta('payer', accounts.payer),
       getAccountMeta('initializerProgram', accounts.initializerProgram),
       getAccountMeta('initializerConfig', accounts.initializerConfig),
       getAccountMeta('launch', accounts.launch),
@@ -650,7 +647,7 @@ export async function getSettleMigratedFeesInstructionAsync<
     programAddress,
   } as SettleMigratedFeesInstruction<
     TProgramAddress,
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -684,7 +681,7 @@ export async function getSettleMigratedFeesInstructionAsync<
 }
 
 export type SettleMigratedFeesInput<
-  TAccountSettlementAuthority extends string = string,
+  TAccountPayer extends string = string,
   TAccountInitializerProgram extends string = string,
   TAccountInitializerConfig extends string = string,
   TAccountLaunch extends string = string,
@@ -715,7 +712,7 @@ export type SettleMigratedFeesInput<
   TAccountSystemProgram extends string = string,
   TAccountOracle extends string = string,
 > = {
-  settlementAuthority: TransactionSigner<TAccountSettlementAuthority>;
+  payer: TransactionSigner<TAccountPayer>;
   initializerProgram?: Address<TAccountInitializerProgram>;
   initializerConfig: Address<TAccountInitializerConfig>;
   launch: Address<TAccountLaunch>;
@@ -752,7 +749,7 @@ export type SettleMigratedFeesInput<
 };
 
 export function getSettleMigratedFeesInstruction<
-  TAccountSettlementAuthority extends string,
+  TAccountPayer extends string,
   TAccountInitializerProgram extends string,
   TAccountInitializerConfig extends string,
   TAccountLaunch extends string,
@@ -786,7 +783,7 @@ export function getSettleMigratedFeesInstruction<
     typeof DOPPLER_REHYPE_ROUTER_V1_PROGRAM_ADDRESS,
 >(
   input: SettleMigratedFeesInput<
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -820,7 +817,7 @@ export function getSettleMigratedFeesInstruction<
   config?: { programAddress?: TProgramAddress },
 ): SettleMigratedFeesInstruction<
   TProgramAddress,
-  TAccountSettlementAuthority,
+  TAccountPayer,
   TAccountInitializerProgram,
   TAccountInitializerConfig,
   TAccountLaunch,
@@ -857,10 +854,7 @@ export function getSettleMigratedFeesInstruction<
 
   // Original accounts.
   const originalAccounts = {
-    settlementAuthority: {
-      value: input.settlementAuthority ?? null,
-      isWritable: true,
-    },
+    payer: { value: input.payer ?? null, isWritable: true },
     initializerProgram: {
       value: input.initializerProgram ?? null,
       isWritable: false,
@@ -953,7 +947,7 @@ export function getSettleMigratedFeesInstruction<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   return Object.freeze({
     accounts: [
-      getAccountMeta('settlementAuthority', accounts.settlementAuthority),
+      getAccountMeta('payer', accounts.payer),
       getAccountMeta('initializerProgram', accounts.initializerProgram),
       getAccountMeta('initializerConfig', accounts.initializerConfig),
       getAccountMeta('launch', accounts.launch),
@@ -990,7 +984,7 @@ export function getSettleMigratedFeesInstruction<
     programAddress,
   } as SettleMigratedFeesInstruction<
     TProgramAddress,
-    TAccountSettlementAuthority,
+    TAccountPayer,
     TAccountInitializerProgram,
     TAccountInitializerConfig,
     TAccountLaunch,
@@ -1029,7 +1023,7 @@ export type ParsedSettleMigratedFeesInstruction<
 > = {
   programAddress: Address<TProgram>;
   accounts: {
-    settlementAuthority: TAccountMetas[0];
+    payer: TAccountMetas[0];
     initializerProgram: TAccountMetas[1];
     initializerConfig: TAccountMetas[2];
     launch: TAccountMetas[3];
@@ -1095,7 +1089,7 @@ export function parseSettleMigratedFeesInstruction<
   return {
     programAddress: instruction.programAddress,
     accounts: {
-      settlementAuthority: getNextAccount(),
+      payer: getNextAccount(),
       initializerProgram: getNextAccount(),
       initializerConfig: getNextAccount(),
       launch: getNextAccount(),

--- a/src/solana/generated/dopplerRehypeRouterV1/programs/dopplerRehypeRouterV1.ts
+++ b/src/solana/generated/dopplerRehypeRouterV1/programs/dopplerRehypeRouterV1.ts
@@ -356,11 +356,11 @@ export type DopplerRehypeRouterV1PluginInstructions = {
   ) => ReturnType<typeof getReplaceBeneficiaryInstructionAsync> &
     SelfPlanAndSendFunctions;
   settleFees: (
-    input: SettleFeesAsyncInput,
+    input: MakeOptional<SettleFeesAsyncInput, 'payer'>,
   ) => ReturnType<typeof getSettleFeesInstructionAsync> &
     SelfPlanAndSendFunctions;
   settleMigratedFees: (
-    input: SettleMigratedFeesAsyncInput,
+    input: MakeOptional<SettleMigratedFeesAsyncInput, 'payer'>,
   ) => ReturnType<typeof getSettleMigratedFeesInstructionAsync> &
     SelfPlanAndSendFunctions;
 };
@@ -414,12 +414,18 @@ export function dopplerRehypeRouterV1Program() {
           settleFees: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getSettleFeesInstructionAsync(input),
+              getSettleFeesInstructionAsync({
+                ...input,
+                payer: input.payer ?? client.payer,
+              }),
             ),
           settleMigratedFees: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getSettleMigratedFeesInstructionAsync(input),
+              getSettleMigratedFeesInstructionAsync({
+                ...input,
+                payer: input.payer ?? client.payer,
+              }),
             ),
         },
       },

--- a/test/solana/unit/feeRehypothecation/launch.test.ts
+++ b/test/solana/unit/feeRehypothecation/launch.test.ts
@@ -85,7 +85,6 @@ describe('fee rehypothecation launch preparation', () => {
         swapFeeBps: 200,
       },
       buybackDestination: payer.address,
-      settlementAuthority: payer,
       beneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
       strategy: feeRehypothecation.allFeesToBeneficiariesInNumeraire(),
       metadata: null,
@@ -104,10 +103,9 @@ describe('fee rehypothecation launch preparation', () => {
     expect(routingData.launchId).toEqual(prepared.launchId);
     expect(routingData).not.toHaveProperty('settlementAuthority');
     expect(
-      prepared.initializeRoutingInstruction.accounts!.slice(0, 3),
+      prepared.initializeRoutingInstruction.accounts!.slice(0, 2),
     ).toMatchObject([
       { address: payer.address, role: AccountRole.WRITABLE_SIGNER },
-      { address: payer.address, role: AccountRole.READONLY_SIGNER },
       { address: baseMint.address, role: AccountRole.READONLY_SIGNER },
     ]);
     expect(prepared.namespace).toBe(
@@ -166,7 +164,6 @@ describe('fee rehypothecation launch preparation', () => {
           swapFeeBps: 200,
         },
         buybackDestination: payer.address,
-        settlementAuthority: payer,
         beneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
         strategy: feeRehypothecation.inKindBeneficiaryFees(),
       }),
@@ -196,7 +193,6 @@ describe('fee rehypothecation launch preparation', () => {
         swapFeeBps: 200,
       },
       buybackDestination: payer.address,
-      settlementAuthority: payer,
       beneficiaries: [],
       strategy: {
         routingMode:
@@ -248,7 +244,6 @@ describe('fee rehypothecation launch preparation', () => {
         swapFeeBps: 200,
       },
       buybackDestination: payer.address,
-      settlementAuthority: payer,
       beneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
       strategy: feeRehypothecation.inKindBeneficiaryFees(),
       vesting: {
@@ -311,7 +306,6 @@ describe('fee rehypothecation launch preparation', () => {
         swapFeeBps: 200,
       },
       buybackDestination: payer.address,
-      settlementAuthority: payer,
       beneficiaries: [{ wallet: payer.address, shareBps: 10_000 }],
       strategy: feeRehypothecation.inKindBeneficiaryFees(),
       cosignerGate: gate,

--- a/test/solana/unit/feeRehypothecation/settlement.test.ts
+++ b/test/solana/unit/feeRehypothecation/settlement.test.ts
@@ -221,7 +221,7 @@ describe('fee rehypothecation settlement preparation', () => {
       beneficiaryCount: 1,
       inflightKind: 0,
       inflightDirection: 0,
-      settlementAuthority: payer.address,
+      reservedSettlementAuthority: new Uint8Array(32),
       cumulativeRoutedBaseFees: 0n,
       cumulativeRoutedQuoteFees: 0n,
       settledInitializerBaseFees: 0n,
@@ -299,7 +299,7 @@ describe('fee rehypothecation settlement preparation', () => {
       rpc,
       deployment,
       launch,
-      settlementAuthority: payer,
+      payer,
     });
     const settlementData = getSettleFeesInstructionDataDecoder().decode(
       settlement.instruction.data!,


### PR DESCRIPTION
## Summary

- consume the permissionless Rehype router IDL from whetstoneresearch/doppler-sol#202
- remove settlementAuthority from fee-rehypothecation launch creation
- accept a transaction payer when preparing settlement
- regenerate Rehype account and instruction codecs
- update Solana examples, unit tests, and integration documentation

## User-flow example

Previously, an integrator had to configure and retain a dedicated settlement-authority key at launch creation. The settlement helper rejected any different signer before constructing the transaction.

With the upgraded router, the caller supplies any payer that is willing to submit the settlement transaction. Beneficiaries and buyback destinations are still read from immutable routing state; the payer receives no authority over routed funds.

## Dependency

Depends on https://github.com/whetstoneresearch/doppler-sol/pull/202 and must be released against the upgraded Rehype router ABI.

## Testing

- pnpm generate:codecs
- pnpm typecheck
- pnpm format:check
- pnpm test:solana
- pnpm build
- pnpm typecheck:solana-examples

The Solana unit suite passed 190 tests. The broader pnpm typecheck:test command still reports existing unrelated EVM/fork fixture type errors.